### PR TITLE
Cutover: all seven pickers on the platform social graph (useSocial + audience)

### DIFF
--- a/examples/defcon-picker/App.jsx
+++ b/examples/defcon-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   FESTIVAL_2026,
   toFestivalDate,
@@ -57,7 +57,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 const migrateDefconDoc = (doc, handle) => {
   if (doc.type === 'favorite')
@@ -81,6 +80,22 @@ export default function DefconPicker() {
     migrate: migrateDefconDoc,
   });
   const { can, ready } = useVibe('defcon34');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+    removeFollower,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -105,10 +120,9 @@ export default function DefconPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -162,34 +176,6 @@ export default function DefconPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -317,50 +303,51 @@ export default function DefconPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -373,7 +360,7 @@ export default function DefconPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -382,10 +369,10 @@ export default function DefconPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have events or shifts, ordered by the con day order.
   // We deliberately do NOT seed with the full dayOrder — a con day with nothing on
@@ -708,7 +695,7 @@ export default function DefconPicker() {
                   {viewName === 'browse' && `All Sessions`}
                   {viewName === 'tracks' && `Tracks`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -803,8 +790,14 @@ export default function DefconPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -822,8 +815,6 @@ export default function DefconPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -909,34 +900,10 @@ export default function DefconPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your schedule with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-[#141419] border border-[#39ff14]/40 rounded-2xl p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add <span className="text-[#39ff14]">@{friendConfirm}</span> to
-              your crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button onClick={declineAddFriend} className={c.btnDim}>
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnAccent}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/defcon-picker/FriendsView.jsx
+++ b/examples/defcon-picker/FriendsView.jsx
@@ -1,13 +1,23 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +35,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,16 +63,31 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-[#1a1a20] rounded-2xl m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#141419] border border-[#39ff14]/20 rounded-2xl m-0.5 mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         {/* QR codes need dark-on-light to scan reliably, so this box stays white
             even in the committed-dark shell. */}
         <div className="bg-white rounded-2xl m-0.5 p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -91,18 +131,54 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
+          Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#141419] border border-[#39ff14]/20 rounded-2xl m-0.5">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#1a1a20]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnAccent}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-[#26262e] text-[#e8e8e8] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-[#1a1a20] rounded-2xl m-0.5">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -111,7 +187,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -126,49 +202,89 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.userId ? 'bg-[#39ff14]' : 'bg-[#26262e]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.handle ? 'bg-[#39ff14]' : 'bg-[#26262e]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-[#1a1a20] text-[#e8e8e8] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#141419] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-[#1a1a20] text-[#e8e8e8] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.friendSlug ? 'bg-[#39ff14]' : 'bg-[#26262e]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#26262e]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-[#1a1a20] text-[#e8e8e8] hover:bg-[#39ff14] hover:text-[#0a0a0c] transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-[#1a1a20] text-[#e8e8e8] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -180,7 +296,7 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone You Follow</h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black ${c.bodyText}`}>Picks by</h3>
@@ -203,8 +319,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any sessions yet."
-                : "This friend hasn't picked any sessions yet."
+                ? 'Nobody you follow has picked any sessions yet.'
+                : "They haven't picked any sessions yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/defcon-picker/NowView.jsx
+++ b/examples/defcon-picker/NowView.jsx
@@ -21,7 +21,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             </span>
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/defcon-picker/RUNBOOK.md
+++ b/examples/defcon-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull calendar/defcon-picker
 - **Database**: Fireproof `"defcon34"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js` — same design as the pickathon-picker original):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared extras (via the friend grant) but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
 - **Tracks view** — the "bands" analog: sessions grouped by their track (the feed's `tags[0].label` — Workshop, Demo Labs, Party, …), rendered in the feed's own per-track colors.
 - **Super mode** — URL easter egg (`?super=1`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 
@@ -168,3 +168,23 @@ aggregation, proxy route, both ics lanes) and `schedule.test.js` (feed flattenin
 | Add a new view/tab  | Add to the `["now", "browse", "tracks", …]` array in nav, add `{view === "newview" && ...}` section in the body |
 | Change colors       | `c` object in `styles.js` (committed dark — keep neon for accents only, body text `#e8e8e8`)                    |
 | Proxy cache TTL     | `SCHEDULE_TTL_MS` in backend.js (client copy: the `600_000` in App.jsx's `getCached`)                           |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/defcon-picker/ShiftsView.jsx
+++ b/examples/defcon-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5 accent-[#39ff14]"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4 accent-[#39ff14]"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/defcon-picker/access.js
+++ b/examples/defcon-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/defcon-picker/access.test.js
+++ b/examples/defcon-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,42 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, vibes.diy#3433): bob must be
-  // able to revoke the mutual sharing alice created by scanning his QR — the
-  // "Added You" list renders a remove control for exactly this. Deletes only:
-  // bob still cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(
-      run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })
-    ).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 

--- a/examples/euroscipy-picker/App.jsx
+++ b/examples/euroscipy-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   FESTIVAL_2026,
   toFestivalDate,
@@ -56,7 +56,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 const migrateEuroSciPyDoc = (doc, handle) => {
   if (doc.type === 'favorite')
@@ -80,6 +79,22 @@ export default function EuroSciPyPicker() {
     migrate: migrateEuroSciPyDoc,
   });
   const { can, ready } = useVibe('euroscipy2026');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+    removeFollower,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -104,10 +119,9 @@ export default function EuroSciPyPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -161,34 +175,6 @@ export default function EuroSciPyPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -314,50 +300,51 @@ export default function EuroSciPyPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -370,7 +357,7 @@ export default function EuroSciPyPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -379,10 +366,10 @@ export default function EuroSciPyPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have talks or shifts, ordered by the conference day order.
   // We deliberately do NOT seed with the full dayOrder — a conference day with nothing
@@ -579,8 +566,12 @@ export default function EuroSciPyPicker() {
   // show THEIR picks (from the readable firehose), not the current user's.
   const viewedFavoriteEvents = useMemo(() => {
     if (!viewingUser || viewingUser === userId) return favoriteEvents;
-    const ids = new Set(allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId));
-    return events.filter((e) => ids.has(e.eventId)).sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
+    const ids = new Set(
+      allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
+    );
+    return events
+      .filter((e) => ids.has(e.eventId))
+      .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
   }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
 
   const makeSchedule = (day) => {
@@ -694,7 +685,7 @@ export default function EuroSciPyPicker() {
                   {viewName === 'browse' && `All Talks`}
                   {viewName === 'tracks' && `Tracks`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -789,8 +780,14 @@ export default function EuroSciPyPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -808,8 +805,6 @@ export default function EuroSciPyPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -895,37 +890,10 @@ export default function EuroSciPyPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your schedule with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-white dark:bg-[#15202b] rounded-2xl p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add <span className="text-[#4B8BBE]">@{friendConfirm}</span> to
-              your crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button
-                onClick={declineAddFriend}
-                className="py-1 px-2 font-bold rounded-2xl bg-white dark:bg-[#141b22] text-[#22303c] dark:text-[#e4edf5] border border-black/10 dark:border-white/20 hover:opacity-90 transition-all"
-              >
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnAccent}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/euroscipy-picker/FriendsView.jsx
+++ b/examples/euroscipy-picker/FriendsView.jsx
@@ -1,13 +1,23 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +35,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,14 +63,29 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-white dark:bg-[#15202b] rounded-2xl m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#dbe7f3] dark:bg-[#101c2a] rounded-2xl m-0.5 mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         <div className="bg-white dark:bg-[#1d3a55] rounded-2xl m-0.5 p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -89,18 +129,54 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
+          Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#dbe7f3] dark:bg-[#101c2a] rounded-2xl m-0.5">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#15202b]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnAccent}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#141b22] text-[#22303c] dark:text-[#e4edf5] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-white dark:bg-[#15202b] rounded-2xl m-0.5">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -109,7 +185,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -124,49 +200,89 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.userId ? 'bg-[#FFD43B]' : 'bg-[#4B8BBE] dark:bg-[#1d3a55]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.handle ? 'bg-[#FFD43B]' : 'bg-[#dbe7f3] dark:bg-[#101c2a]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#15202b] text-[#22303c] dark:text-[#e4edf5] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#15202b] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#141b22] text-[#22303c] dark:text-[#e4edf5] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.friendSlug ? 'bg-[#FFD43B]' : 'bg-[#dbe7f3] dark:bg-[#101c2a]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#4B8BBE] dark:bg-[#1d3a55]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#15202b] text-[#22303c] dark:text-[#e4edf5] hover:bg-[#FFD43B] hover:text-[#1a1a1a] transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#15202b] text-[#22303c] dark:text-[#e4edf5] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -178,7 +294,7 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone You Follow</h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black ${c.bodyText}`}>Picks by</h3>
@@ -201,8 +317,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any talks yet."
-                : "This friend hasn't picked any talks yet."
+                ? 'Nobody you follow has picked any talks yet.'
+                : "They haven't picked any talks yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/euroscipy-picker/NowView.jsx
+++ b/examples/euroscipy-picker/NowView.jsx
@@ -21,7 +21,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             </span>
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/euroscipy-picker/RUNBOOK.md
+++ b/examples/euroscipy-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull calendar/euroscipy-picker
 - **Database**: Fireproof `"euroscipy2026"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js` — same design as the pickathon-picker vibe):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared extras (via the friend grant) but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
 - **Super mode** — URL easter egg (`?super=1`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 - **Tracks** — the feed's thematic grouping (a talk belongs to exactly one track). The Tracks tab groups talks by track; each track gets a deterministic color from `TRACK_COLORS` (hash of the track name, `festival-utils.js`). The yellow entry (`#FFD43B`) always carries dark tag text — white on it fails contrast.
 
@@ -125,3 +125,23 @@ Thursday 2026-07-23 with a 4 AM cutoff, matching the feed's own day windows.
 | Add a new view/tab      | Add to the `["now", "browse", "tracks", …]` array in nav, add `{view === "newview" && ...}` section in the body |
 | Change colors           | the `c` object in `styles.js`                                                                                   |
 | Change schedule feed    | fetch URL in `App.jsx` (`fetchSchedule`) + `SCHEDULE_URL` in `backend.js`                                       |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/euroscipy-picker/ShiftsView.jsx
+++ b/examples/euroscipy-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/euroscipy-picker/access.js
+++ b/examples/euroscipy-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/euroscipy-picker/access.test.js
+++ b/examples/euroscipy-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,40 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, vibes.diy#3433): bob must be
-  // able to revoke the mutual sharing alice created by scanning his QR — the
-  // "Added You" list renders a remove control for exactly this. Deletes only:
-  // bob still cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 

--- a/examples/ietf-picker/App.jsx
+++ b/examples/ietf-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   MEETING_NUMBER,
   MEETING_126,
@@ -57,7 +57,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 // Re-stamp a locally-stored doc onto the freshly signed-in handle when useFireproof's
 // anonymousLocal store migrates local → cloud on first login. Owned docs are keyed by
@@ -84,6 +83,22 @@ export default function IetfAgendaPicker() {
     migrate: migrateIetfDoc,
   });
   const { can, ready } = useVibe('ietf126');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+    removeFollower,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -108,10 +123,9 @@ export default function IetfAgendaPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -165,34 +179,6 @@ export default function IetfAgendaPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -317,50 +303,51 @@ export default function IetfAgendaPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -373,7 +360,7 @@ export default function IetfAgendaPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -382,10 +369,10 @@ export default function IetfAgendaPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have sessions or shifts, ordered by the meeting day order.
   // We deliberately do NOT seed with the full dayOrder — a meeting day with nothing on
@@ -595,8 +582,12 @@ export default function IetfAgendaPicker() {
   // show THEIR picks (from the readable firehose), not the current user's.
   const viewedFavoriteEvents = useMemo(() => {
     if (!viewingUser || viewingUser === userId) return favoriteEvents;
-    const ids = new Set(allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId));
-    return events.filter((e) => ids.has(e.eventId)).sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start));
+    const ids = new Set(
+      allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
+    );
+    return events
+      .filter((e) => ids.has(e.eventId))
+      .sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start));
   }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
 
   const makeSchedule = (day) => {
@@ -716,7 +707,7 @@ export default function IetfAgendaPicker() {
                   {viewName === 'browse' && `All Sessions`}
                   {viewName === 'groups' && `Groups`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -809,8 +800,14 @@ export default function IetfAgendaPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -828,8 +825,6 @@ export default function IetfAgendaPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -917,38 +912,10 @@ export default function IetfAgendaPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your session picks with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your session picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-white dark:bg-[#21262d] rounded-lg p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add{' '}
-              <span className="text-[#205a9e] dark:text-[#58a6ff]">@{friendConfirm}</span> to your
-              crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button
-                onClick={declineAddFriend}
-                className="py-1 px-2 font-bold rounded-lg bg-white dark:bg-[#161b22] text-[#1f2328] dark:text-[#e6edf3] border border-black/10 dark:border-white/20 hover:opacity-90 transition-all"
-              >
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnPink}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/ietf-picker/FriendsView.jsx
+++ b/examples/ietf-picker/FriendsView.jsx
@@ -1,13 +1,23 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +35,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,14 +63,29 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-white dark:bg-[#21262d] rounded-lg m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#e9eef5] dark:bg-[#101826] rounded-lg m-0.5 mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         <div className="bg-white dark:bg-[#132f4f] rounded-lg m-0.5 p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -89,18 +129,54 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the session picks and shared extras on your
+          schedule. Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#e9eef5] dark:bg-[#101826] rounded-lg m-0.5">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#21262d]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnPink}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#161b22] text-[#1f2328] dark:text-[#e6edf3] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-white dark:bg-[#21262d] rounded-lg m-0.5">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -109,7 +185,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -124,49 +200,89 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.userId ? 'bg-[#b45309]' : 'bg-[#205a9e] dark:bg-[#132f4f]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.handle ? 'bg-[#b45309]' : 'bg-[#e9eef5] dark:bg-[#101826]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#21262d] text-[#1f2328] dark:text-[#e6edf3] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#21262d] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#161b22] text-[#1f2328] dark:text-[#e6edf3] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your session picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5 transition-all ${selectedFriend === f.friendSlug ? 'bg-[#b45309]' : 'bg-[#e9eef5] dark:bg-[#101826]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#205a9e] dark:bg-[#132f4f]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#21262d] text-[#1f2328] dark:text-[#e6edf3] hover:bg-[#b45309] hover:text-white transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#21262d] text-[#1f2328] dark:text-[#e6edf3] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -178,7 +294,7 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone You Follow</h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black ${c.bodyText}`}>Picks by</h3>
@@ -201,8 +317,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any sessions yet."
-                : "This friend hasn't picked any sessions yet."
+                ? 'Nobody you follow has picked any sessions yet.'
+                : "They haven't picked any sessions yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/ietf-picker/NowView.jsx
+++ b/examples/ietf-picker/NowView.jsx
@@ -23,7 +23,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             )}
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/ietf-picker/RUNBOOK.md
+++ b/examples/ietf-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull calendar/ietf-picker
 - **Database**: Fireproof `"ietf126"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js` — same design as pickathon-picker's; the file is fully generic):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** (the Extras tab) → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared side meetings but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
 - **Super mode** — URL easter egg (`?super=1` / `?super=true`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 
 ## Granting super access
@@ -122,3 +122,23 @@ through Friday 2026-07-24 with the 4 AM night cutoff.
 | Change area chip colors   | `AREA_COLORS` in `festival-utils.js`                                                                                                                             |
 | Add a new view/tab        | Add to the `["now", "browse", "groups", ...]` array in nav, add `{view === "newview" && ...}` section in the body                                                |
 | Change colors             | the `c` object in `styles.js`                                                                                                                                    |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/ietf-picker/ShiftsView.jsx
+++ b/examples/ietf-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/ietf-picker/access.js
+++ b/examples/ietf-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/ietf-picker/access.test.js
+++ b/examples/ietf-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,40 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, vibes.diy#3433): bob must be
-  // able to revoke the mutual sharing alice created by scanning his QR — the
-  // "Added You" list renders a remove control for exactly this. Deletes only:
-  // bob still cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 

--- a/examples/juliacon-picker/App.jsx
+++ b/examples/juliacon-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   FESTIVAL_2026,
   toFestivalDate,
@@ -54,7 +54,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 // The three Julia dots, drawn once as a small static inline SVG next to the
 // wordmark (no animation → zero repaint tax, and no third-party image fetch).
@@ -91,6 +90,22 @@ export default function JuliaConPicker() {
     migrate: migrateJuliaConDoc,
   });
   const { can, ready } = useVibe('juliacon2026');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+    removeFollower,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -115,10 +130,9 @@ export default function JuliaConPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -172,34 +186,6 @@ export default function JuliaConPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -325,50 +311,51 @@ export default function JuliaConPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -381,7 +368,7 @@ export default function JuliaConPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -390,10 +377,10 @@ export default function JuliaConPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have events or shifts, ordered by the conference day order.
   // We deliberately do NOT seed with the full dayOrder — a conference day with nothing
@@ -592,8 +579,12 @@ export default function JuliaConPicker() {
   // show THEIR picks (from the readable firehose), not the current user's.
   const viewedFavoriteEvents = useMemo(() => {
     if (!viewingUser || viewingUser === userId) return favoriteEvents;
-    const ids = new Set(allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId));
-    return events.filter((e) => ids.has(e.eventId)).sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
+    const ids = new Set(
+      allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
+    );
+    return events
+      .filter((e) => ids.has(e.eventId))
+      .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
   }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
 
   const makeSchedule = (day) => {
@@ -713,7 +704,7 @@ export default function JuliaConPicker() {
                   {viewName === 'browse' && `All Talks`}
                   {viewName === 'tracks' && `Tracks`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -808,8 +799,14 @@ export default function JuliaConPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -827,8 +824,6 @@ export default function JuliaConPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -914,37 +909,10 @@ export default function JuliaConPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your schedule with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-white dark:bg-[#262031] rounded-2xl p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add <span className="text-[#389826]">@{friendConfirm}</span> to
-              your crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button
-                onClick={declineAddFriend}
-                className="py-1 px-2 font-bold rounded-2xl bg-white dark:bg-[#18161f] text-[#2a2a2a] dark:text-[#ece9f1] border border-black/10 dark:border-white/20 hover:opacity-90 transition-all"
-              >
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnPink}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/juliacon-picker/FriendsView.jsx
+++ b/examples/juliacon-picker/FriendsView.jsx
@@ -1,13 +1,23 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +35,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,14 +63,29 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-white dark:bg-[#262031] rounded-2xl m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#ece4f3] dark:bg-[#241a2e] rounded-2xl m-0.5  mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         <div className="bg-white dark:bg-[#262031] rounded-2xl m-0.5  p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -89,18 +129,54 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
+          Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#ece4f3] dark:bg-[#241a2e] rounded-2xl m-0.5 ">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#262031]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnPink}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#18161f] text-[#2a2a2a] dark:text-[#ece9f1] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-white dark:bg-[#262031] rounded-2xl m-0.5 ">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -109,7 +185,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -124,49 +200,89 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.userId ? 'bg-[#CB3C33]' : 'bg-[#9558B2] dark:bg-[#3a2545]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.handle ? 'bg-[#CB3C33]' : 'bg-[#ece4f3] dark:bg-[#241a2e]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#262031] text-[#2a2a2a] dark:text-[#ece9f1] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#262031] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#18161f] text-[#2a2a2a] dark:text-[#ece9f1] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.friendSlug ? 'bg-[#CB3C33]' : 'bg-[#ece4f3] dark:bg-[#241a2e]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#9558B2] dark:bg-[#3a2545]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#262031] text-[#2a2a2a] dark:text-[#ece9f1] hover:bg-[#CB3C33] hover:text-white transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#262031] text-[#2a2a2a] dark:text-[#ece9f1] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -178,7 +294,7 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone You Follow</h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black ${c.bodyText}`}>Picks by</h3>
@@ -201,8 +317,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any talks yet."
-                : "This friend hasn't picked any talks yet."
+                ? 'Nobody you follow has picked any talks yet.'
+                : "They haven't picked any talks yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/juliacon-picker/NowView.jsx
+++ b/examples/juliacon-picker/NowView.jsx
@@ -21,7 +21,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             </span>
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/juliacon-picker/RUNBOOK.md
+++ b/examples/juliacon-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull calendar/juliacon-picker
 - **Database**: Fireproof `"juliacon2026"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js` — same design as the pickathon-picker reference):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`; eventId is the pretalx talk `guid`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`; eventId is the pretalx talk `guid`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared extras (via the friend grant) but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
 - **Super mode** — URL easter egg (`?super=1` / `?super=true`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 - **Tracks tab** — the "Bands" analog: talks grouped by their pretalx `track` (a minisymposium's talks share a track, not a title). Track colors are a deterministic hash of the track name into the Julia brand cycle (`TRACK_COLORS` in `festival-utils.js`), so the same track renders the same color everywhere with no registry to maintain.
 
@@ -128,3 +128,23 @@ feed's own `day_start` uses).
 | Change the track colors | `TRACK_COLORS` in `festival-utils.js`                                                                           |
 | Add a new view/tab      | Add to the `["now", "browse", "tracks", …]` array in nav, add `{view === "newview" && ...}` section in the body |
 | Change colors           | the `c` object in `styles.js`                                                                                   |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/juliacon-picker/ShiftsView.jsx
+++ b/examples/juliacon-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/juliacon-picker/access.js
+++ b/examples/juliacon-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/juliacon-picker/access.test.js
+++ b/examples/juliacon-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,40 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, vibes.diy#3433): bob must be
-  // able to revoke the mutual sharing alice created by scanning his QR — the
-  // "Added You" list renders a remove control for exactly this. Deletes only:
-  // bob still cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 

--- a/examples/ocf-picker/App.jsx
+++ b/examples/ocf-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   FESTIVAL_2026,
   toFestivalDate,
@@ -58,7 +58,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 // A pennant-bunting line along the header's bottom edge: one scalloped string of
 // small triangular flags alternating terracotta / teal / bronze. The three path
@@ -101,6 +100,22 @@ export default function OcfPicker() {
     migrate: migrateOcfDoc,
   });
   const { can, ready } = useVibe('ocf2026');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+    removeFollower,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -125,10 +140,9 @@ export default function OcfPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -182,34 +196,6 @@ export default function OcfPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -338,50 +324,51 @@ export default function OcfPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -394,7 +381,7 @@ export default function OcfPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -403,10 +390,10 @@ export default function OcfPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have events or shifts, ordered by the fair day order.
   // We deliberately do NOT seed with the full dayOrder — a fair day with nothing on
@@ -780,7 +767,7 @@ export default function OcfPicker() {
                   {viewName === 'browse' && `All Events`}
                   {viewName === 'artists' && `Artists`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -875,8 +862,14 @@ export default function OcfPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -894,8 +887,6 @@ export default function OcfPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -990,37 +981,10 @@ export default function OcfPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your schedule with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-[#fffaf2] dark:bg-[#1e1a12] rounded-2xl p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add <span className="text-[#d95931]">@{friendConfirm}</span> to
-              your crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button
-                onClick={declineAddFriend}
-                className="py-1 px-2 font-bold rounded-2xl bg-[#efe4cf] dark:bg-[#1e1a12] text-[#3a2f28] dark:text-[#f0e9df] border border-black/10 dark:border-white/20 hover:opacity-90 transition-all"
-              >
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnAccent}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/ocf-picker/FriendsView.jsx
+++ b/examples/ocf-picker/FriendsView.jsx
@@ -1,13 +1,23 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +35,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,14 +63,29 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-[#efe4cf] dark:bg-[#1e1a12] rounded-2xl m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#f7e8d8] dark:bg-[#241c10] rounded-2xl m-0.5  mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         <div className="bg-white dark:bg-[#123d36] rounded-2xl m-0.5  p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -89,18 +129,54 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
+          Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#f7e8d8] dark:bg-[#241c10] rounded-2xl m-0.5 ">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#fffaf2] dark:bg-[#1b1813]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnAccent}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-[#efe4cf] dark:bg-[#1e1a12] text-[#3a2f28] dark:text-[#f0e9df] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-[#efe4cf] dark:bg-[#1e1a12] rounded-2xl m-0.5 ">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -109,7 +185,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -124,49 +200,89 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.userId ? 'bg-[#d95931]' : 'bg-[#25a48f] dark:bg-[#123d36]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.handle ? 'bg-[#d95931]' : 'bg-[#f7e8d8] dark:bg-[#241c10]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-[#efe4cf] dark:bg-[#1e1a12] text-[#3a2f28] dark:text-[#f0e9df] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#fffaf2] dark:bg-[#1b1813] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-[#efe4cf] dark:bg-[#1e1a12] text-[#3a2f28] dark:text-[#f0e9df] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.friendSlug ? 'bg-[#d95931]' : 'bg-[#f7e8d8] dark:bg-[#241c10]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#25a48f] dark:bg-[#123d36]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-[#fffaf2] dark:bg-[#1b1813] text-[#3a2f28] dark:text-[#f0e9df] hover:bg-[#d95931] hover:text-white transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-[#fffaf2] dark:bg-[#1b1813] text-[#3a2f28] dark:text-[#f0e9df] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -178,7 +294,9 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black font-serif ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black font-serif ${c.bodyText}`}>
+                  Everyone You Follow
+                </h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black font-serif ${c.bodyText}`}>Picks by</h3>
@@ -201,8 +319,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any events yet."
-                : "This friend hasn't picked any events yet."
+                ? 'Nobody you follow has picked any events yet.'
+                : "They haven't picked any events yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/ocf-picker/NowView.jsx
+++ b/examples/ocf-picker/NowView.jsx
@@ -21,7 +21,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             </span>
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/ocf-picker/RUNBOOK.md
+++ b/examples/ocf-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull calendar/ocf-picker
 - **Database**: Fireproof `"ocf2026"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js` — same design as the pickathon-picker original):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared extras (via the friend grant) but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
   - **Schedule-snapshot chunks** (`schedule-snapshot-{seq}`) → owner-only writes into an unreadable `snapshot-internal` channel (the backend's fallback data path must not be poisonable by ordinary signed-in users; the scheduled lane reads unfiltered anyway).
 - **Artists view** — the "bands" analog: sets grouped by artist title (OCF artists play multiple sets across days and stages), sectioned by genre in the fixed genre palette.
 - **Super mode** — URL easter egg (`?super=1`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
@@ -184,3 +184,23 @@ aggregation, parse proxy, snapshot fallback, both ics lanes) and
 | Add a new view/tab  | Add to the `["now", "browse", "artists", …]` array in nav, add `{view === "newview" && ...}` section in the body        |
 | Change colors       | `c` object in `styles.js` (cream/terracotta/teal/bronze; every surface keeps a `dark:` variant)                         |
 | Proxy cache TTL     | `SCHEDULE_TTL_MS` in backend.js (client copy: the `600_000` in App.jsx's `getCached`)                                   |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/ocf-picker/ShiftsView.jsx
+++ b/examples/ocf-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/ocf-picker/access.js
+++ b/examples/ocf-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/ocf-picker/access.test.js
+++ b/examples/ocf-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,42 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, #3433): bob must be able to
-  // revoke the mutual sharing alice created by scanning his QR — the "Added You"
-  // list renders a remove control for exactly this. Deletes only: bob still
-  // cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(
-      run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })
-    ).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 

--- a/examples/pickathon-picker/App.jsx
+++ b/examples/pickathon-picker/App.jsx
@@ -147,6 +147,7 @@ export default function PickathonPicker() {
     follow,
     unfollow,
     approve,
+    removeFollower,
   } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
@@ -887,6 +888,7 @@ export default function PickathonPicker() {
                   follow={follow}
                   unfollow={unfollow}
                   approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}

--- a/examples/pickathon-picker/App.jsx
+++ b/examples/pickathon-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   FESTIVAL_2026,
   LOGO_URL,
@@ -59,7 +59,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 // A layered Pacific-Northwest forestscape for the header's bottom edge: two rows of
 // tiered Christmas trees at varying heights that overlap, drawn once as a static SVG
@@ -134,6 +133,21 @@ export default function PickathonPicker() {
     migrate: migratePickathonDoc,
   });
   const { can, ready } = useVibe('pickathon');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -158,10 +172,9 @@ export default function PickathonPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -215,34 +228,6 @@ export default function PickathonPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -388,50 +373,51 @@ export default function PickathonPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -444,7 +430,7 @@ export default function PickathonPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -453,10 +439,10 @@ export default function PickathonPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have events or shifts, ordered by the festival day order.
   // We deliberately do NOT seed with the full dayOrder — a festival day with nothing on
@@ -651,8 +637,12 @@ export default function PickathonPicker() {
   // show THEIR picks (from the readable firehose), not the current user's.
   const viewedFavoriteEvents = useMemo(() => {
     if (!viewingUser || viewingUser === userId) return favoriteEvents;
-    const ids = new Set(allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId));
-    return events.filter((e) => ids.has(e.eventId)).sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
+    const ids = new Set(
+      allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
+    );
+    return events
+      .filter((e) => ids.has(e.eventId))
+      .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
   }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
 
   const makeSchedule = (day) => {
@@ -785,7 +775,7 @@ export default function PickathonPicker() {
                   {viewName === 'browse' && `All Events`}
                   {viewName === 'bands' && `Bands`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -890,8 +880,13 @@ export default function PickathonPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -909,8 +904,6 @@ export default function PickathonPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -998,37 +991,10 @@ export default function PickathonPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your schedule with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-white dark:bg-[#22252d] rounded-2xl p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add <span className="text-[#71AD44]">@{friendConfirm}</span> to
-              your crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button
-                onClick={declineAddFriend}
-                className="py-1 px-2 font-bold rounded-2xl bg-white dark:bg-[#181a20] text-[#4A4A4A] dark:text-[#e9e9e9] border border-black/10 dark:border-white/20 hover:opacity-90 transition-all"
-              >
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnPink}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/pickathon-picker/FriendsView.jsx
+++ b/examples/pickathon-picker/FriendsView.jsx
@@ -1,13 +1,22 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +34,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,14 +62,29 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-white dark:bg-[#22252d] rounded-2xl m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#BACD32] dark:bg-[#2c3510] rounded-2xl m-0.5  mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         <div className="bg-white dark:bg-[#1d3015] rounded-2xl m-0.5  p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -89,18 +128,46 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
+          Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#BACD32] dark:bg-[#2c3510] rounded-2xl m-0.5 ">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#22252d]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnPink}
+                >
+                  Approve
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-white dark:bg-[#22252d] rounded-2xl m-0.5 ">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -109,7 +176,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -124,49 +191,79 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.userId ? 'bg-[#CD6C0C]' : 'bg-[#71AD44] dark:bg-[#1d3015]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.handle ? 'bg-[#CD6C0C]' : 'bg-[#BACD32] dark:bg-[#2c3510]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#22252d] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#181a20] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.friendSlug ? 'bg-[#CD6C0C]' : 'bg-[#BACD32] dark:bg-[#2c3510]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#71AD44] dark:bg-[#1d3015]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#CD6C0C] hover:text-white transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -178,7 +275,7 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone You Follow</h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black ${c.bodyText}`}>Picks by</h3>
@@ -201,8 +298,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any events yet."
-                : "This friend hasn't picked any events yet."
+                ? 'Nobody you follow has picked any events yet.'
+                : "They haven't picked any events yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/pickathon-picker/FriendsView.jsx
+++ b/examples/pickathon-picker/FriendsView.jsx
@@ -17,6 +17,7 @@ export default function FriendsView({
   follow,
   unfollow,
   approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -155,6 +156,14 @@ export default function FriendsView({
                 >
                   Approve
                 </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#181a20] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
               </div>
             ))}
           </div>
@@ -262,6 +271,16 @@ export default function FriendsView({
                     className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#CD6C0C] hover:text-white transition-all"
                   >
                     Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
                   </button>
                 )}
               </div>

--- a/examples/pickathon-picker/NowView.jsx
+++ b/examples/pickathon-picker/NowView.jsx
@@ -18,7 +18,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             </span>
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/pickathon-picker/RUNBOOK.md
+++ b/examples/pickathon-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull og/pickathon-picker
 - **Database**: Fireproof `"pickathon"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js`):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared shifts (via the friend grant) but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
 - **Super mode** — URL easter egg (`?super=1` / `?super=true`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 
 ## Granting super access
@@ -115,3 +115,23 @@ Fetched from `https://pickathon.com/wp-content/plugins/pickathon/schedule.php` a
 | Change logo           | `LOGO_URL` constant                                                                                                            |
 | Add a new view/tab    | Add to the `["browse", "favorites", "shifts", "schedule"]` array in nav, add `{view === "newview" && ...}` section in the body |
 | Change colors         | `c` object near bottom of component                                                                                            |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/pickathon-picker/ShiftsView.jsx
+++ b/examples/pickathon-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/pickathon-picker/access.js
+++ b/examples/pickathon-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/pickathon-picker/access.test.js
+++ b/examples/pickathon-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,40 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, vibes.diy#3433): bob must be
-  // able to revoke the mutual sharing alice created by scanning his QR — the
-  // "Added You" list renders a remove control for exactly this. Deletes only:
-  // bob still cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 

--- a/examples/sotm-picker/App.jsx
+++ b/examples/sotm-picker/App.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
-import { useViewer, useVibe } from 'use-vibes';
+import { useSocial, useViewer, useVibe } from 'use-vibes';
 import {
   FESTIVAL_2026,
   toFestivalDate,
@@ -57,7 +57,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-const byTypeFriendSlug = (doc) => [doc.type, doc.friendSlug];
 
 // A topographic contour-line motif along the header's bottom edge: a few thin,
 // low-contrast elevation lines, like a corner of an IGN hiking map behind the
@@ -94,6 +93,22 @@ export default function SotmPicker() {
     migrate: migrateSotmDoc,
   });
   const { can, ready } = useVibe('sotm2026');
+  // The follow graph lives in the PLATFORM (Settings → Social) — the app stores
+  // no edge docs. `ready` is false for anonymous viewers and during the initial
+  // round-trip, so every social surface gates on it. Mutations resolve after the
+  // shell pushes a refreshed snapshot, and expected refusals (self-follow,
+  // blocked pair, unknown handle) resolve QUIETLY — render from the lists, don't
+  // branch on errors that never arrive.
+  const {
+    ready: socialReady,
+    following,
+    followers,
+    requests,
+    follow,
+    unfollow,
+    approve,
+    removeFollower,
+  } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
@@ -118,10 +133,9 @@ export default function SotmPicker() {
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
   const [linkedFriend, setLinkedFriend] = useState(null);
-  const [friendConfirm, setFriendConfirm] = useState(null);
   const friendScrolledRef = useRef(false);
-  // Handles we've already resolved (added or declined) this session, so the confirm
-  // prompt doesn't re-appear after the friends list updates.
+  // Handles this session already followed from a link, so a re-render doesn't
+  // re-fire the follow.
   const handledFriendRef = useRef(new Set());
   const [pendingDelete, setPendingDelete] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
@@ -175,34 +189,6 @@ export default function SotmPicker() {
     setLinkedFriend(fp);
     clearFriendParamFromUrl();
   }, []);
-
-  // Adding a friend (they can see your schedule) should be deliberate: the add-intent
-  // rides in the URL and the parent vibes.diy URL is cross-origin, so we can't strip it
-  // there — someone could re-share their address bar and silently propose *their* friend
-  // to a third party. So instead of auto-adding, we confirm first (see the prompt effect
-  // below, after the friends list is available).
-  const confirmAddFriend = () => {
-    const slug = friendConfirm;
-    if (!slug || !viewer?.userHandle) return;
-    handledFriendRef.current.add(slug);
-    database
-      .put({
-        _id: `friend-${viewer.userHandle}-${slug}`,
-        type: 'friend',
-        userId: viewer.userHandle,
-        friendSlug: slug,
-        createdAt: Date.now(),
-      })
-      .catch(() => {});
-    setSelectedFriend(slug);
-    setView('friends');
-    setFriendConfirm(null);
-  };
-  const declineAddFriend = () => {
-    if (friendConfirm) handledFriendRef.current.add(friendConfirm);
-    setFriendConfirm(null);
-    setLinkedFriend(null);
-  };
 
   // Scroll to the friend's schedule once it's rendered (one-time).
   useEffect(() => {
@@ -328,50 +314,51 @@ export default function SotmPicker() {
   );
   const myFavIds = useMemo(() => new Set(myFavorites.map((f) => f.eventId)), [myFavorites]);
 
-  const { docs: friends } = useLiveQuery(byTypeUser, { key: ['friend', userId] });
-  const { docs: friendedBy } = useLiveQuery(byTypeFriendSlug, { key: ['friend', userId] });
+  // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
+  // a private account sits at state "requested" until they approve — it grants
+  // no reads, so including it would only render empty schedule sections.
+  const followedHandles = useMemo(
+    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
+    [following]
+  );
 
-  const friendSlugs = useMemo(() => {
-    const s = new Set();
-    for (const f of friends) s.add(f.friendSlug);
-    for (const f of friendedBy) s.add(f.userId);
-    s.delete(userId);
-    return s;
-  }, [friends, friendedBy, userId]);
-
-  // Once signed in, a captured ?friend link prompts a confirmation before adding —
-  // unless you already follow them, in which case just jump to their schedule.
+  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
+  // Following is one-directional — it exposes nothing of YOURS (they see your
+  // picks only if they follow you back) — so the old add-friend confirmation
+  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
+  // into a private account lands as "requested" and their schedule stays empty
+  // until they approve.
   useEffect(() => {
-    if (!signedIn || !linkedFriend || linkedFriend === viewer.userHandle) return;
+    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
     if (handledFriendRef.current.has(linkedFriend)) return;
-    if (friends.some((f) => f.friendSlug === linkedFriend)) {
-      handledFriendRef.current.add(linkedFriend);
-      // Clear any prompt we may have opened in an earlier run before `friends` hydrated
-      // (useLiveQuery starts empty), so an already-followed user never gets stuck with it.
-      setFriendConfirm(null);
+    handledFriendRef.current.add(linkedFriend);
+    const go = () => {
       setSelectedFriend(linkedFriend);
       setView('friends');
+    };
+    if (followedHandles.has(linkedFriend)) {
+      go();
       return;
     }
-    setFriendConfirm(linkedFriend);
-  }, [signedIn, linkedFriend, friends, viewer?.userHandle]);
+    follow(linkedFriend).then(go, go);
+  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
 
   const friendFavIds = useMemo(() => {
     const s = new Set();
     for (const f of allFavorites) {
-      if (friendSlugs.has(f.userId || 'anonymous')) s.add(f.eventId);
+      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
     }
     return s;
-  }, [allFavorites, friendSlugs]);
+  }, [allFavorites, followedHandles]);
 
-  // Selecting ALL_FRIENDS unifies everyone you're connected to (Following + Added You,
-  // i.e. friendSlugs — plus yourself, when "include my faves" is on) into one schedule;
+  // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
+  // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
   const friendFavoriteEvents = useMemo(() => {
     if (!selectedFriend) return [];
     const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => friendSlugs.has(uid) || (includeMyFaves && uid === userId);
+    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
     const pickedBy = new Map();
     for (const f of allFavorites) {
       const uid = f.userId || 'anonymous';
@@ -384,7 +371,7 @@ export default function SotmPicker() {
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, friendSlugs, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -393,10 +380,10 @@ export default function SotmPicker() {
     return allShifts
       .filter((s) => {
         const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? friendSlugs.has(uid) : uid === selectedFriend);
+        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
       })
       .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, friendSlugs]);
+  }, [selectedFriend, allShifts, followedHandles]);
 
   // Only days that actually have events or shifts, ordered by the conference day order.
   // We deliberately do NOT seed with the full dayOrder — a conference day with nothing
@@ -593,8 +580,12 @@ export default function SotmPicker() {
   // show THEIR picks (from the readable firehose), not the current user's.
   const viewedFavoriteEvents = useMemo(() => {
     if (!viewingUser || viewingUser === userId) return favoriteEvents;
-    const ids = new Set(allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId));
-    return events.filter((e) => ids.has(e.eventId)).sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
+    const ids = new Set(
+      allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
+    );
+    return events
+      .filter((e) => ids.has(e.eventId))
+      .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
   }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
 
   const makeSchedule = (day) => {
@@ -726,7 +717,7 @@ export default function SotmPicker() {
                   {viewName === 'browse' && `All Talks`}
                   {viewName === 'tracks' && `Tracks`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Friends`}
+                  {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -821,8 +812,14 @@ export default function SotmPicker() {
 
               {view === 'friends' && (
                 <FriendsView
-                  friends={friends}
-                  friendedBy={friendedBy}
+                  socialReady={socialReady}
+                  following={following}
+                  followers={followers}
+                  requests={requests}
+                  follow={follow}
+                  unfollow={unfollow}
+                  approve={approve}
+                  removeFollower={removeFollower}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
@@ -840,8 +837,6 @@ export default function SotmPicker() {
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
                   qrSrc={qrSrc}
-                  renderDeleteX={renderDeleteX}
-                  pendingDelete={pendingDelete}
                   ViewerTag={ViewerTag}
                   c={c}
                 />
@@ -927,37 +922,10 @@ export default function SotmPicker() {
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
               {linkedFriend
-                ? 'Sign in via the Vibes DIY logo to add friends'
-                : 'Sign in via the Vibes DIY logo to share your schedule with friends'}
+                ? 'Sign in via the Vibes DIY logo to follow people'
+                : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
             <div className="w-[120px] shrink-0 self-stretch" aria-hidden="true" />
-          </div>
-        </div>
-      )}
-
-      {friendConfirm && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-1"
-          role="dialog"
-          aria-modal="true"
-        >
-          <div className="bg-white dark:bg-[#1b2913] rounded-2xl p-2 max-w-sm w-full shadow-2xl">
-            <h3 className={`text-xl font-black mb-0.5 ${c.bodyText}`}>Add friend?</h3>
-            <p className={`font-bold mb-1.5 ${c.bodyText}`}>
-              This link wants to add <span className="text-[#2d6a8f]">@{friendConfirm}</span> to
-              your crew. You'll see each other's schedules.
-            </p>
-            <div className="flex gap-[3px] justify-end flex-wrap">
-              <button
-                onClick={declineAddFriend}
-                className="py-1 px-2 font-bold rounded-2xl bg-white dark:bg-[#161c12] text-[#2b3a24] dark:text-[#e9f0e3] border border-black/10 dark:border-white/20 hover:opacity-90 transition-all"
-              >
-                Not now
-              </button>
-              <button onClick={confirmAddFriend} className={c.btnAccent}>
-                Add friend
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/examples/sotm-picker/FriendsView.jsx
+++ b/examples/sotm-picker/FriendsView.jsx
@@ -1,13 +1,23 @@
 import React, { useState } from 'react';
 import ScheduleView from './ScheduleView.jsx';
 
-// Sentinel for selectedFriend meaning "everyone I'm connected to" — the unified
+// Sentinel for selectedFriend meaning "everyone I follow" — the unified
 // schedule. `*` can't appear in a real handle, so it can't collide.
 export const ALL_FRIENDS = '*all*';
 
+// The follow graph lives in the platform (Settings → Social); this view renders
+// the viewer's edges from useSocial() and never touches the app db for them.
+// Copy discipline: "following" = whose picks I see; "followers" = who sees my
+// picks — never "friends".
 export default function FriendsView({
-  friends,
-  friendedBy,
+  socialReady,
+  following,
+  followers,
+  requests,
+  follow,
+  unfollow,
+  approve,
+  removeFollower,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,12 +35,27 @@ export default function FriendsView({
   fmtTime,
   connectUrl,
   qrSrc,
-  renderDeleteX,
-  pendingDelete,
   ViewerTag,
   c,
 }) {
   const [copied, setCopied] = useState(false);
+  // Handles with an in-flight mutation: the promise resolves only after the
+  // shell pushes the refreshed snapshot, so this is purely a double-tap guard —
+  // when it clears, the lists already show the new state. Expected refusals
+  // (self-follow, blocked pair, unknown handle) resolve quietly — the snapshot
+  // just doesn't change — so there is nothing to catch and no error UI to render.
+  const [busy, setBusy] = useState(() => new Set());
+  const mutate = (fn, handle) => {
+    setBusy((b) => new Set(b).add(handle));
+    fn(handle).finally(() =>
+      setBusy((b) => {
+        const n = new Set(b);
+        n.delete(handle);
+        return n;
+      })
+    );
+  };
+
   const copyLink = () => {
     navigator.clipboard.writeText(connectUrl).then(() => {
       setCopied(true);
@@ -38,14 +63,29 @@ export default function FriendsView({
     });
   };
 
+  const followingActive = following.filter((f) => f.state === 'active');
+  const followingRequested = following.filter((f) => f.state === 'requested');
+  const followingSet = new Set(following.map((f) => f.handle));
+
+  // Signed-in but the graph snapshot hasn't arrived yet — skeleton, not lists.
+  if (!socialReady) {
+    return (
+      <div className="mb-1.5 p-2.5 bg-white dark:bg-[#1b2913] rounded-2xl m-0.5">
+        <p className={`font-bold ${c.bodyText}`}>Loading your follows…</p>
+      </div>
+    );
+  }
+
   return (
     <div>
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#d8e8c8] dark:bg-[#16220e] rounded-2xl m-0.5  mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
-          <p className={`text-lg font-bold ${c.bodyText}`}>Share this link to connect schedules</p>
+          <p className={`text-lg font-bold ${c.bodyText}`}>
+            Share this link so people can follow you
+          </p>
         </div>
         <div className="bg-white dark:bg-[#1c3012] rounded-2xl m-0.5  p-2">
-          <img src={qrSrc} alt="Connect QR code" width="320" height="320" />
+          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -89,18 +129,54 @@ export default function FriendsView({
           </button>
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Send this link to someone you want to add as a friend. When they open it, you'll be added
-          to each other's crews and can see each other's schedules.
+          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
+          Follow them back to see theirs.
         </p>
       </div>
 
+      {requests.length > 0 && (
+        <div className="mb-1.5 p-2.5 bg-[#d8e8c8] dark:bg-[#16220e] rounded-2xl m-0.5 ">
+          <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>
+            Follow requests ({requests.length})
+          </h3>
+          <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+            Your account is private — approve a request to let that person see your picks.
+          </p>
+          <div className="flex flex-wrap gap-[3px]">
+            {requests.map((r) => (
+              <div
+                key={`req-${r.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#1b2913]"
+              >
+                <ViewerTag userHandle={r.handle} />
+                <button
+                  onClick={() => mutate(approve, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className={c.btnAccent}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => mutate(removeFollower, r.handle)}
+                  disabled={busy.has(r.handle)}
+                  className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#161c12] text-[#2b3a24] dark:text-[#e9f0e3] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Decline — they can request again later"
+                >
+                  Decline
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="mb-1.5 p-2.5 bg-white dark:bg-[#1b2913] rounded-2xl m-0.5 ">
         <p className={`text-sm font-bold mb-1 ${c.bodyText} italic`}>
-          {friends.length + friendedBy.length > 0
-            ? 'Click a friend to see their schedule'
-            : 'Add a friend to see their schedule'}
+          {followingActive.length > 0
+            ? 'Tap someone you follow to see their schedule'
+            : 'Follow someone to see their schedule'}
         </p>
-        {friends.length + friendedBy.length > 0 && (
+        {followingActive.length > 0 && (
           <div className="flex items-center flex-wrap gap-0.5 mb-1.5">
             <button
               onClick={() => setSelectedFriend(selectedFriend === ALL_FRIENDS ? null : ALL_FRIENDS)}
@@ -109,7 +185,7 @@ export default function FriendsView({
               All
             </button>
             <span className={`text-sm font-bold ${c.bodyText}`}>
-              everyone's picks as one schedule
+              everyone you follow, as one schedule
             </span>
             <label
               className={`flex items-center gap-0.5 text-sm font-bold ${c.bodyText} cursor-pointer`}
@@ -124,49 +200,89 @@ export default function FriendsView({
             </label>
           </div>
         )}
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Added You ({friendedBy.length})</h3>
-        {friendedBy.length === 0 ? (
-          <p className={`font-bold ${c.bodyText} mb-1.5`}>Nobody has scanned your QR yet.</p>
+
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
+        {following.length === 0 ? (
+          <p className={`font-bold ${c.bodyText} mb-1.5`}>
+            Not following anyone yet — scan a friend's QR code to follow them.
+          </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
-            {friendedBy.map((f) => (
+            {followingActive.map((f) => (
               <div
-                key={`by-${f._id}`}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.userId ? 'bg-[#2d6a8f]' : 'bg-[#4c7a34] dark:bg-[#1c3012]'}`}
+                key={`fw-${f.handle}`}
+                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.handle ? 'bg-[#2d6a8f]' : 'bg-[#d8e8c8] dark:bg-[#16220e]'}`}
               >
                 <button
-                  onClick={() => setSelectedFriend(selectedFriend === f.userId ? null : f.userId)}
+                  onClick={() => setSelectedFriend(selectedFriend === f.handle ? null : f.handle)}
                   className="flex items-center"
                 >
-                  <ViewerTag userHandle={f.userId} />
+                  <ViewerTag userHandle={f.handle} />
                 </button>
-                {canWrite && renderDeleteX(f._id)}
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#1b2913] text-[#2b3a24] dark:text-[#e9f0e3] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Unfollow"
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {followingRequested.map((f) => (
+              <div
+                key={`fw-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-white dark:bg-[#1b2913] opacity-80"
+                title="They have a private account — waiting for approval"
+              >
+                <ViewerTag userHandle={f.handle} />
+                <span className={`text-xs font-bold pr-0.5 ${c.bodyText}`}>requested</span>
+                <button
+                  onClick={() => mutate(unfollow, f.handle)}
+                  disabled={busy.has(f.handle)}
+                  className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#161c12] text-[#2b3a24] dark:text-[#e9f0e3] hover:bg-[#B22222] hover:text-white transition-all"
+                  title="Cancel request"
+                >
+                  ×
+                </button>
               </div>
             ))}
           </div>
         )}
 
-        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({friends.length})</h3>
-        {friends.length === 0 ? (
-          <p className={`font-bold ${c.bodyText}`}>
-            No friends yet — share your QR code above to connect.
-          </p>
+        <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
+        <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
+          Followers can see your picks and shared extras.
+        </p>
+        {followers.length === 0 ? (
+          <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
         ) : (
           <div className="flex flex-wrap gap-[3px]">
-            {friends.map((f) => (
+            {followers.map((f) => (
               <div
-                key={f._id}
-                className={`flex items-center gap-0.5 p-0.5 rounded-full m-0.5  transition-all ${selectedFriend === f.friendSlug ? 'bg-[#2d6a8f]' : 'bg-[#d8e8c8] dark:bg-[#16220e]'}`}
+                key={`fb-${f.handle}`}
+                className="flex items-center gap-0.5 p-0.5 rounded-full m-0.5 bg-[#4c7a34] dark:bg-[#1c3012]"
               >
-                <button
-                  onClick={() =>
-                    setSelectedFriend(selectedFriend === f.friendSlug ? null : f.friendSlug)
-                  }
-                  className="flex items-center"
-                >
-                  <ViewerTag userHandle={f.friendSlug} />
-                </button>
-                {canWrite && renderDeleteX(f._id)}
+                <ViewerTag userHandle={f.handle} />
+                {canWrite && !followingSet.has(f.handle) && (
+                  <button
+                    onClick={() => mutate(follow, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="py-[1px] px-1 rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#1b2913] text-[#2b3a24] dark:text-[#e9f0e3] hover:bg-[#2d6a8f] hover:text-white transition-all"
+                  >
+                    Follow back
+                  </button>
+                )}
+                {canWrite && (
+                  <button
+                    onClick={() => mutate(removeFollower, f.handle)}
+                    disabled={busy.has(f.handle)}
+                    className="px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold bg-white dark:bg-[#1b2913] text-[#2b3a24] dark:text-[#e9f0e3] hover:bg-[#B22222] hover:text-white transition-all"
+                    title="Remove this follower — soft: they can follow you again later (block is the hard version, in Settings)"
+                  >
+                    ×
+                  </button>
+                )}
               </div>
             ))}
           </div>
@@ -178,7 +294,7 @@ export default function FriendsView({
           <div className="flex items-center justify-between mb-1 flex-wrap gap-0.5">
             <div className="flex items-center gap-0.5 flex-wrap">
               {selectedFriend === ALL_FRIENDS ? (
-                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone's Picks</h3>
+                <h3 className={`text-2xl font-black ${c.bodyText}`}>Everyone You Follow</h3>
               ) : (
                 <>
                   <h3 className={`text-2xl font-black ${c.bodyText}`}>Picks by</h3>
@@ -201,8 +317,8 @@ export default function FriendsView({
             shiftEndRaw={shiftEndRaw}
             emptyMessage={
               selectedFriend === ALL_FRIENDS
-                ? "Your crew hasn't picked any talks yet."
-                : "This friend hasn't picked any talks yet."
+                ? 'Nobody you follow has picked any talks yet.'
+                : "They haven't picked any talks yet — or their account is private and hasn't approved you yet."
             }
             canWrite={false}
             onToggleFavorite={canWrite ? toggleFavorite : null}

--- a/examples/sotm-picker/NowView.jsx
+++ b/examples/sotm-picker/NowView.jsx
@@ -21,7 +21,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             </span>
             {isFriendPick && (
               <span className={c.badge} title="A friend favorited this">
-                friend pick
+                followed pick
               </span>
             )}
           </div>

--- a/examples/sotm-picker/RUNBOOK.md
+++ b/examples/sotm-picker/RUNBOOK.md
@@ -27,10 +27,10 @@ npx vibes-diy pull calendar/sotm-picker
 - **Database**: Fireproof `"sotm2026"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
 - **Auth**: `useViewer()` from `use-vibes`. `can(...)` gates write surfaces. Anonymous users favorite locally (migrated on sign-in); notes/shifts/friends need sign-in.
 - **Channels** (`access.js` — same design as pickathon-picker's):
-  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; friends read them because a **friend edge grants read of each other's `share-` channel**. Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
+  - **Favorites** (`type: "favorite"`, keyed `favorite-{userId}-{eventId}`) → the owner's **`share-{userId}`** channel _and_ the global **`super`** firehose. The owner reads their own via `share-`; followers read them via the platform follow graph (**`audience: { followersOf }`**, see § Social migration). Nobody is granted `super` — it exists only to be unlocked by a `grant` doc (see below). This is deliberately NOT world-readable: it's what keeps every client from syncing every user's favorites at scale.
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared extras (via the friend grant) but not your private ones.
-  - **Friend edge** (`friend-{owner}-{slug}`) → lives in both `user-` channels (for following/followers lists) and cross-grants each person read of the other's `share-` channel.
+  - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
 - **Super mode** — URL easter egg (`?super=1`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 - **Tracks tab** — groups talks by their pretalx `track` (Mapping, Cartography, …). Each track gets a deterministic color from the map-legend palette (`TRACK_COLORS` + FNV-1a hash in `festival-utils.js`), which also tints event cards via the `--lineup` custom prop.
 
@@ -125,3 +125,23 @@ past-midnight social groups under the day it started.
 | Change header motif     | `CONTOUR_PATHS` in `App.jsx` (static SVG contour lines)                                                           |
 | Add a new view/tab      | Add to the `["now", "browse", "tracks", ...]` array in nav, add `{view === "newview" && ...}` section in the body |
 | Change colors           | `c` object in `styles.js`                                                                                         |
+
+## Social migration (2026-07: friend docs → platform follow graph)
+
+This app used to store `type:"friend"` edge docs and cross-grant `share-` channel
+reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
+
+- The app reads/mutates edges with `useSocial()` (`following`/`followers`/`requests`
+  - `follow`/`unfollow`/`approve`/`removeFollower`); access.js labels follower-visible
+    docs with `audience: { followersOf: <owner> }` instead of granting per-edge.
+- **Legacy `type:"friend"` docs remain in the db but are inert** — they fall to the
+  unknown-type discard branch (kept, unreadable). Do not delete them casually, and
+  NEVER re-run the one-shot import (`vibes.diy` repo:
+  `vibes-diy/cli/social-import-friend-edges.oneoff.mts`) — it ran once at cutover to
+  convert the edges to bidirectional platform follows; a post-cutover re-run could
+  resurrect deliberately removed edges (no-resurrection residual, see the import spec
+  in vibes.diy `docs/superpowers/specs/2026-07-09-friend-doc-import-and-prompt-landing.md`).
+- Semantics changed with the model: visibility is now FOLLOW-DIRECTION (I see the
+  picks of people I follow), not mutual-edge; a private account's inbound follows sit
+  `requested` until approved. Copy discipline everywhere: "following"/"followers",
+  never "friends".

--- a/examples/sotm-picker/ShiftsView.jsx
+++ b/examples/sotm-picker/ShiftsView.jsx
@@ -74,7 +74,7 @@ export default function ShiftsView({
               onChange={(e) => mergeShift({ shareWithFriends: e.target.checked })}
               className="w-5 h-5"
             />
-            Show in friends view
+            Share with followers
           </label>
           <button
             onClick={handleSubmit}
@@ -113,7 +113,7 @@ export default function ShiftsView({
                         }
                         className="w-4 h-4"
                       />
-                      Show in friends view
+                      Share with followers
                     </label>
                   )}
                 </div>

--- a/examples/sotm-picker/access.js
+++ b/examples/sotm-picker/access.js
@@ -12,14 +12,17 @@ export default function (doc, oldDoc, user, ctx) {
   // live in localStorage and migrate in on first sign-in.
   if (!user) throw { forbidden: 'authentication required' };
 
-  // Favorites live in the owner's *shared* channel (owner + their friends can read it,
-  // so "friend picks" resolve without fetching the world) AND are mirrored into the
-  // global "super" firehose. Nobody is granted "super" here — only a `grant` doc unlocks
-  // it. This is what stops every client from syncing every user's favorites at scale.
+  // Favorites live in the owner's *shared* channel and are readable by the
+  // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
+  // lives in the platform (Settings → Social), not in this db. Resolution is
+  // read-time: a new follower sees history instantly, an unfollow/block revokes
+  // instantly, and the owner is always in their own audience (X ∈ followersOf X),
+  // so no self-grant is needed. Favorites are still mirrored into the global
+  // "super" firehose, which stays locked behind an owner-written `grant` doc.
   if (type === 'favorite') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const share = `share-${ownerId}`;
-    return { channels: ['super', share], grant: { users: { [ownerId]: [share] } } };
+    return { channels: ['super', share], audience: { followersOf: ownerId } };
   }
 
   // Calendar-subscription token: the random capability that makes the user's
@@ -39,42 +42,26 @@ export default function (doc, oldDoc, user, ctx) {
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A shift marked shareWithFriends goes to the owner's shared channel (friends can read
-  // it — that's the friend-shift-sharing feature); otherwise it stays private in the
-  // owner's user channel.
+  // A shift marked shareWithFriends is readable by the owner's followers (same
+  // audience label as favorites); a private shift stays on the owner's private
+  // user channel with a plain self-grant — `audience` is only for follower
+  // visibility, it does not replace channels+grant for private data.
   if (type === 'shift') {
     if (ownerId !== user.userHandle) throw { forbidden: 'not owner' };
     const shared =
       doc.shareWithFriends != null ? doc.shareWithFriends : oldDoc && oldDoc.shareWithFriends;
-    const ch = shared ? `share-${ownerId}` : `user-${ownerId}`;
+    if (shared) {
+      return { channels: [`share-${ownerId}`], audience: { followersOf: ownerId } };
+    }
+    const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
 
-  // A friend edge makes the two people's *shared* channels mutually readable, so each
-  // sees the other's favorites and shared shifts. Private user channels (notes, private
-  // shifts) are NOT shared. The edge doc itself lives in both user channels so it appears
-  // in each person's following/followers list.
-  if (type === 'friend') {
-    const friendSlug = doc.friendSlug != null ? doc.friendSlug : oldDoc && oldDoc.friendSlug;
-    // Only the initiator may create or modify the edge — but EITHER endpoint may
-    // sever it: the "Added You" list renders a remove control, and the person
-    // being followed must be able to revoke the mutual share grant someone else
-    // created by scanning their QR. Deleting the doc drops its grant on the next
-    // fixpoint, which is exactly the revocation.
-    const isDelete = Boolean(doc._deleted);
-    if (ownerId !== user.userHandle && !(isDelete && friendSlug === user.userHandle)) {
-      throw { forbidden: 'not owner' };
-    }
-    return {
-      channels: [`user-${ownerId}`, `user-${friendSlug}`],
-      grant: {
-        users: {
-          [ownerId]: [`user-${ownerId}`, `share-${friendSlug}`],
-          [friendSlug]: [`user-${friendSlug}`, `share-${ownerId}`],
-        },
-      },
-    };
-  }
+  // The friend graph moved to the platform (follow edges, privacy, blocks —
+  // Settings → Social). This app no longer stores `type:"friend"` docs; legacy
+  // edge docs fall through to the unknown-type branch below (kept, unreadable).
+  // NOTE: their old cross-grants stop applying once this function is live —
+  // visibility comes from platform follows only. See RUNBOOK § Social migration.
 
   // A `grant` doc unlocks the "super" favorites firehose for one user (doc.grantTo).
   // Owner-only — `user.isOwner` is the reserved vibe-owner flag (the account that owns

--- a/examples/sotm-picker/access.test.js
+++ b/examples/sotm-picker/access.test.js
@@ -12,10 +12,13 @@ function run(doc, oldDoc, user) {
 const alice = { userHandle: 'alice' };
 
 describe('access.js — channel routing', () => {
-  it("favorites go to super + the owner's share channel, granted to the owner only", () => {
+  it("favorites go to super + the owner's share channel, follower-readable via audience", () => {
     const { ok } = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice);
     expect(ok.channels).toEqual(['super', 'share-alice']);
-    expect(ok.grant).toEqual({ users: { alice: ['share-alice'] } }); // nobody is granted "super"
+    // The follow graph lives in the platform: followers (and always the owner —
+    // X ∈ followersOf X) read via the audience label; no self-grant needed.
+    expect(ok.audience).toEqual({ followersOf: 'alice' });
+    expect(ok.grant).toBeUndefined();
   });
 
   it("notes are private to the owner's user channel", () => {
@@ -24,40 +27,20 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it('a shared shift goes to the share channel; a private shift stays in the user channel', () => {
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok.channels
-    ).toEqual(['share-alice']);
-    expect(
-      run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok.channels
-    ).toEqual(['user-alice']);
+  it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
+    const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
+    expect(shared.channels).toEqual(['share-alice']);
+    expect(shared.audience).toEqual({ followersOf: 'alice' });
+    const priv = run({ type: 'shift', userId: 'alice', shareWithFriends: false }, null, alice).ok;
+    expect(priv.channels).toEqual(['user-alice']);
+    expect(priv.audience).toBeUndefined();
+    expect(priv.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
-  it("a friend edge cross-grants read of each other's share channel", () => {
+  it('legacy friend edge docs are accepted but land unreadable (graph moved to the platform)', () => {
     const { ok } = run({ type: 'friend', userId: 'alice', friendSlug: 'bob' }, null, alice);
-    expect(ok.channels).toEqual(['user-alice', 'user-bob']);
-    expect(ok.grant).toEqual({
-      users: {
-        alice: ['user-alice', 'share-bob'], // alice reads bob's shared favorites/shifts
-        bob: ['user-bob', 'share-alice'], // and bob reads alice's
-      },
-    });
-  });
-
-  // Either endpoint may sever a friend edge (Codex, vibes.diy#3433): bob must be
-  // able to revoke the mutual sharing alice created by scanning his QR — the
-  // "Added You" list renders a remove control for exactly this. Deletes only:
-  // bob still cannot create or modify an edge he doesn't own.
-  it('the target of a friend edge can delete it, but not create or modify it', () => {
-    const edge = { _id: 'friend-alice-bob', type: 'friend', userId: 'alice', friendSlug: 'bob' };
-    const bob = { userHandle: 'bob' };
-    const del = run({ _id: 'friend-alice-bob', _deleted: true }, edge, bob);
-    expect(del.ok.channels).toEqual(['user-alice', 'user-bob']); // authorized, routed like the edge
-    expect(run(edge, null, bob)).toEqual({ forbidden: 'not owner' }); // create for someone else
-    expect(run({ ...edge, friendSlug: 'bob' }, edge, bob)).toEqual({ forbidden: 'not owner' }); // non-delete update
-    expect(run({ _id: 'friend-alice-bob', _deleted: true }, edge, { userHandle: 'mallory' })).toEqual({
-      forbidden: 'not owner', // a third party can't sever other people's edges
-    });
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
   });
 });
 


### PR DESCRIPTION
**No longer a draft — this is the real cutover**, executed in the #3421 runbook order and validated live at each step.

## Sequence (all complete)

1. **Prompt-readiness dry run** on pickathon-picker (the original scope of this PR) — validated two-sided on prod at `qa/pickathon-picker`: follow-via-QR-link → read-time `followersOf` visibility → follow-back/soft-remove → quiet idempotent refusals. Owner experienced it and approved.
2. **One-shot friend-doc import** ran against all five legacy tuples (vibes.diy `social-import-friend-edges.oneoff.mts --real`): 12 directed edges created, idempotency verified (`edgesCreated: 0` on re-run), `SocialEdges` inspected — one known asymmetric pair (the smoke's own edge; pair-guard working as designed), fixed by a follow-back at validation.
3. **This PR: the migration applied to all seven pickers** — pickathon (reference), then ietf / juliacon / euroscipy / sotm / defcon / ocf, each in its own palette and vocabulary:
   - `access.js`: `audience: { followersOf: owner }` on favorites + shared shifts, self-grants dropped, friend branch deleted (legacy docs inert via the unknown-type branch); defcon's and ocf's owner-gated `schedule-snapshot` branches untouched.
   - `App.jsx`: `useSocial()` (incl. `removeFollower`, #3468) replaces the friend-doc LiveQueries; `?friend=` links follow directly (no dialog); visibility = active following.
   - `FriendsView.jsx`: Following / Followers (follow-back + soft-remove ×) / Requests (Approve/Decline), `socialReady` skeleton, quiet-refusal mutation handling.
   - Copy discipline throughout, including NowView's badge (`friend pick` → `followed pick`).
   - Every RUNBOOK gains **§ Social migration** (inert legacy docs, never-re-run-the-import warning, follow-direction semantics) and loses its stale friend-edge channel description.

## Tests

653 passing across the examples suite (all seven pickers' access/schedule/backend files). Deployments: `og/pickathon-picker` + the six `calendar/` apps, pushed from this branch and validated post-deploy (authed og check with the imported community follows).

Related: vibesdiy/vibes.diy#3421 (program), #3423/#3468 (platform + hook), vibes.diy#3476 (import runner + two-user smoke, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn