### PR TITLE
meta-hub: add postAt scheduling to the publish-request pipeline

### DIFF
--- a/examples/meta-hub/RUNBOOK.md
+++ b/examples/meta-hub/RUNBOOK.md
@@ -14,6 +14,11 @@ publishing pipeline so GitHub never carries social credentials:
 - **requests db** (owner-only): `publish-request` docs walk a state machine
   `pending → items-created → carousel-created → done|error`, carrying
   `images[]` (public JPEG URLs, 4:5), `caption`, and eventually `permalink`.
+  An optional `postAt` ISO timestamp **schedules** the post: the triage loop
+  holds any request whose `postAt` is in the future (`heldReason: scheduled
+for <postAt>`) before it touches tokens or egress, so a backlog can be
+  spaced out instead of draining 3-per-tick all at once. Omit it to post ASAP;
+  an unparseable `postAt` is treated as "due now" so a typo can't wedge a post.
 - **oplog db** (owner-only): rotation/publish log + the `egress-probe` doc.
 
 All token-touching work runs in the `scheduled` handler (1m tick) **on
@@ -41,6 +46,10 @@ just retries next tick (bounded by `MAX_ATTEMPTS`).
     "createdAt": "<iso-now>"
   }'
   ```
+
+  To **schedule** it for later, add `"postAt": "<iso-future>"` — the request
+  holds until then, then posts on the next tick. Stagger several `postAt`
+  values (e.g. 6h apart) to drip a backlog into a feed instead of flooding it.
 
   Status lands on the same doc within ~1–3 ticks; `done` carries the
   Instagram `permalink`.

--- a/examples/meta-hub/backend.js
+++ b/examples/meta-hub/backend.js
@@ -879,6 +879,24 @@ export async function scheduled(event, ctx) {
   // steady-state hold costs no writes).
   const actionable = [];
   for (const req of reqs) {
+    // Scheduled posts: a request may carry a `postAt` ISO timestamp. Hold it
+    // — before any token/egress check, so a scheduled post can't terminal-
+    // error on a transient token gap before its time — until that moment
+    // arrives, so a backlog can be spaced out instead of draining 3-per-tick
+    // all at once. An unparseable postAt (NaN) is treated as "due now" so a
+    // typo can't wedge a post forever. heldReason is cleared when the request
+    // becomes actionable (see the actionable.push below).
+    const postAtMs = req.postAt ? new Date(req.postAt).getTime() : NaN;
+    if (Number.isFinite(postAtMs) && postAtMs > Date.now()) {
+      const held = `scheduled for ${req.postAt}`;
+      if (req.heldReason !== held) {
+        await ctx.db.put(
+          { ...req, heldReason: held, updatedAt: new Date().toISOString() },
+          { db: 'requests' }
+        );
+      }
+      continue;
+    }
     const t = fresh.find((x) => x.platform === (req.platform || 'ig'));
     if (!t || !t.token) {
       await ctx.db.put(

--- a/examples/meta-hub/backend.test.js
+++ b/examples/meta-hub/backend.test.js
@@ -835,6 +835,101 @@ describe('scheduled — shared-path invariants (ig/threads/fbpage parity)', () =
     expect(ctx.dbs.requests.find((d) => d._id === 'r-bsky').status).toBe('done');
   });
 
+  it('holds a future-postAt request even with NO token in the vault (schedule gate precedes the token error)', async () => {
+    // The whole point of ordering the postAt check first: a scheduled post must
+    // not get terminal-errored ("no token in vault") before its time — the
+    // token only has to exist when it actually becomes due.
+    const calls = routedFetch([META_PROBE_LIVE, LI_LANE_LIVE]);
+    const postAt = new Date(Date.now() + 3600_000).toISOString();
+    const ctx = mockCtx({
+      vault: [], // deliberately empty — no bsky token
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: [],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          status: 'pending',
+          attempts: 0,
+          postAt,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('pending'); // held, NOT errored
+    expect(r.heldReason).toBe(`scheduled for ${postAt}`);
+    expect(r.error).toBeUndefined();
+    expect(calls.some((c) => c.url.includes('createRecord'))).toBe(false);
+  });
+
+  it('releases a held request on a later tick and clears heldReason (held → due transition)', async () => {
+    vi.useFakeTimers();
+    try {
+      const base = new Date('2026-07-09T00:00:00.000Z').getTime();
+      vi.setSystemTime(base);
+      const postAt = new Date(base + 6 * 3600_000).toISOString(); // +6h
+      routedFetch([
+        META_PROBE_LIVE,
+        LI_LANE_LIVE,
+        [
+          'com.atproto.server.refreshSession',
+          () =>
+            json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+        ],
+        [
+          'com.atproto.repo.createRecord',
+          () => json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kREL', cid: 'x' }),
+        ],
+      ]);
+      const ctx = mockCtx({
+        vault: [
+          {
+            _id: 'token-bsky',
+            kind: 'token',
+            platform: 'bsky',
+            token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+            igUserId: 'did:plc:abc',
+            username: 'vibes.diy',
+            refreshJwt: 'R1',
+            accessJwt: 'A1',
+            refreshedAt: new Date(base - 86400000).toISOString(), // aged, so the refresh path runs when due
+          },
+        ],
+        requests: [
+          {
+            _id: 'r-bsky',
+            kind: 'publish-request',
+            platform: 'bsky',
+            slug: 's',
+            images: [],
+            caption: 'hook https://x.example/blog/s?src=bsky',
+            title: 'T',
+            status: 'pending',
+            attempts: 0,
+            postAt,
+          },
+        ],
+      });
+      // Tick 1 — before postAt: held, not published.
+      await scheduled({}, ctx);
+      let r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+      expect(r.status).toBe('pending');
+      expect(r.heldReason).toBe(`scheduled for ${postAt}`);
+      // Advance past postAt and tick again — now due: publishes and clears the hold.
+      vi.setSystemTime(base + 7 * 3600_000);
+      await scheduled({}, ctx);
+      r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+      expect(r.status).toBe('done');
+      expect(r.heldReason).toBeNull();
+      expect(r.permalink).toBe('https://bsky.app/profile/vibes.diy/post/3kREL');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('bsky 401 on createSession (revoked app password) flags re-auth and holds the request', async () => {
     routedFetch([
       META_PROBE_LIVE,

--- a/examples/meta-hub/backend.test.js
+++ b/examples/meta-hub/backend.test.js
@@ -695,6 +695,146 @@ describe('scheduled — shared-path invariants (ig/threads/fbpage parity)', () =
     expect(ctx.dbs.vault.find((d) => d._id === 'token-bsky').refreshJwt).toBe('R9');
   });
 
+  it('holds a request whose postAt is in the future — no publish, heldReason names the time', async () => {
+    const calls = routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      // must NOT be reached
+      [
+        'com.atproto.repo.createRecord',
+        () => json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kNOPE', cid: 'x' }),
+      ],
+    ]);
+    const postAt = new Date(Date.now() + 3600_000).toISOString();
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(0),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: [],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          status: 'pending',
+          attempts: 0,
+          postAt,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('pending');
+    expect(r.heldReason).toBe(`scheduled for ${postAt}`);
+    expect(r.attempts).toBe(0); // never advanced
+    expect(calls.some((c) => c.url.includes('createRecord'))).toBe(false);
+  });
+
+  it('publishes a request once its postAt has passed', async () => {
+    routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      [
+        'com.atproto.repo.createRecord',
+        () => json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kYES', cid: 'x' }),
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: [],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+          postAt: new Date(Date.now() - 60_000).toISOString(),
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('done');
+    expect(r.permalink).toBe('https://bsky.app/profile/vibes.diy/post/3kYES');
+  });
+
+  it('treats an unparseable postAt as due now (a typo cannot wedge a post forever)', async () => {
+    routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      [
+        'com.atproto.repo.createRecord',
+        () => json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kTYPO', cid: 'x' }),
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: [],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          status: 'pending',
+          attempts: 0,
+          postAt: 'not-a-real-date',
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    expect(ctx.dbs.requests.find((d) => d._id === 'r-bsky').status).toBe('done');
+  });
+
   it('bsky 401 on createSession (revoked app password) flags re-auth and holds the request', async () => {
     routedFetch([
       META_PROBE_LIVE,


### PR DESCRIPTION
## What

Adds optional scheduling to the meta-hub social publisher. A `publish-request` doc may now carry a `postAt` ISO timestamp; the `scheduled` triage loop holds any request whose `postAt` is in the future (`heldReason: scheduled for <postAt>`) and releases it on the first tick at or after that time.

Before this, the only throttle was the 3-requests-per-tick batch cap, so re-queuing a backlog drained ~3/minute and flooded the target feed. `postAt` lets a backlog be spaced out (e.g. 6h apart). Omitting `postAt` preserves the existing post-ASAP behavior.

## Design notes

- The `postAt` check sits at the very top of the per-request loop, **before** the token-existence and egress/re-auth gates. That's deliberate: a scheduled post shouldn't terminal-error on a transient missing token before its time comes — it just holds until due.
- An unparseable `postAt` (`new Date(x)` → `NaN`) is treated as "due now" rather than held forever, so a typo can't silently wedge a post.
- `heldReason` is written only on change (steady-state hold costs no writes) and is cleared when the request becomes actionable, via the existing `actionable.push` path.

## Tests

Three new cases in `backend.test.js` drive the real `scheduled` handler through the in-memory ctx: future `postAt` holds without publishing (no `createRecord` call, `attempts` stays 0), past `postAt` publishes normally, and an invalid `postAt` is treated as due-now. Full file: **37 passing**.

## Deployment status

Already deployed live to `jchris/meta-hub` (release seq 15) and verified end-to-end: the six backlogged Bluesky posts were re-queued with `postAt` staggered 6h apart and the running backend holds all six with `heldReason: scheduled for <postAt>` — none posted early. This PR carries that same source change into the canonical example so a future redeploy from `examples/meta-hub` doesn't regress it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iXPxoPX7qvhHnvfbi7gP4

---
_Generated by [Claude Code](https://claude.ai/code/session_015iXPxoPX7qvhHnvfbi7gP4)_