### PR TITLE
ietf-picker: Side Meetings lane (sidemeetings.ietf.org via db snapshot)

### DIFF
--- a/examples/ietf-picker/App.jsx
+++ b/examples/ietf-picker/App.jsx
@@ -6,9 +6,11 @@ import {
   MEETING_126,
   AGENDA_URL,
   MEETING_URL,
+  SIDE_MEETINGS_API,
   toMeetingDate,
   meetingDayFor,
   flattenAgenda,
+  flattenSideMeetings,
   sessionsOnNow,
   upNextSessions,
   fmtTime,
@@ -16,6 +18,7 @@ import {
 } from './festival-utils.js';
 import { c } from './styles.js';
 import ScheduleView from './ScheduleView.jsx';
+import SideMeetingsView from './SideMeetingsView.jsx';
 import GroupsView from './GroupsView.jsx';
 import NowView from './NowView.jsx';
 import BrowseView from './BrowseView.jsx';
@@ -113,6 +116,8 @@ export default function IetfAgendaPicker() {
   const canWrite = ready && signedIn && Boolean(can?.create?.({ type: 'shift', userId })?.ok);
 
   const [events, setEvents] = useState([]);
+  const [sideMeetings, setSideMeetings] = useState([]);
+  const [sideError, setSideError] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
@@ -202,6 +207,7 @@ export default function IetfAgendaPicker() {
 
   useEffect(() => {
     fetchSchedule();
+    fetchSideMeetings();
   }, []);
 
   const getCached = () => {
@@ -250,6 +256,36 @@ export default function IetfAgendaPicker() {
   const ingest = (data) => {
     setEvents(flattenAgenda(data));
   };
+
+  // Side meetings come through the backend proxy (the board's /_data has no
+  // CORS), on the same cache-then-refresh pattern as the agenda. A failure only
+  // degrades the side lane — the agenda board must not care.
+  const fetchSideMeetings = async () => {
+    const cachedRaw = localStorage.getItem('ietf126-sidemtg-cache');
+    const cachedTs = +localStorage.getItem('ietf126-sidemtg-timestamp');
+    const cached = cachedRaw && cachedTs ? JSON.parse(cachedRaw) : null;
+    if (cached) {
+      setSideMeetings(flattenSideMeetings(cached));
+      if (Date.now() - cachedTs <= 600_000) return;
+    }
+    try {
+      const res = await fetch(SIDE_MEETINGS_API);
+      if (!res.ok) throw new Error(`side meetings ${res.status}`);
+      const data = await res.json();
+      localStorage.setItem('ietf126-sidemtg-cache', JSON.stringify(data));
+      localStorage.setItem('ietf126-sidemtg-timestamp', Date.now().toString());
+      setSideMeetings(flattenSideMeetings(data));
+      setSideError(null);
+    } catch (e) {
+      console.error(e);
+      setSideError(cached ? 'Using cached side meetings' : 'Failed to load the side meetings');
+    }
+  };
+
+  // Side meetings are first-class events downstream: favorites/notes key on the
+  // (side-prefixed) eventId, so My Faves, Now, the friends schedule, super-mode
+  // counts, and both ics lanes see one merged board.
+  const allEvents = useMemo(() => [...events, ...sideMeetings], [events, sideMeetings]);
 
   const getDateForDay = (day) => {
     // Prefer the meeting day's canonical calendar date. Since a day groups
@@ -356,11 +392,11 @@ export default function IetfAgendaPicker() {
         pickedBy.get(f.eventId).push(uid);
       }
     }
-    return events
+    return allEvents
       .filter((e) => pickedBy.has(e.eventId))
       .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
       .sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start));
-  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
+  }, [selectedFriend, allFavorites, allEvents, followedHandles, includeMyFaves, userId]);
 
   const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
   const friendShifts = useMemo(() => {
@@ -379,7 +415,7 @@ export default function IetfAgendaPicker() {
   // it shouldn't show up in the picker or as an empty section.
   const displayDays = useMemo(() => {
     const present = new Set(
-      [...events.map((e) => e.day), ...shifts.map((s) => s.day)].filter(Boolean)
+      [...allEvents.map((e) => e.day), ...shifts.map((s) => s.day)].filter(Boolean)
     );
     const o = MEETING_126.dayOrder;
     return [...present].sort((a, b) => {
@@ -390,7 +426,7 @@ export default function IetfAgendaPicker() {
       if (bi === -1) return -1;
       return ai - bi;
     });
-  }, [events, shifts]);
+  }, [allEvents, shifts]);
 
   const {
     doc: shiftForm,
@@ -551,11 +587,14 @@ export default function IetfAgendaPicker() {
     return [...map.values()].sort((a, b) => a.acronym.localeCompare(b.acronym));
   }, [events]);
 
+  // Right Now / Up Next work off the merged board: a side meeting happening now
+  // is exactly what that tab is for.
   const nowSessions = useMemo(
-    () => sessionsOnNow(events, nowTick).sort((a, b) => a.venueTitle.localeCompare(b.venueTitle)),
-    [events, nowTick]
+    () =>
+      sessionsOnNow(allEvents, nowTick).sort((a, b) => a.venueTitle.localeCompare(b.venueTitle)),
+    [allEvents, nowTick]
   );
-  const nextSessions = useMemo(() => upNextSessions(events, nowTick), [events, nowTick]);
+  const nextSessions = useMemo(() => upNextSessions(allEvents, nowTick), [allEvents, nowTick]);
 
   const filteredEvents = useMemo(
     () =>
@@ -572,10 +611,10 @@ export default function IetfAgendaPicker() {
 
   const favoriteEvents = useMemo(
     () =>
-      events
+      allEvents
         .filter((e) => myFavIds.has(e.eventId))
         .sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start)),
-    [events, myFavIds]
+    [allEvents, myFavIds]
   );
 
   // Super-mode peer picker: when a picker is selected, the favorites list must
@@ -585,10 +624,10 @@ export default function IetfAgendaPicker() {
     const ids = new Set(
       allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
     );
-    return events
+    return allEvents
       .filter((e) => ids.has(e.eventId))
       .sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start));
-  }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
+  }, [viewingUser, userId, favoriteEvents, allFavorites, allEvents]);
 
   const makeSchedule = (day) => {
     const ev = favoriteEvents.filter((e) => meetingDayFor(e.start) === day);
@@ -690,9 +729,9 @@ export default function IetfAgendaPicker() {
 
         <div className={`${c.navBg} ${c.border} p-2`}>
           <div className="flex flex-wrap gap-[3px]">
-            {['now', 'browse', 'groups', 'favorites', 'friends', 'shifts', 'schedule']
+            {['now', 'browse', 'groups', 'side', 'favorites', 'friends', 'shifts', 'schedule']
               .filter((v) => {
-                if (v === 'now' || v === 'browse' || v === 'groups') return true;
+                if (v === 'now' || v === 'browse' || v === 'groups' || v === 'side') return true;
                 if (v === 'favorites') return superMode && canWrite; // super-mode peer picker
                 if (v === 'schedule') return canFavorite; // anon can view their own favorites schedule
                 return canWrite; // friends + extras need a real sign-in
@@ -706,6 +745,7 @@ export default function IetfAgendaPicker() {
                   {viewName === 'now' && `Now`}
                   {viewName === 'browse' && `All Sessions`}
                   {viewName === 'groups' && `Groups`}
+                  {viewName === 'side' && `Side Meetings`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
                   {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
@@ -779,6 +819,25 @@ export default function IetfAgendaPicker() {
                   c={c}
                   database={database}
                   userId={userId}
+                />
+              )}
+
+              {view === 'side' && (
+                <SideMeetingsView
+                  sideMeetings={sideMeetings}
+                  sideError={sideError}
+                  retrySideMeetings={fetchSideMeetings}
+                  displayDays={displayDays}
+                  getDateForDay={getDateForDay}
+                  myFavIds={myFavIds}
+                  canWrite={canWrite}
+                  canFavorite={canFavorite}
+                  toggleFavorite={toggleFavorite}
+                  notes={notes}
+                  saveNote={saveNote}
+                  superMode={superMode}
+                  favCounts={favCounts}
+                  c={c}
                 />
               )}
 
@@ -894,7 +953,7 @@ export default function IetfAgendaPicker() {
                     canWrite={canWrite}
                     onToggleFavorite={canFavorite ? toggleFavorite : null}
                     myFavIds={myFavIds}
-                    allEvents={events}
+                    allEvents={allEvents}
                     showGaps={true}
                   />
                 </div>

--- a/examples/ietf-picker/NoteField.jsx
+++ b/examples/ietf-picker/NoteField.jsx
@@ -9,7 +9,7 @@ export default function NoteField({
   saved,
   onSave,
   className,
-  placeholder = 'Add note...',
+  placeholder = 'Add private note...',
   collapsedStyle,
   collapsedRight,
 }) {

--- a/examples/ietf-picker/RUNBOOK.md
+++ b/examples/ietf-picker/RUNBOOK.md
@@ -118,15 +118,24 @@ through Friday 2026-07-24 with the 4 AM night cutoff.
 
 The Side Meetings lane comes from `https://sidemeetings.ietf.org/_data`
 (`{ meeting, rooms, bookings }`) — community-organized meetings that are NOT in
-the datatracker agenda. Two things differ from the agenda feed:
+the datatracker agenda. Three things differ from the agenda feed:
 
 - **No CORS headers** on `/_data`, so the app cannot fetch it from the iframe.
-  `backend.js` proxies it at `GET /_api/side-meetings` (module cache ~10 min,
-  stale-served on upstream failure); the client caches the proxy response in
-  `localStorage` for 10 minutes like the agenda.
+  `backend.js` serves it at `GET /_api/side-meetings`; the client caches the
+  response in `localStorage` for 10 minutes like the agenda.
+- **The board 403s the platform's worker egress** (IP/ASN-level, browser headers
+  don't help — verified 2026-07-09, same class as DEF CON's `info.defcon.org`).
+  So the endpoint actually serves an owner-written **db snapshot**: the vibes.diy
+  repo's `scripts/vibe-ops/refresh-ietf-side-meetings.mjs` (run where the
+  upstream IS reachable — an agent container, a laptop, a Routine) writes the raw
+  `/_data` JSON into the `ietf126` db as owner-gated `side-snapshot` chunk docs,
+  and the backend's 1-minute scheduled tick assembles a COMPLETE chunk set into
+  module state. The direct upstream fetch is kept as the fast path in case the
+  block ever lifts. A refresh Routine keeps the snapshot current through the
+  meeting; disable it after IETF 126 ends (July 24).
 - **No meeting number in the URL** — the board always serves the _current_
-  meeting. At the IETF 127 swap, verify the board has flipped before shipping
-  (a 126 board on a 127 app would show last meeting's side meetings).
+  meeting. The refresher refuses to write a snapshot whose `meeting.meetingNumber`
+  isn't 126; at the IETF 127 swap, update that check alongside `MEETING_NUMBER`.
 
 `flattenSideMeetings` maps bookings into the same event shape as sessions with
 `eventId: "side-<booking id>"` (prefixed — booking ids and `session_id`s are both

--- a/examples/ietf-picker/RUNBOOK.md
+++ b/examples/ietf-picker/RUNBOOK.md
@@ -114,14 +114,35 @@ and computes `end = start + duration` ("H:MM:SS" — the feed has no end timesta
 All times displayed in `Europe/Vienna`; meeting days run Saturday 2026-07-18
 through Friday 2026-07-24 with the 4 AM night cutoff.
 
+## Side meetings data
+
+The Side Meetings lane comes from `https://sidemeetings.ietf.org/_data`
+(`{ meeting, rooms, bookings }`) — community-organized meetings that are NOT in
+the datatracker agenda. Two things differ from the agenda feed:
+
+- **No CORS headers** on `/_data`, so the app cannot fetch it from the iframe.
+  `backend.js` proxies it at `GET /_api/side-meetings` (module cache ~10 min,
+  stale-served on upstream failure); the client caches the proxy response in
+  `localStorage` for 10 minutes like the agenda.
+- **No meeting number in the URL** — the board always serves the _current_
+  meeting. At the IETF 127 swap, verify the board has flipped before shipping
+  (a 126 board on a 127 app would show last meeting's side meetings).
+
+`flattenSideMeetings` maps bookings into the same event shape as sessions with
+`eventId: "side-<booking id>"` (prefixed — booking ids and `session_id`s are both
+bare numbers), so hearts/notes/My Faves/friends/super-mode all work unchanged.
+The ics subscription lane splits a user's picks and joins `side-*` ids against
+the board (`sideMeetingItems` in `backend.js`); a booking that disappears from
+the board drops out of the join like a canceled session.
+
 ## Common edits
 
-| Task                      | Where                                                                                                                                                            |
-| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Point at the next meeting | `MEETING_NUMBER` + `MEETING_126.dates` in `festival-utils.js`; `MEETING_NUMBER` + `MEETING_DATES` + `ANCHOR_ITEMS` in `backend.js`; header subtitle in `App.jsx` |
-| Change area chip colors   | `AREA_COLORS` in `festival-utils.js`                                                                                                                             |
-| Add a new view/tab        | Add to the `["now", "browse", "groups", ...]` array in nav, add `{view === "newview" && ...}` section in the body                                                |
-| Change colors             | the `c` object in `styles.js`                                                                                                                                    |
+| Task                      | Where                                                                                                                                                                                                                                                 |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Point at the next meeting | `MEETING_NUMBER` + `MEETING_126.dates` in `festival-utils.js`; `MEETING_NUMBER` + `MEETING_DATES` + `ANCHOR_ITEMS` in `backend.js`; header subtitle in `App.jsx`; confirm sidemeetings.ietf.org has flipped to the new meeting (no number in its URL) |
+| Change area chip colors   | `AREA_COLORS` in `festival-utils.js`                                                                                                                                                                                                                  |
+| Add a new view/tab        | Add to the `["now", "browse", "groups", ...]` array in nav, add `{view === "newview" && ...}` section in the body                                                                                                                                     |
+| Change colors             | the `c` object in `styles.js`                                                                                                                                                                                                                         |
 
 ## Social migration (2026-07: friend docs → platform follow graph)
 

--- a/examples/ietf-picker/SideMeetingsView.jsx
+++ b/examples/ietf-picker/SideMeetingsView.jsx
@@ -1,0 +1,195 @@
+import React from 'react';
+import { fmtTime, SIDE_MEETINGS_URL, AREA_COLORS, DEFAULT_AREA_COLOR } from './festival-utils.js';
+import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
+import NoteField from './NoteField.jsx';
+
+// The side-meetings lane: community-organized meetings from sidemeetings.ietf.org,
+// day-grouped like All Sessions. Cards carry the organizer and the organizer-tagged
+// area chips (side meetings aren't area-official — the teal SIDE chip is the lane
+// marker, the little area chips are just the organizer's own tags).
+export default function SideMeetingsView({
+  sideMeetings,
+  sideError,
+  retrySideMeetings,
+  displayDays,
+  getDateForDay,
+  myFavIds,
+  canWrite,
+  canFavorite,
+  toggleFavorite,
+  notes,
+  saveNote,
+  superMode,
+  favCounts,
+  c,
+}) {
+  if (sideMeetings.length === 0) {
+    return (
+      <div className="text-center py-3">
+        <h3 className={`text-2xl font-black mb-0.5 ${c.bodyText}`}>
+          {sideError ? "Couldn't load the side meetings" : 'No side meetings posted yet'}
+        </h3>
+        {sideError && <p className={`text-lg ${c.bodyText} mb-1`}>{sideError}</p>}
+        {sideError && retrySideMeetings && (
+          <button onClick={retrySideMeetings} className={c.btnPink}>
+            Retry
+          </button>
+        )}
+        <p className={`mt-1 text-sm font-bold ${c.bodyText}`}>
+          Side meetings are listed on{' '}
+          <a
+            href={SIDE_MEETINGS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            sidemeetings.ietf.org
+          </a>
+          .
+        </p>
+      </div>
+    );
+  }
+
+  const byDay = {};
+  for (const m of sideMeetings) {
+    const day = m.day || '';
+    (byDay[day] || (byDay[day] = [])).push(m);
+  }
+  const daysToShow = displayDays.filter((day) => byDay[day]?.length > 0);
+
+  return (
+    <div>
+      <div className="mb-1.5 flex items-start justify-between flex-wrap gap-1">
+        <p className={`text-sm font-bold ${c.bodyText} m-0.5`}>
+          Community-organized meetings that aren't on the official agenda — anyone can{' '}
+          <a
+            href={SIDE_MEETINGS_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline"
+          >
+            book one
+          </a>
+          . Heart them and they join your faves and calendar feed.
+        </p>
+      </div>
+      {sideError && <div className={c.readOnlyBanner}>{sideError}</div>}
+
+      {daysToShow.map((day) => (
+        <div key={day} className={c.schedDay}>
+          <h3 className="text-xl font-black mb-1 text-white">
+            {day} — {getDateForDay(day)}
+          </h3>
+          <div className="grid gap-1">
+            {byDay[day].map((event) => {
+              const tag = lineupTag(event);
+              return (
+                <div
+                  key={event.eventId}
+                  className={`rounded-lg m-0.5 p-2 shadow-lg ${eventCardBg}`}
+                  style={eventCardStyle(event)}
+                >
+                  <div className="flex flex-col sm:flex-row justify-between items-start gap-1">
+                    <div className="flex-1">
+                      <div className="flex items-center gap-0.5 mb-0.5 flex-wrap">
+                        {superMode && favCounts[event.eventId] > 0 && (
+                          <span className={c.badge} title="People who picked this">
+                            ★ {favCounts[event.eventId]}
+                          </span>
+                        )}
+                        <h3 className={`text-xl font-black ${c.bodyText}`}>{event.title}</h3>
+                        <span
+                          className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5 uppercase"
+                          style={{ backgroundColor: tag.color, color: tag.textColor }}
+                        >
+                          {tag.label}
+                        </span>
+                        {event.areas.map((a) => (
+                          <span
+                            key={a}
+                            className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5 uppercase"
+                            style={{
+                              backgroundColor: AREA_COLORS[a.toLowerCase()] || DEFAULT_AREA_COLOR,
+                              color: '#fff',
+                            }}
+                            title="Related IETF area (organizer's tag)"
+                          >
+                            {a}
+                          </span>
+                        ))}
+                      </div>
+                      <div className={`space-y-[1px] text-sm font-bold ${c.bodyText}`}>
+                        <p>
+                          {event.venueTitle}
+                          {event.organizer && ` · organized by ${event.organizer}`}
+                        </p>
+                        <p>
+                          {fmtTime(event.start)} – {fmtTime(event.end)}
+                        </p>
+                      </div>
+                      {event.description && (
+                        <p className={`mt-0.5 text-sm ${c.bodyText} whitespace-pre-line`}>
+                          {event.description}
+                        </p>
+                      )}
+                      {canWrite ? (
+                        <NoteField
+                          saved={notes[event.eventId]}
+                          onSave={(t) => saveNote(event.eventId, t)}
+                          className={c.noteArea}
+                        />
+                      ) : notes[event.eventId] ? (
+                        <div className={c.noteBox}>
+                          <p className={`text-sm font-bold ${c.bodyText}`}>
+                            {notes[event.eventId]}
+                          </p>
+                        </div>
+                      ) : null}
+                    </div>
+                    <div className="flex gap-0.5">
+                      {canFavorite && (
+                        <button
+                          onClick={() => toggleFavorite(event)}
+                          className={myFavIds.has(event.eventId) ? c.favToggleOn : c.favToggleOff}
+                        >
+                          {myFavIds.has(event.eventId) ? '♥' : '♡'}
+                        </button>
+                      )}
+                      <a
+                        href={event.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={c.linkBtn}
+                        title={
+                          event.url === SIDE_MEETINGS_URL
+                            ? 'View on the side-meetings board'
+                            : 'Join remotely'
+                        }
+                      >
+                        <svg
+                          width="20"
+                          height="20"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                          <polyline points="15 3 21 3 21 9" />
+                          <line x1="10" y1="14" x2="21" y2="3" />
+                        </svg>
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/examples/ietf-picker/access.js
+++ b/examples/ietf-picker/access.js
@@ -76,6 +76,17 @@ export default function (doc, oldDoc, user, ctx) {
     };
   }
 
+  // Side-meetings snapshot chunks are the backend's fallback data source
+  // (sidemeetings.ietf.org 403s the worker egress, so the scheduled tick
+  // assembles the board from these docs and serves it to EVERYONE). Owner-only,
+  // creates and updates alike — otherwise any signed-in user could overwrite a
+  // chunk and poison the board. No grant: clients never read them; the
+  // scheduled lane reads unfiltered anyway.
+  if (type === 'side-snapshot') {
+    if (!user.isOwner) throw { forbidden: 'owner only' };
+    return { channels: ['snapshot-internal'], grant: {} };
+  }
+
   // Unknown / legacy doc types: accept the write but route it to an unreadable channel
   // (no grant) rather than throwing — a single stray local doc must not fail the whole
   // anonymousLocal sign-in migration.

--- a/examples/ietf-picker/access.test.js
+++ b/examples/ietf-picker/access.test.js
@@ -62,6 +62,31 @@ describe('access.js — super grants (owner only)', () => {
   });
 });
 
+describe('access.js — side-meetings snapshot chunks (owner only)', () => {
+  it('the owner writes snapshot chunks into an internal channel with no grant', () => {
+    const { ok } = run(
+      { _id: 'side-snapshot-0', type: 'side-snapshot', seq: 0, total: 1, body: '{}' },
+      null,
+      { userHandle: 'calendar', isOwner: true }
+    );
+    expect(ok.channels).toEqual(['snapshot-internal']);
+    expect(ok.grant).toEqual({});
+  });
+
+  it('a non-owner cannot write (or overwrite) a snapshot chunk — no board poisoning', () => {
+    expect(
+      run({ _id: 'side-snapshot-0', type: 'side-snapshot', seq: 0, body: '{}' }, null, alice)
+    ).toEqual({ forbidden: 'owner only' });
+    expect(
+      run(
+        { _id: 'side-snapshot-0', type: 'side-snapshot', seq: 0, body: 'poison' },
+        { type: 'side-snapshot', seq: 0, body: '{}' },
+        alice
+      )
+    ).toEqual({ forbidden: 'owner only' });
+  });
+});
+
 describe('access.js — guards', () => {
   it('requires a signed-in user', () => {
     expect(run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, null)).toEqual({

--- a/examples/ietf-picker/backend.js
+++ b/examples/ietf-picker/backend.js
@@ -1,5 +1,11 @@
-// IETF 126 Agenda Picker backend: serve faves schedules as .ics.
+// IETF 126 Agenda Picker backend: serve faves schedules as .ics, and proxy the
+// side-meetings board.
 //
+// GET  /_api/side-meetings
+//   → 200 application/json — a pass-through of https://sidemeetings.ietf.org/_data
+//   (module-cached ~10m, stale-served on upstream failure). The board has no
+//   CORS headers, so the app can't fetch it from the iframe; this proxy is the
+//   only reason the Side Meetings lane can exist client-side.
 // POST /_api/faves.ics  { items: [{ id, title, start, end, location?, url? }] }
 //   → 200 text/calendar attachment (ietf126-faves.ics) — one-shot download of
 //   whatever the client sends (works for anonymous local-only faves too).
@@ -334,6 +340,83 @@ export const fetchScheduleItems = async (ids) => {
   return items;
 };
 
+// ── Side-meetings proxy + join ───────────────────────────────────────────────
+
+export const SIDE_MEETINGS_DATA_URL = 'https://sidemeetings.ietf.org/_data';
+const SIDE_MEETINGS_URL = 'https://sidemeetings.ietf.org/';
+const SIDE_CACHE_MS = 10 * 60 * 1000;
+
+// Module-level cache shared by the proxy GET and the subscription join. On
+// upstream failure a stale copy beats an outage: the proxy keeps serving the
+// lane, and the subscription keeps a user's side picks in their calendar
+// instead of silently deleting them from every subscribed client.
+let sideCache = null;
+export const __resetSideCacheForTests = () => {
+  sideCache = null;
+};
+
+const fetchSideData = async () => {
+  if (sideCache && Date.now() - sideCache.at < SIDE_CACHE_MS) return sideCache.data;
+  try {
+    const res = await globalThis.fetch(SIDE_MEETINGS_DATA_URL, {
+      headers: { accept: 'application/json' },
+    });
+    if (!res.ok) throw new Error(`side meetings feed ${res.status}`);
+    const data = await res.json();
+    sideCache = { at: Date.now(), data };
+    return data;
+  } catch (err) {
+    if (sideCache) return sideCache.data;
+    throw err;
+  }
+};
+
+const handleSideMeetings = async () => {
+  let data;
+  try {
+    data = await fetchSideData();
+  } catch (err) {
+    return textResponse(502, `side meetings feed unavailable — try again later (${err.message})`);
+  }
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'public, max-age=300',
+    },
+  });
+};
+
+// Project favorited side-meeting ids (`side-<booking id>`) into ics items — the
+// side-board twin of fetchScheduleItems. A booking that vanished from the board
+// (canceled/rebooked) drops out of the join silently, same as a canceled session.
+export const sideMeetingItems = async (ids) => {
+  const wanted = new Set(ids);
+  const data = await fetchSideData();
+  const bookings = Array.isArray(data?.bookings) ? data.bookings : [];
+  const items = [];
+  for (const b of bookings) {
+    if (b === null || typeof b !== 'object' || !wanted.has(`side-${b.id}`)) continue;
+    const startDate = parseToDate(String(b.start ?? ''));
+    if (startDate === null) continue;
+    items.push({
+      id: `side-${b.id}`,
+      title: String(b.title || 'Side meeting'),
+      start: String(b.start),
+      end:
+        parseToDate(String(b.end ?? '')) !== null
+          ? String(b.end)
+          : new Date(startDate.getTime() + DEFAULT_SESSION_MS).toISOString(),
+      location: String(b.roomName || 'TBA'),
+      url:
+        typeof b.location === 'string' && /^https?:\/\//i.test(b.location)
+          ? b.location
+          : SIDE_MEETINGS_URL,
+    });
+  }
+  return items;
+};
+
 // Stable UID per item so re-importing an updated export replaces events instead
 // of duplicating them. The client keys items by doc identity (event-<eventId> /
 // shift-<_id>); fall back to title+start for a hand-rolled payload.
@@ -445,12 +528,25 @@ const handleSubscription = async (url) => {
   const cold = subCache === null;
   const handle = cold ? undefined : subCache.tokens.get(t);
   const entry = (handle && subCache.users.get(handle)) || { eventIds: [], shifts: [] };
+  // Side-meeting picks join against the side board, everything else against the
+  // agenda feed. Either upstream failing 502s the refresh (rather than serving
+  // a calendar with those events missing, which subscribed clients would treat
+  // as deletions) — the side board additionally rides its stale cache first.
+  const agendaIds = entry.eventIds.filter((id) => !id.startsWith('side-'));
+  const sideIds = entry.eventIds.filter((id) => id.startsWith('side-'));
   let eventItems = [];
-  if (entry.eventIds.length > 0) {
+  if (agendaIds.length > 0) {
     try {
-      eventItems = await fetchScheduleItems(entry.eventIds);
+      eventItems = await fetchScheduleItems(agendaIds);
     } catch (err) {
       return textResponse(502, 'agenda feed unavailable — try again later');
+    }
+  }
+  if (sideIds.length > 0) {
+    try {
+      eventItems = [...eventItems, ...(await sideMeetingItems(sideIds))];
+    } catch (err) {
+      return textResponse(502, 'side meetings feed unavailable — try again later');
     }
   }
   const shiftRows = entry.shifts.map((r, i) => ({
@@ -486,10 +582,16 @@ const handleSubscription = async (url) => {
 // The `_api` request arrives prefix-stripped (…/_api/faves.ics → /faves.ics).
 export async function fetch(request, ctx) {
   const url = new URL(request.url);
+  if (url.pathname === '/side-meetings') {
+    if (request.method === 'GET' || request.method === 'HEAD') return handleSideMeetings();
+    return textResponse(405, 'method not allowed — GET the side-meetings board', {
+      allow: 'GET',
+    });
+  }
   if (url.pathname !== '/faves.ics') {
     return textResponse(
       404,
-      'not found — /faves.ics (POST to download, GET ?t=<token> to subscribe)'
+      'not found — /faves.ics (POST to download, GET ?t=<token> to subscribe) or /side-meetings'
     );
   }
   if (request.method === 'GET' || request.method === 'HEAD') {

--- a/examples/ietf-picker/backend.js
+++ b/examples/ietf-picker/backend.js
@@ -2,10 +2,15 @@
 // side-meetings board.
 //
 // GET  /_api/side-meetings
-//   → 200 application/json — a pass-through of https://sidemeetings.ietf.org/_data
-//   (module-cached ~10m, stale-served on upstream failure). The board has no
-//   CORS headers, so the app can't fetch it from the iframe; this proxy is the
-//   only reason the Side Meetings lane can exist client-side.
+//   → 200 application/json — the sidemeetings.ietf.org/_data board. The board
+//   has no CORS headers, so the app can't fetch it from the iframe; this proxy
+//   is the only reason the Side Meetings lane can exist client-side. AND the
+//   board 403s this platform's worker egress outright (IP/ASN-level — browser
+//   headers don't help; verified 2026-07-09), so the data actually comes from
+//   `side-snapshot` chunk docs written owner-side by the vibes.diy repo's
+//   scripts/vibe-ops/refresh-ietf-side-meetings.mjs and assembled by the
+//   scheduled tick. The direct upstream fetch is kept as the fast path in case
+//   the block is ever lifted.
 // POST /_api/faves.ics  { items: [{ id, title, start, end, location?, url? }] }
 //   → 200 text/calendar attachment (ietf126-faves.ics) — one-shot download of
 //   whatever the client sends (works for anonymous local-only faves too).
@@ -255,6 +260,37 @@ export async function scheduled(event, ctx) {
     if (!users.has(key)) users.set(key, { eventIds: [], shifts: [] });
     return users.get(key);
   };
+  // Assemble the side-meetings snapshot from its chunk docs (written owner-side
+  // by the vibes.diy repo's scripts/vibe-ops/refresh-ietf-side-meetings.mjs;
+  // the board 403s this isolate's egress). Chunks join in seq order, and only a
+  // COMPLETE set (all `total` present, one fetchedAt) replaces the previous
+  // snapshot — a half-written refresh must not produce truncated JSON. The _id
+  // check is defense-in-depth on top of access.js's owner-only rule for this
+  // type: only docs at the canonical chunk ids participate, so a stray doc that
+  // merely carries the type can never displace a chunk.
+  const sideChunks = docs
+    .filter(
+      (d) =>
+        d &&
+        d.type === 'side-snapshot' &&
+        typeof d.body === 'string' &&
+        Number.isInteger(d.seq) &&
+        d._id === `side-snapshot-${d.seq}`
+    )
+    .sort((a, b) => a.seq - b.seq);
+  if (sideChunks.length > 0) {
+    const total = sideChunks[0].total;
+    const fetchedAt = sideChunks[0].fetchedAt;
+    const complete =
+      Number.isInteger(total) &&
+      sideChunks.length === total &&
+      sideChunks.every((c, i) => c.seq === i && c.total === total && c.fetchedAt === fetchedAt);
+    if (complete)
+      sideDbSnapshot = {
+        at: Date.parse(fetchedAt) || Date.now(),
+        body: sideChunks.map((c) => c.body).join(''),
+      };
+  }
   for (const d of docs) {
     if (!d || !d.userId) continue;
     if (d.type === 'caltoken') {
@@ -346,39 +382,49 @@ export const SIDE_MEETINGS_DATA_URL = 'https://sidemeetings.ietf.org/_data';
 const SIDE_MEETINGS_URL = 'https://sidemeetings.ietf.org/';
 const SIDE_CACHE_MS = 10 * 60 * 1000;
 
-// Module-level cache shared by the proxy GET and the subscription join. On
-// upstream failure a stale copy beats an outage: the proxy keeps serving the
-// lane, and the subscription keeps a user's side picks in their calendar
-// instead of silently deleting them from every subscribed client.
-let sideCache = null;
+// Raw board JSON TEXT in module state, shared by the proxy GET and the
+// subscription join. Two layers: `sideCache` holds the last successful direct
+// fetch (fast path, currently always blocked), `sideDbSnapshot` holds the
+// owner-written snapshot assembled from `side-snapshot` chunk docs by the
+// scheduled tick — in practice the only layer that ever has data. A stale copy
+// always beats an outage: the proxy keeps serving the lane, and the
+// subscription keeps a user's side picks in their calendar instead of silently
+// deleting them from every subscribed client.
+let sideCache = null; // { at, body }
+let sideDbSnapshot = null; // { at, body }
 export const __resetSideCacheForTests = () => {
   sideCache = null;
+  sideDbSnapshot = null;
 };
 
-const fetchSideData = async () => {
-  if (sideCache && Date.now() - sideCache.at < SIDE_CACHE_MS) return sideCache.data;
+const fetchSideText = async () => {
+  const now = Date.now();
+  if (sideCache !== null && now - sideCache.at < SIDE_CACHE_MS) return sideCache.body;
   try {
     const res = await globalThis.fetch(SIDE_MEETINGS_DATA_URL, {
       headers: { accept: 'application/json' },
     });
     if (!res.ok) throw new Error(`side meetings feed ${res.status}`);
-    const data = await res.json();
-    sideCache = { at: Date.now(), data };
-    return data;
+    const body = await res.text();
+    sideCache = { at: now, body };
+    return body;
   } catch (err) {
-    if (sideCache) return sideCache.data;
+    if (sideDbSnapshot !== null) return sideDbSnapshot.body;
+    if (sideCache !== null) return sideCache.body;
     throw err;
   }
 };
 
 const handleSideMeetings = async () => {
-  let data;
+  let body;
   try {
-    data = await fetchSideData();
+    body = await fetchSideText();
   } catch (err) {
+    // Surface the upstream failure — a bare 502 with no cause makes egress
+    // problems undiagnosable.
     return textResponse(502, `side meetings feed unavailable — try again later (${err.message})`);
   }
-  return new Response(JSON.stringify(data), {
+  return new Response(body, {
     status: 200,
     headers: {
       'content-type': 'application/json; charset=utf-8',
@@ -392,7 +438,7 @@ const handleSideMeetings = async () => {
 // (canceled/rebooked) drops out of the join silently, same as a canceled session.
 export const sideMeetingItems = async (ids) => {
   const wanted = new Set(ids);
-  const data = await fetchSideData();
+  const data = JSON.parse(await fetchSideText());
   const bookings = Array.isArray(data?.bookings) ? data.bookings : [];
   const items = [];
   for (const b of bookings) {

--- a/examples/ietf-picker/backend.test.js
+++ b/examples/ietf-picker/backend.test.js
@@ -621,6 +621,56 @@ describe('fetch handler — GET /side-meetings (the board proxy)', () => {
     expect(res.status).toBe(405);
     expect(res.headers.get('allow')).toBe('GET');
   });
+
+  // The production path: sidemeetings.ietf.org 403s the worker egress outright,
+  // so the board really comes from owner-written `side-snapshot` chunk docs
+  // assembled by the scheduled tick.
+  const sideBody = JSON.stringify(SIDE_FEED);
+  const half = Math.ceil(sideBody.length / 2);
+  const SNAP_CHUNKS = [sideBody.slice(0, half), sideBody.slice(half)].map((chunk, seq) => ({
+    _id: `side-snapshot-${seq}`,
+    type: 'side-snapshot',
+    seq,
+    total: 2,
+    fetchedAt: '2026-07-09T18:00:00Z',
+    body: chunk,
+  }));
+  const blockedUpstream = () => {
+    const spy = vi.fn(async (url) =>
+      String(url).includes('sidemeetings')
+        ? new Response('blocked', { status: 403 })
+        : new Response(JSON.stringify(FEED), { status: 200 })
+    );
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  };
+  const tickWith = (docs) =>
+    scheduled({ scheduledTime: '2026-07-09T18:05:00Z' }, { db: { query: async () => docs } });
+
+  it('serves the owner-written db snapshot when the upstream blocks egress (the real path)', async () => {
+    __resetSubCacheForTests();
+    blockedUpstream();
+    await tickWith(SNAP_CHUNKS);
+    const res = await icsFetch(req('/side-meetings'), {});
+    expect(res.status).toBe(200);
+    expect((await res.json()).bookings[0].title).toBe('AUDIT charter discussion');
+  });
+
+  it('never assembles an incomplete chunk set — half a refresh must not serve truncated JSON', async () => {
+    __resetSubCacheForTests();
+    blockedUpstream();
+    await tickWith([SNAP_CHUNKS[0]]); // seq 1 of 2 missing
+    const res = await icsFetch(req('/side-meetings'), {});
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('side meetings feed 403');
+  });
+
+  it('ignores chunk docs not at their canonical _id (poisoning defense-in-depth)', async () => {
+    __resetSubCacheForTests();
+    blockedUpstream();
+    await tickWith(SNAP_CHUNKS.map((c) => ({ ...c, _id: `evil-${c.seq}` })));
+    expect((await icsFetch(req('/side-meetings'), {})).status).toBe(502);
+  });
 });
 
 describe('subscription lane — side-meeting picks join against the board', () => {
@@ -677,5 +727,34 @@ describe('subscription lane — side-meeting picks join against the board', () =
     const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
     expect(res.status).toBe(502);
     expect(await res.text()).toContain('side meetings feed unavailable');
+  });
+
+  it('joins side picks against the db snapshot when the board blocks egress (the real path)', async () => {
+    const sideBody = JSON.stringify(SIDE_FEED);
+    const snap = {
+      _id: 'side-snapshot-0',
+      type: 'side-snapshot',
+      seq: 0,
+      total: 1,
+      fetchedAt: '2026-07-09T18:00:00Z',
+      body: sideBody,
+    };
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (url) =>
+        String(url).includes('sidemeetings')
+          ? new Response('blocked', { status: 403 })
+          : new Response(JSON.stringify(FEED), { status: 200 })
+      )
+    );
+    await scheduled(
+      { scheduledTime: '2026-07-09T18:05:00Z' },
+      { db: { query: async () => [...SIDE_DOCS, snap] } }
+    );
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('SUMMARY:AUDIT charter discussion');
+    expect(body).toContain('SUMMARY:Bidirectional Forwarding Detection');
   });
 });

--- a/examples/ietf-picker/backend.test.js
+++ b/examples/ietf-picker/backend.test.js
@@ -9,6 +9,8 @@ import {
   __resetSubCacheForTests,
   MAX_ITEMS,
   SCHEDULE_URL,
+  SIDE_MEETINGS_DATA_URL,
+  __resetSideCacheForTests,
   fetch as icsFetch,
 } from './backend.js';
 
@@ -529,5 +531,151 @@ describe('fetch handler — POST /faves.ics', () => {
   it('never needs ctx — works with an anonymous, ctx-less call', async () => {
     const res = await icsFetch(post({ items: items() }), undefined);
     expect(res.status).toBe(200);
+  });
+});
+
+// ── Side-meetings proxy + subscription join ──────────────────────────────────
+
+const SIDE_FEED = {
+  meeting: { meetingNumber: '126', timezone: 'Europe/Vienna' },
+  rooms: [{ id: 1, title: 'Park Suite 4' }],
+  bookings: [
+    {
+      id: 99,
+      roomId: 1,
+      roomName: 'Park Suite 4',
+      title: 'AUDIT charter discussion',
+      description: 'Draft charter for a proposed new group',
+      start: '2026-07-20T07:30:00.000Z',
+      end: '2026-07-20T09:30:00.000Z',
+      location: 'https://ietf.webex.com/meet/sidemeetings2',
+      organizerName: 'Mirja',
+      areas: ['SEC'],
+    },
+  ],
+};
+
+// URL-routing stub: the subscription join fetches BOTH upstreams.
+const routedFeeds = ({ agendaStatus = 200, sideStatus = 200 } = {}) => {
+  const spy = vi.fn(async (url) => {
+    if (String(url).includes('sidemeetings')) {
+      return new Response(JSON.stringify(SIDE_FEED), { status: sideStatus });
+    }
+    return new Response(JSON.stringify(FEED), { status: agendaStatus });
+  });
+  vi.stubGlobal('fetch', spy);
+  return spy;
+};
+
+describe('fetch handler — GET /side-meetings (the board proxy)', () => {
+  beforeEach(() => __resetSideCacheForTests());
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('proxies the board JSON with a short shared cache (the board itself has no CORS)', async () => {
+    routedFeeds();
+    const res = await icsFetch(req('/side-meetings'), {});
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/json; charset=utf-8');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=300');
+    const body = await res.json();
+    expect(body.bookings[0].title).toBe('AUDIT charter discussion');
+  });
+
+  it('serves from the module cache inside the TTL — one upstream fetch for many GETs', async () => {
+    const spy = routedFeeds();
+    await icsFetch(req('/side-meetings'), {});
+    await icsFetch(req('/side-meetings'), {});
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(SIDE_MEETINGS_DATA_URL, expect.anything());
+  });
+
+  it('serves the stale copy when a refresh past the TTL fails — an outage never empties the lane', async () => {
+    vi.useFakeTimers();
+    routedFeeds();
+    await icsFetch(req('/side-meetings'), {});
+    vi.setSystemTime(Date.now() + 11 * 60 * 1000); // past the 10m TTL
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 }))
+    );
+    const res = await icsFetch(req('/side-meetings'), {});
+    expect(res.status).toBe(200);
+    expect((await res.json()).bookings[0].title).toBe('AUDIT charter discussion');
+  });
+
+  it('502s with a diagnostic when the upstream is down and there is no cache yet', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 403 }))
+    );
+    const res = await icsFetch(req('/side-meetings'), {});
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('side meetings feed 403');
+  });
+
+  it('405s non-GET methods', async () => {
+    const res = await icsFetch(req('/side-meetings', { method: 'POST' }), {});
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('GET');
+  });
+});
+
+describe('subscription lane — side-meeting picks join against the board', () => {
+  beforeEach(() => {
+    __resetSubCacheForTests();
+    __resetSideCacheForTests();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const SIDE_DOCS = [
+    { _id: 'favorite-alice-35438', type: 'favorite', userId: 'alice', eventId: 35438 },
+    { _id: 'favorite-alice-side99', type: 'favorite', userId: 'alice', eventId: 'side-99' },
+    // A side pick whose booking vanished from the board (canceled) — drops silently.
+    { _id: 'favorite-alice-side404', type: 'favorite', userId: 'alice', eventId: 'side-404' },
+    { _id: 'caltoken-alice', type: 'caltoken', userId: 'alice', token: 'alice-token-1234567890A' },
+  ];
+  const sideTick = () =>
+    scheduled({ scheduledTime: '2026-07-04T12:00:00Z' }, { db: { query: async () => SIDE_DOCS } });
+
+  it('merges agenda picks and side-meeting picks into one calendar', async () => {
+    const spy = routedFeeds();
+    await sideTick();
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain('SUMMARY:Bidirectional Forwarding Detection'); // agenda join
+    expect(body).toContain('SUMMARY:AUDIT charter discussion'); // side join
+    expect(body).toContain('LOCATION:Park Suite 4');
+    expect(body).toContain('URL:https://ietf.webex.com/meet/sidemeetings2');
+    expect(body).toContain('UID:side-99@ietf-picker.vibes.diy'); // stable across refreshes
+    expect(body).toContain('DTSTART:20260720T073000Z');
+    expect(body).not.toContain('side-404'); // vanished booking drops out of the join
+    const urls = spy.mock.calls.map((c) => String(c[0]));
+    expect(urls).toContain(SCHEDULE_URL);
+    expect(urls).toContain(SIDE_MEETINGS_DATA_URL);
+  });
+
+  it('side-only pickers never touch the agenda feed', async () => {
+    const spy = routedFeeds();
+    await scheduled(
+      { scheduledTime: '2026-07-04T12:00:00Z' },
+      { db: { query: async () => [SIDE_DOCS[1], SIDE_DOCS[3]] } }
+    );
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('SUMMARY:AUDIT charter discussion');
+    const urls = spy.mock.calls.map((c) => String(c[0]));
+    expect(urls).toEqual([SIDE_MEETINGS_DATA_URL]);
+  });
+
+  it('502s (rather than silently deleting side picks from calendars) when the board is down uncached', async () => {
+    routedFeeds({ sideStatus: 500 });
+    await sideTick();
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain('side meetings feed unavailable');
   });
 });

--- a/examples/ietf-picker/festival-utils.js
+++ b/examples/ietf-picker/festival-utils.js
@@ -6,6 +6,14 @@ export const MEETING_TZ = 'Europe/Vienna';
 export const AGENDA_URL = `https://datatracker.ietf.org/meeting/${MEETING_NUMBER}/agenda.json`;
 export const MEETING_URL = `https://www.ietf.org/meeting/${MEETING_NUMBER}/`;
 
+// Community-organized side meetings live on their own board, NOT in the
+// datatracker agenda. sidemeetings.ietf.org always serves the CURRENT meeting's
+// data (no meeting number in the URL), and its /_data endpoint has no CORS
+// headers — so unlike the agenda the app can't fetch it directly; backend.js
+// proxies it at GET /_api/side-meetings.
+export const SIDE_MEETINGS_URL = 'https://sidemeetings.ietf.org/';
+export const SIDE_MEETINGS_API = '/_api/side-meetings';
+
 const hasExplicitTZ = (s) => /([+-]\d\d:\d\d|Z)$/.test(s);
 export const ensureT = (s = '') => (s.includes('T') ? s : s.replace(' ', 'T'));
 
@@ -193,6 +201,52 @@ export const flattenAgenda = (data) => {
     }
   }
   return list;
+};
+
+// Side meetings aren't IETF-area events, so they get their own lane color — a
+// teal no area uses — and the areas the organizer tagged ride along as chips.
+export const SIDE_MEETING_COLOR = '#0e7490';
+
+// sidemeetings.ietf.org /_data → the same event shape flattenAgenda emits, so
+// side meetings are first-class events everywhere downstream (hearts, My Faves,
+// the friends schedule, ics). eventIds are `side-<booking id>`: booking ids and
+// datatracker session_ids are both bare numbers, so the prefix keeps a favorite
+// on one from ever colliding with the other.
+export const flattenSideMeetings = (data) => {
+  const bookings = Array.isArray(data?.bookings) ? data.bookings : [];
+  const list = [];
+  for (const b of bookings) {
+    if (b === null || typeof b !== 'object' || b.id == null) continue;
+    const start = toMeetingDate(b.start);
+    if (isNaN(start)) continue;
+    const title = typeof b.title === 'string' && b.title.trim() !== '' ? b.title.trim() : '';
+    if (title === '') continue;
+    // The board stamps an end on every booking; if one ever arrives blank, a
+    // nominal hour keeps the meeting on the board (same rule as the agenda).
+    const end = isNaN(toMeetingDate(b.end))
+      ? new Date(start.getTime() + 60 * 60 * 1000).toISOString().replace(/\.\d{3}Z$/, 'Z')
+      : b.end;
+    list.push({
+      eventId: `side-${b.id}`,
+      title,
+      start: b.start,
+      end,
+      // `location` is the remote-participation link (webex etc.) when the
+      // organizer provided one; the side-meetings board is the stable fallback.
+      url:
+        typeof b.location === 'string' && /^https?:\/\//i.test(b.location)
+          ? b.location
+          : SIDE_MEETINGS_URL,
+      venueTitle: b.roomName || 'TBA',
+      organizer: typeof b.organizerName === 'string' ? b.organizerName : '',
+      description: typeof b.description === 'string' ? b.description : '',
+      areas: Array.isArray(b.areas) ? b.areas.filter((a) => typeof a === 'string') : [],
+      isSide: true,
+      lineup: { id: 'side', color: SIDE_MEETING_COLOR },
+      day: meetingDayFor(b.start),
+    });
+  }
+  return list.sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start));
 };
 
 // What's in session right now: started at/before `nowMs` and not yet ended. A session

--- a/examples/ietf-picker/schedule.test.js
+++ b/examples/ietf-picker/schedule.test.js
@@ -6,6 +6,9 @@ import {
   toMeetingDate,
   scheduleIcsItems,
   flattenAgenda,
+  flattenSideMeetings,
+  SIDE_MEETING_COLOR,
+  SIDE_MEETINGS_URL,
   AREA_COLORS,
   DEFAULT_AREA_COLOR,
 } from './festival-utils.js';
@@ -468,5 +471,78 @@ describe('scheduleIcsItems — flattening My Faves for the .ics backend', () => 
       shiftEnd,
     });
     expect(items.map((i) => i.id)).toEqual(['shift-ok']);
+  });
+});
+
+describe('flattenSideMeetings — the sidemeetings.ietf.org /_data board', () => {
+  const SIDE_DATA = {
+    meeting: { meetingNumber: '126', timezone: 'Europe/Vienna' },
+    rooms: [{ id: 1, title: 'Park Suite 4' }],
+    bookings: [
+      {
+        id: 21758539,
+        roomId: 1,
+        roomName: 'Park Suite 4',
+        title: 'Coherent Pluggable CCAMP meeting',
+        description: 'Weekly modeling and gap analysis',
+        start: '2026-07-21T07:00:00.000Z',
+        end: '2026-07-21T08:00:00.000Z',
+        location: 'https://ietf.webex.com/meet/sidemeetings1',
+        organizerName: 'Reza',
+        areas: ['RTG'],
+      },
+      {
+        id: 2,
+        roomName: 'Grand Klimt Hall 3',
+        title: 'In-person only meetup',
+        start: '2026-07-20T15:00:00.000Z',
+        end: '2026-07-20T16:00:00.000Z',
+        location: 'meet at the room', // not a URL — no remote link
+        organizerName: '',
+      },
+      { id: 3, title: '   ', start: '2026-07-21T15:00:00.000Z', end: '2026-07-21T16:00:00.000Z' },
+      { id: 4, title: 'Bad start', start: 'junk', end: '2026-07-21T16:00:00.000Z' },
+      { id: 5, title: 'No end stamped', roomName: 'R', start: '2026-07-22T15:00:00.000Z' },
+    ],
+  };
+  const flat = flattenSideMeetings(SIDE_DATA);
+
+  it('prefixes booking ids so they can never collide with datatracker session_ids', () => {
+    expect(flat.map((m) => m.eventId)).toContain('side-21758539');
+    expect(flat.every((m) => m.eventId.startsWith('side-'))).toBe(true);
+  });
+  it('drops blank-title and unparseable-start bookings, keeps the rest', () => {
+    expect(flat.map((m) => m.eventId).sort()).toEqual(['side-2', 'side-21758539', 'side-5']);
+  });
+  it('marks the lane: isSide, the teal side chip, organizer and areas carried through', () => {
+    const m = flat.find((x) => x.eventId === 'side-21758539');
+    expect(m.isSide).toBe(true);
+    expect(m.lineup).toEqual({ id: 'side', color: SIDE_MEETING_COLOR });
+    expect(m.organizer).toBe('Reza');
+    expect(m.areas).toEqual(['RTG']);
+    expect(m.venueTitle).toBe('Park Suite 4');
+  });
+  it('uses the remote-participation link as the url when it is a real URL, else the board', () => {
+    expect(flat.find((x) => x.eventId === 'side-21758539').url).toBe(
+      'https://ietf.webex.com/meet/sidemeetings1'
+    );
+    expect(flat.find((x) => x.eventId === 'side-2').url).toBe(SIDE_MEETINGS_URL);
+  });
+  it('groups by the Vienna meeting day (feed stamps UTC)', () => {
+    expect(flat.find((x) => x.eventId === 'side-21758539').day).toBe('Tuesday'); // 09:00 CEST
+    expect(flat.find((x) => x.eventId === 'side-2').day).toBe('Monday'); // 17:00 CEST
+  });
+  it('defaults a missing end to a nominal hour so the meeting stays on the board', () => {
+    const m = flat.find((x) => x.eventId === 'side-5');
+    expect(toMeetingDate(m.end).getTime() - toMeetingDate(m.start).getTime()).toBe(3600_000);
+  });
+  it('returns the board sorted by start', () => {
+    const times = flat.map((m) => toMeetingDate(m.start).getTime());
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+  it('tolerates a malformed payload', () => {
+    expect(flattenSideMeetings(null)).toEqual([]);
+    expect(flattenSideMeetings({})).toEqual([]);
+    expect(flattenSideMeetings({ bookings: [null, 42] })).toEqual([]);
   });
 });


### PR DESCRIPTION
Adds a **Side Meetings** tab to the IETF 126 picker, fed by the community side-meetings board at sidemeetings.ietf.org — which the datatracker agenda doesn't cover.

## Data path (the interesting part)

The board's `/_data` endpoint has **no CORS headers**, so the app can't fetch it from the iframe — and the board also **403s the platform's worker egress** (IP/ASN-level; browser headers don't help — verified live on `qa/ietf-picker`, same class as DEF CON's `info.defcon.org`). So this adopts the DEF CON db-snapshot pattern:

- an owner-side refresher (vibes.diy repo: `scripts/vibe-ops/refresh-ietf-side-meetings.mjs`) writes the raw `/_data` JSON into the `ietf126` db as owner-gated `side-snapshot` chunk docs (it refuses to overwrite if the board flips to meeting 127 or serves zero bookings)
- the backend's 1-minute scheduled tick assembles a COMPLETE chunk set into module state
- `GET /_api/side-meetings` serves it (direct upstream fetch kept as the fast path in case the block lifts)

## App integration

- Bookings flatten into the standard event shape with `side-<booking id>` eventIds (prefixed — booking ids and datatracker `session_id`s are both bare numbers), so side meetings are **first-class everywhere downstream**: hearts, notes, My Faves, Right Now / Up Next, the friends schedule, super-mode counts.
- The ics subscription lane splits a user's picks and joins `side-*` ids against the snapshot, so favorited side meetings reach subscribed calendars; either upstream failing 502s the refresh rather than serving a calendar that clients would treat as deletions.
- New `SideMeetingsView`: day-grouped cards with the teal SIDE lane chip, organizer-tagged area chips, room + organizer, description, and the remote-participation (webex) link when the organizer provided one.
- `access.js`: `side-snapshot` writes are owner-only (creates AND updates), so ordinary signed-in users can't poison the served board.

Tests: 75 → 97 (flattener, proxy + snapshot assembly + poisoning defense, subscription join, access rules).

Validated on `qa/ietf-picker`: full loop refresher → chunk docs → tick assembly → proxy 200 (37 bookings) → rendered lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn)_