### PR TITLE
meta-hub: attach a website-card thumbnail to Bluesky posts

### DIFF
--- a/examples/meta-hub/RUNBOOK.md
+++ b/examples/meta-hub/RUNBOOK.md
@@ -106,11 +106,25 @@ bullets). Five platforms publish:
   an organization Page instead of the member needs `w_organization_social`
   via the Community Management API (app review) — deliberately out of scope.
 
-- **`platform: "bsky"`** — text + link-card post (no images yet): caption
-  ≤300 chars with the post URL in it (the backend adds the byte-offset link
-  facet — Bluesky does NOT auto-detect links), plus a website-card embed
-  built from `link`/first URL, `title` (falls back to slug), optional
-  `description`. Nothing is scraped, and no thumb until an `uploadBlob` v2.
+- **`platform: "bsky"`** — text + link-card post: caption ≤300 chars with the
+  post URL in it (the backend adds the byte-offset link facet — Bluesky does
+  NOT auto-detect links), plus a website-card embed built from `link`/first
+  URL, `title` (falls back to slug), optional `description`. Nothing is
+  scraped, so Bluesky renders the card **imageless unless you supply a
+  thumbnail**. Supply it by embedding the image bytes in the request as
+  **`thumbBase64`** (base64 of the JPEG/PNG, ≤1,000,000 decoded bytes) plus
+  optional `thumbMime` (default `image/jpeg`); the backend decodes it and
+  uploads it as a blob (`com.atproto.repo.uploadBlob`), attaching it as the
+  card thumb. **Why bytes and not a URL:** the backend **cannot fetch our card
+  images** — `*.vibes.diy` (incl. `good.vibes.diy`) is on the egress floor
+  denylist (#3048, SSRF prevention, beats every policy), so whoever queues the
+  request (which _can_ read good.vibes.diy) inlines the bytes. A raw
+  `images[0]` URL is accepted as a fallback but only works for non-floor,
+  CORS-open hosts. Thumbnailing is **best-effort**: if decode/fetch/upload
+  fails the post still goes out with the imageless text+link card (a
+  `bsky-thumb-skipped` oplog entry records why), never blocked. To generate
+  `thumbBase64` from a card at build time:
+  `base64 -w0 card.jpg` (or `Buffer.from(await (await fetch(url)).arrayBuffer()).toString('base64')`).
   Synchronous, done in one tick; permalink constructed from the returned
   `at://` URI. **No egress change was needed**: the AT Protocol XRPC API is
   fully CORS-open (Bluesky's own client is a browser SPA), so it rides the

--- a/examples/meta-hub/RUNBOOK.md
+++ b/examples/meta-hub/RUNBOOK.md
@@ -112,7 +112,7 @@ bullets). Five platforms publish:
   URL, `title` (falls back to slug), optional `description`. Nothing is
   scraped, so Bluesky renders the card **imageless unless you supply a
   thumbnail**. Supply it by embedding the image bytes in the request as
-  **`thumbBase64`** (base64 of the JPEG/PNG, ≤1,000,000 decoded bytes) plus
+  **`thumbBase64`** (base64 of the JPEG/PNG, ≤1,000,000 decoded bytes (Bluesky's blob cap)) plus
   optional `thumbMime` (default `image/jpeg`); the backend decodes it and
   uploads it as a blob (`com.atproto.repo.uploadBlob`), attaching it as the
   card thumb. **Why bytes and not a URL:** the backend **cannot fetch our card

--- a/examples/meta-hub/RUNBOOK.md
+++ b/examples/meta-hub/RUNBOOK.md
@@ -124,7 +124,8 @@ bullets). Five platforms publish:
   fails the post still goes out with the imageless text+link card (a
   `bsky-thumb-skipped` oplog entry records why), never blocked. To generate
   `thumbBase64` from a card at build time:
-  `base64 -w0 card.jpg` (or `Buffer.from(await (await fetch(url)).arrayBuffer()).toString('base64')`).
+  `base64 -w0 card.jpg` (`-w0` is GNU/Linux; on macOS/BSD drop it) or
+  `Buffer.from(await (await fetch(url)).arrayBuffer()).toString('base64')`.
   Synchronous, done in one tick; permalink constructed from the returned
   `at://` URI. **No egress change was needed**: the AT Protocol XRPC API is
   fully CORS-open (Bluesky's own client is a browser SPA), so it rides the

--- a/examples/meta-hub/backend.js
+++ b/examples/meta-hub/backend.js
@@ -280,7 +280,11 @@ async function bskyThumbBytes(req, images) {
       error: `thumb fetch not an image (${detail}, content-type: ${contentType || 'none'})`,
     };
   }
-  return { bytes: new Uint8Array(await img.arrayBuffer()), mimeType: contentType };
+  try {
+    return { bytes: new Uint8Array(await img.arrayBuffer()), mimeType: contentType };
+  } catch (e) {
+    return { error: `thumb body read: ${String((e && e.message) || e)}` };
+  }
 }
 
 // The paste is `identifier:app-password`. App passwords are
@@ -675,17 +679,32 @@ async function advanceRequest(ctx, req, t) {
       if (body.error) return save({ status: 'error', error: body.error });
       const s = await bskySession(ctx, t);
       if (!s.accessJwt) return fail(s.r, 'bsky session');
-      // Best-effort card thumbnail: a failed decode/fetch/upload must not block
-      // the post, so on error we log and fall back to the imageless text+link
-      // card. Bytes come from thumbBase64 (or an images[0] URL fallback).
+      // Best-effort card thumbnail: NOTHING here may block the post. The whole
+      // block is wrapped so an unexpected throw (a body-read rejection, an
+      // oplog write that fails) degrades to the imageless text+link card
+      // instead of bubbling to the outer catch and terminal-erroring the post.
+      // Bytes come from thumbBase64 (or an images[0] URL fallback).
       if (req.thumbBase64 || images[0]) {
-        const src = await bskyThumbBytes(req, images);
-        if (src.bytes) {
-          const up = await bskyUploadBlobBytes(src.bytes, src.mimeType, s.accessJwt);
-          if (up.blob) body.record.embed.external.thumb = up.blob;
-          else await log(ctx, { op: 'bsky-thumb-skipped', slug: req.slug, error: up.error });
-        } else {
-          await log(ctx, { op: 'bsky-thumb-skipped', slug: req.slug, error: src.error });
+        try {
+          const src = await bskyThumbBytes(req, images);
+          if (src.bytes) {
+            const up = await bskyUploadBlobBytes(src.bytes, src.mimeType, s.accessJwt);
+            if (up.blob) body.record.embed.external.thumb = up.blob;
+            else await log(ctx, { op: 'bsky-thumb-skipped', slug: req.slug, error: up.error });
+          } else {
+            await log(ctx, { op: 'bsky-thumb-skipped', slug: req.slug, error: src.error });
+          }
+        } catch (e) {
+          // Even the skip-logging is best-effort — swallow so the post proceeds.
+          try {
+            await log(ctx, {
+              op: 'bsky-thumb-skipped',
+              slug: req.slug,
+              error: `thumb path threw: ${String((e && e.message) || e)}`,
+            });
+          } catch {
+            /* give up on logging; the post must still go out */
+          }
         }
       }
       const r = await bskyFetch('com.atproto.repo.createRecord', {

--- a/examples/meta-hub/backend.js
+++ b/examples/meta-hub/backend.js
@@ -207,6 +207,82 @@ async function bskyFetch(path, { method = 'GET', body, token } = {}) {
   return { ok: true, data };
 }
 
+// Bluesky's blob limit is 1,000,000 bytes; the branded card JPEGs are ~80KB.
+const BSKY_BLOB_MAX = 1_000_000;
+
+// POST raw image bytes to uploadBlob → { blob } or { error }. Best-effort: the
+// caller posts without a thumb on any error rather than failing the post.
+async function bskyUploadBlobBytes(bytes, mimeType, accessJwt) {
+  if (!bytes || bytes.length === 0) return { error: 'empty thumb bytes' };
+  if (bytes.length > BSKY_BLOB_MAX)
+    return { error: `thumb too big: ${bytes.length} bytes (max ${BSKY_BLOB_MAX})` };
+  let res;
+  try {
+    res = await fetch(`${HOSTS.bsky}/xrpc/com.atproto.repo.uploadBlob`, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${accessJwt}`,
+        'content-type': mimeType || 'application/octet-stream',
+      },
+      body: bytes,
+    });
+  } catch (e) {
+    return { error: `uploadBlob transport: ${String((e && e.message) || e)}` };
+  }
+  let data = {};
+  try {
+    data = await res.json();
+  } catch {
+    data = {};
+  }
+  if (data && data.vibesEgressDenied)
+    return { error: `uploadBlob egress denied: ${data.gate || true}` };
+  if (!res.ok || !data.blob)
+    return { error: data.message || data.error || `uploadBlob HTTP ${res.status}` };
+  return { blob: data.blob };
+}
+
+// Get the card-thumbnail bytes for a request, or { error }. Bluesky never
+// scrapes the URL, so an external embed is imageless without an uploaded blob.
+// PRIMARY source is `thumbBase64` embedded in the doc — the backend CANNOT
+// fetch our card images: `*.vibes.diy` is on the egress FLOOR denylist (#3048,
+// SSRF prevention, beats every policy), so the queuer (which can read
+// good.vibes.diy) inlines the bytes. FALLBACK is a URL in `images[0]`, which
+// only works for non-floor, CORS-open hosts.
+async function bskyThumbBytes(req, images) {
+  if (req.thumbBase64) {
+    try {
+      const bytes = Uint8Array.from(atob(req.thumbBase64), (c) => c.charCodeAt(0));
+      return { bytes, mimeType: req.thumbMime || 'image/jpeg' };
+    } catch (e) {
+      return { error: `thumbBase64 decode: ${String((e && e.message) || e)}` };
+    }
+  }
+  if (!images[0]) return { error: 'no thumb source (thumbBase64 or images[0])' };
+  let img;
+  try {
+    img = await fetch(images[0]);
+  } catch (e) {
+    return { error: `thumb fetch transport: ${String((e && e.message) || e)}` };
+  }
+  const contentType = img.headers.get('content-type') || '';
+  // A denied egress fetch comes back as a JSON marker, not image bytes (a
+  // platform host hits the floor); an error page is also non-image.
+  if (!img.ok || !contentType.startsWith('image/')) {
+    let detail = `HTTP ${img.status}`;
+    try {
+      const j = await img.json();
+      if (j && j.vibesEgressDenied) detail = `egress denied: ${j.gate || true}`;
+    } catch {
+      /* not JSON — keep the HTTP-status detail */
+    }
+    return {
+      error: `thumb fetch not an image (${detail}, content-type: ${contentType || 'none'})`,
+    };
+  }
+  return { bytes: new Uint8Array(await img.arrayBuffer()), mimeType: contentType };
+}
+
 // The paste is `identifier:app-password`. App passwords are
 // xxxx-xxxx-xxxx-xxxx (never a colon), while the identifier may be a handle,
 // an email, or a DID (`did:plc:...`) — so split on the LAST colon, which is
@@ -235,10 +311,11 @@ export function bskyLinkFacets(text) {
 }
 
 // Build the post record, or return { error } for a bad request doc. Like
-// LinkedIn, nothing is scraped: the website card (external embed) shows
-// exactly what the request carries. No thumb in v1 — that needs uploadBlob,
-// the same image dance deferred everywhere else.
-export function bskyPostRecord(req, createdAt) {
+// LinkedIn, nothing is scraped: the website card (external embed) shows exactly
+// what the request carries. Pass an uploaded `thumb` blob (from bskyUploadBlob)
+// to give the card an image — Bluesky renders the external embed imageless
+// without one.
+export function bskyPostRecord(req, createdAt, thumb) {
   const text = req.caption || '';
   const chars = [...text].length;
   if (chars > BSKY_MAX_TEXT) return { error: `bsky text is ${chars} chars (max ${BSKY_MAX_TEXT})` };
@@ -256,6 +333,7 @@ export function bskyPostRecord(req, createdAt) {
           uri: link,
           title: req.title || req.slug || link,
           description: req.description || '',
+          ...(thumb ? { thumb } : {}),
         },
       },
     },
@@ -589,19 +667,27 @@ async function advanceRequest(ctx, req, t) {
   }
   try {
     // Bluesky: synchronous — refresh-or-mint a session JWT, then one createRecord.
-    // Text + link facet + website-card embed only for now (thumb needs
-    // uploadBlob — the image dance is v2, same as LinkedIn).
+    // Text + link facet + website-card embed; `images[0]`, if present, becomes
+    // the card's thumbnail (uploaded as a blob). Extra images are ignored (the
+    // external embed carries a single thumb).
     if (platform === 'bsky') {
-      if (images.length > 0) {
-        return save({
-          status: 'error',
-          error: 'bsky is text+link-card only for now — image embeds need uploadBlob (v2)',
-        });
-      }
       const body = bskyPostRecord(req, new Date().toISOString());
       if (body.error) return save({ status: 'error', error: body.error });
       const s = await bskySession(ctx, t);
       if (!s.accessJwt) return fail(s.r, 'bsky session');
+      // Best-effort card thumbnail: a failed decode/fetch/upload must not block
+      // the post, so on error we log and fall back to the imageless text+link
+      // card. Bytes come from thumbBase64 (or an images[0] URL fallback).
+      if (req.thumbBase64 || images[0]) {
+        const src = await bskyThumbBytes(req, images);
+        if (src.bytes) {
+          const up = await bskyUploadBlobBytes(src.bytes, src.mimeType, s.accessJwt);
+          if (up.blob) body.record.embed.external.thumb = up.blob;
+          else await log(ctx, { op: 'bsky-thumb-skipped', slug: req.slug, error: up.error });
+        } else {
+          await log(ctx, { op: 'bsky-thumb-skipped', slug: req.slug, error: src.error });
+        }
+      }
       const r = await bskyFetch('com.atproto.repo.createRecord', {
         method: 'POST',
         body: { repo: s.t.igUserId, collection: 'app.bsky.feed.post', record: body.record },

--- a/examples/meta-hub/backend.test.js
+++ b/examples/meta-hub/backend.test.js
@@ -577,6 +577,196 @@ describe('scheduled — shared-path invariants (ig/threads/fbpage parity)', () =
     expect(record.method).toBe('POST');
   });
 
+  it('bsky uploads images[0] as a blob and attaches it as the website-card thumb', async () => {
+    let sentRecord = null;
+    const blob = { $type: 'blob', ref: { $link: 'bafkreiblob' }, mimeType: 'image/jpeg', size: 4 };
+    const calls = routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      // the image fetch — real bytes, image content-type
+      [
+        'good.vibes.diy',
+        () =>
+          new Response(new Uint8Array([1, 2, 3, 4]), {
+            status: 200,
+            headers: { 'content-type': 'image/jpeg' },
+          }),
+      ],
+      ['com.atproto.repo.uploadBlob', () => json({ blob })],
+      [
+        'com.atproto.repo.createRecord',
+        (url, init) => {
+          sentRecord = JSON.parse(init.body);
+          return json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kIMG', cid: 'x' });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: ['https://good.vibes.diy/images/blog/s/card.jpg'],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('done');
+    // thumb blob made it into the posted record's external embed
+    expect(sentRecord.record.embed.external.thumb).toEqual(blob);
+    // uploadBlob POSTed with the image content-type, before createRecord
+    const iUpload = calls.findIndex((c) => c.url.includes('uploadBlob'));
+    const iRecord = calls.findIndex((c) => c.url.includes('createRecord'));
+    expect(iUpload).toBeGreaterThanOrEqual(0);
+    expect(iUpload).toBeLessThan(iRecord);
+    expect(calls[iUpload].method).toBe('POST');
+  });
+
+  it('bsky uploads thumbBase64 bytes as the card thumb — no image fetch (platform images are floor-denied)', async () => {
+    let sentRecord = null;
+    let uploadInit = null;
+    const blob = { $type: 'blob', ref: { $link: 'bafkb64' }, mimeType: 'image/png', size: 4 };
+    const calls = routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      [
+        'com.atproto.repo.uploadBlob',
+        (url, init) => {
+          uploadInit = init;
+          return json({ blob });
+        },
+      ],
+      [
+        'com.atproto.repo.createRecord',
+        (url, init) => {
+          sentRecord = JSON.parse(init.body);
+          return json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kB64', cid: 'x' });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: [],
+          thumbBase64: Buffer.from([1, 2, 3, 4]).toString('base64'),
+          thumbMime: 'image/png',
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('done');
+    expect(sentRecord.record.embed.external.thumb).toEqual(blob);
+    // uploaded with the declared mime; NO image fetch to a platform host
+    expect(uploadInit.headers['content-type']).toBe('image/png');
+    expect(calls.some((c) => c.url.includes('good.vibes.diy'))).toBe(false);
+  });
+
+  it('bsky posts WITHOUT a thumb when the image fetch is egress-denied (best-effort), logging bsky-thumb-skipped', async () => {
+    let sentRecord = null;
+    routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      [
+        'good.vibes.diy',
+        () => json({ vibesEgressDenied: true, gate: 'cors', host: 'good.vibes.diy' }, 403),
+      ],
+      [
+        'com.atproto.repo.createRecord',
+        (url, init) => {
+          sentRecord = JSON.parse(init.body);
+          return json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kNOIMG', cid: 'x' });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: ['https://good.vibes.diy/images/blog/s/card.jpg'],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('done'); // post still went out
+    expect(sentRecord.record.embed.external.thumb).toBeUndefined();
+    expect(ctx.dbs.oplog.some((d) => d.op === 'bsky-thumb-skipped')).toBe(true);
+  });
+
   it('a batch of bsky requests in one tick shares ONE session mint — no stale refresh JWT replay', async () => {
     let refreshes = 0;
     const calls = routedFetch([

--- a/examples/meta-hub/backend.test.js
+++ b/examples/meta-hub/backend.test.js
@@ -767,6 +767,129 @@ describe('scheduled — shared-path invariants (ig/threads/fbpage parity)', () =
     expect(ctx.dbs.oplog.some((d) => d.op === 'bsky-thumb-skipped')).toBe(true);
   });
 
+  it('bsky posts WITHOUT a thumb when reading the image body throws (best-effort, no bubble)', async () => {
+    let sentRecord = null;
+    routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      // fetch resolves with image headers, but the BODY read rejects mid-stream
+      [
+        'good.vibes.diy',
+        () => ({
+          ok: true,
+          status: 200,
+          headers: { get: (k) => (k === 'content-type' ? 'image/jpeg' : null) },
+          arrayBuffer: () => Promise.reject(new Error('stream broke')),
+        }),
+      ],
+      [
+        'com.atproto.repo.createRecord',
+        (url, init) => {
+          sentRecord = JSON.parse(init.body);
+          return json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kTHROW', cid: 'x' });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: ['https://good.vibes.diy/images/blog/s/card.jpg'],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('done'); // NOT errored
+    expect(sentRecord.record.embed.external.thumb).toBeUndefined();
+    expect(ctx.dbs.oplog.some((d) => d.op === 'bsky-thumb-skipped')).toBe(true);
+  });
+
+  it('bsky posts even if the skip-logging itself throws (thumb path is fully swallowed)', async () => {
+    let sentRecord = null;
+    routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      [
+        'com.atproto.server.refreshSession',
+        () => json({ accessJwt: 'A2', refreshJwt: 'R2', did: 'did:plc:abc', handle: 'vibes.diy' }),
+      ],
+      [
+        'good.vibes.diy',
+        () => json({ vibesEgressDenied: true, gate: 'floor', host: 'good.vibes.diy' }, 403),
+      ],
+      [
+        'com.atproto.repo.createRecord',
+        (url, init) => {
+          sentRecord = JSON.parse(init.body);
+          return json({ uri: 'at://did:plc:abc/app.bsky.feed.post/3kLOG', cid: 'x' });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [
+        {
+          _id: 'token-bsky',
+          kind: 'token',
+          platform: 'bsky',
+          token: 'vibes.diy:abcd-efgh-ijkl-mnop',
+          igUserId: 'did:plc:abc',
+          username: 'vibes.diy',
+          refreshJwt: 'R1',
+          accessJwt: 'A1',
+          refreshedAt: daysAgo(1),
+        },
+      ],
+      requests: [
+        {
+          _id: 'r-bsky',
+          kind: 'publish-request',
+          platform: 'bsky',
+          slug: 's',
+          images: ['https://good.vibes.diy/images/blog/s/card.jpg'],
+          caption: 'hook https://x.example/blog/s?src=bsky',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    // Make ONLY the thumb-skip oplog write blow up, to exercise the swallow.
+    const origPut = ctx.db.put;
+    ctx.db.put = async (doc, opts) => {
+      if (opts.db === 'oplog' && doc.op === 'bsky-thumb-skipped') throw new Error('oplog down');
+      return origPut(doc, opts);
+    };
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-bsky');
+    expect(r.status).toBe('done'); // logging failure did not sink the post
+    expect(sentRecord.record.embed.external.thumb).toBeUndefined();
+  });
+
   it('a batch of bsky requests in one tick shares ONE session mint — no stale refresh JWT replay', async () => {
     let refreshes = 0;
     const calls = routedFetch([


### PR DESCRIPTION
## What

Bluesky link-card posts were showing no image. Root cause: Bluesky **never scrapes the URL** for an og:image (unlike Discord/Facebook) — an `app.bsky.embed.external` renders imageless unless you upload a thumbnail *blob* and attach it. This adds that: the backend uploads a thumb via `com.atproto.repo.uploadBlob` and sets it as the card's `external.thumb`.

## Why bytes in the doc, not a URL

The obvious approach — put the image URL in the request and have the backend fetch it — **cannot work here**. `*.vibes.diy` (including `good.vibes.diy`, where our card images live) is on the egress **floor denylist** ([`egress-floor.ts`](https://github.com/VibesDIY/vibes.diy/blob/main/vibes.diy/api/svc/intern/egress-floor.ts), #3048): a vibe backend may never fetch platform hosts (SSRF prevention), and that beats every policy including owner bless. I verified this empirically — the first attempt logged `thumb fetch not an image (egress denied: floor)`.

So the **queuer** (which *can* read good.vibes.diy) inlines the bytes as `thumbBase64` (+ optional `thumbMime`, default `image/jpeg`); the backend decodes and uploads them. An 82 KB card is ~110 KB base64 — well under the ~1 MB Cloudflare WebSocket limit that only bites on multi-MB raw images. A raw `images[0]` URL is still accepted as a fallback for non-floor, CORS-open hosts.

(`_files` — Fireproof's doc-attached binary feature — was considered and rejected: the CLI `db put` can't attach files, and the `_files` read shim resolves bytes via a `*.vibes.diy` URL, hitting the same floor.)

## Best-effort by design

A failed decode/fetch/upload must never block the post. On any thumb error the backend logs a `bsky-thumb-skipped` oplog entry and posts the plain text+link card — worst case is today's behavior, best case is the image shows.

## Verified live

Deployed to `jchris/meta-hub` (release seq 17). A real post now carries a `feed_thumbnail` blob, confirmed via the public `app.bsky.feed.getPosts` API (`embed.external.thumb` → a `cdn.bsky.app/img/feed_thumbnail/…` URL). The 5 remaining scheduled backlog posts were re-queued with `thumbBase64` and will post with card images at their staggered times.

## Tests

42 pass — new cases: `thumbBase64` decode→upload→attach (asserts no platform-host fetch happens), `images[0]` URL fallback, and graceful `bsky-thumb-skipped` on an egress-denied image. RUNBOOK documents the `thumbBase64` field and the floor-denylist rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015iXPxoPX7qvhHnvfbi7gP4

---
_Generated by [Claude Code](https://claude.ai/code/session_015iXPxoPX7qvhHnvfbi7gP4)_