### PR TITLE
ocf-picker: Community Village workshops as first-class sessions

### DIFF
--- a/examples/ocf-picker/App.jsx
+++ b/examples/ocf-picker/App.jsx
@@ -579,6 +579,7 @@ export default function OcfPicker() {
   const artistsList = useMemo(() => {
     const map = new Map();
     for (const e of events) {
+      if (e.isWorkshop) continue; // workshops have their own tab, not artist pages
       const key = e.title;
       if (!map.has(key))
         map.set(key, { title: key, url: e.url, events: [], lineup: e.lineup, venues: new Set() });
@@ -609,6 +610,13 @@ export default function OcfPicker() {
         )
         .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start)),
     [events, searchTerm, selectedDay]
+  );
+
+  // The Workshops tab is the same browse surface filtered to Community Village
+  // workshops (they also appear everywhere else — All Events, Now, faves, ics).
+  const filteredWorkshops = useMemo(
+    () => filteredEvents.filter((e) => e.isWorkshop),
+    [filteredEvents]
   );
 
   const favoriteEvents = useMemo(
@@ -750,9 +758,10 @@ export default function OcfPicker() {
 
         <div className={`${c.navBg} ${c.border} p-2`}>
           <div className="flex flex-wrap gap-[3px]">
-            {['now', 'browse', 'artists', 'favorites', 'friends', 'shifts', 'schedule']
+            {['now', 'browse', 'artists', 'workshops', 'favorites', 'friends', 'shifts', 'schedule']
               .filter((v) => {
-                if (v === 'now' || v === 'browse' || v === 'artists') return true;
+                if (v === 'now' || v === 'browse' || v === 'artists' || v === 'workshops')
+                  return true;
                 if (v === 'favorites') return superMode && canWrite; // super-mode peer picker
                 if (v === 'schedule') return canFavorite; // anon can view their own favorites schedule
                 return canWrite; // friends + extras need a real sign-in
@@ -766,6 +775,7 @@ export default function OcfPicker() {
                   {viewName === 'now' && `Now`}
                   {viewName === 'browse' && `All Events`}
                   {viewName === 'artists' && `Artists`}
+                  {viewName === 'workshops' && `Workshops`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
                   {viewName === 'friends' && `🙋‍♀️ Follows`}
                   {viewName === 'shifts' && `Extras`}
@@ -812,6 +822,27 @@ export default function OcfPicker() {
               {view === 'browse' && (
                 <BrowseView
                   filteredEvents={filteredEvents}
+                  searchTerm={searchTerm}
+                  setSearchTerm={setSearchTerm}
+                  selectedDay={selectedDay}
+                  setSelectedDay={setSelectedDay}
+                  displayDays={displayDays}
+                  getDateForDay={getDateForDay}
+                  myFavIds={myFavIds}
+                  canWrite={canWrite}
+                  canFavorite={canFavorite}
+                  toggleFavorite={toggleFavorite}
+                  notes={notes}
+                  saveNote={saveNote}
+                  superMode={superMode}
+                  favCounts={favCounts}
+                  c={c}
+                />
+              )}
+
+              {view === 'workshops' && (
+                <BrowseView
+                  filteredEvents={filteredWorkshops}
                   searchTerm={searchTerm}
                   setSearchTerm={setSearchTerm}
                   selectedDay={selectedDay}

--- a/examples/ocf-picker/BrowseView.jsx
+++ b/examples/ocf-picker/BrowseView.jsx
@@ -91,6 +91,9 @@ export default function BrowseView({
                             {fmtTime(event.start)} – {fmtTime(event.end)}
                           </p>
                         </div>
+                        {event.description && (
+                          <p className={`mt-0.5 text-sm ${c.bodyText}`}>{event.description}</p>
+                        )}
                         {canWrite ? (
                           <NoteField
                             saved={notes[event.eventId]}

--- a/examples/ocf-picker/RUNBOOK.md
+++ b/examples/ocf-picker/RUNBOOK.md
@@ -76,6 +76,30 @@ The client instead fetches the same-origin **`GET /_api/schedule.json`**, which
 - The subscription lane's schedule join (`fetchScheduleItems`) reads through the
   **same cache** — one upstream fetch serves both lanes.
 
+### Community Village workshops (merged into the same snapshot)
+
+The Workshops tab (and every downstream surface — All Events, Now, faves, ics)
+gets its data from `https://www.oregoncountryfair.org/community-village-workshops/`,
+parsed by `parseWorkshopsHtml` (festival-utils.js; behaviorally-identical ops
+copy in the vibes.diy repo's `scripts/vibe-ops/refresh-ocf-schedule.mjs`). The
+page is Elementor text soup: day headers (FRIDAY/SATURDAY/SUNDAY), hour headers
+(`11:00`–`6:00`, fair-local 11 AM–6 PM), item lines shaped
+`Title – Presenter: description. Venue` with the venue as a bare trailing token
+from a fixed seven-venue set (sometimes wrapped into its own element — the
+parser attaches a bare venue line to the previous item), a `Noon–6pm,` span
+prefix, and an `ALL DAY, EVERY DAY` section that expands to one 11 AM–7 PM
+entry per fair day. Workshop sessions carry `isWorkshop: true`, a
+`description`, `cv|<date>|<HHMM>|<titleSlug>` eventIds (deterministic across
+refreshes so favorites survive), and the existing `workshop` genre color.
+
+**The workshops ride the db snapshot, not the backend's live parse**: the
+refresher fetches + parses both pages and writes ONE merged snapshot. (The
+backend's live-fetch path knows only the lineup page — if the worker-egress
+block ever lifted mid-fair, a live parse would serve lineup-only. Accepted
+tradeoff; the block has held and the fair is 3 days long.) The refresher
+hard-fails if either page breaks, so a half dataset never overwrites a
+complete snapshot.
+
 ### The parser
 
 `parseLineupHtml` lives in `festival-utils.js`, is **duplicated inline in

--- a/examples/ocf-picker/festival-utils.js
+++ b/examples/ocf-picker/festival-utils.js
@@ -319,7 +319,7 @@ export const parseWorkshopsHtml = (html) => {
   let day = null; // null until the first day header → the ALL DAY section
   let hourMin = null;
   let pendingAllDay = [];
-  const push = (date, startMin, endMin, text, fallbackVenue) => {
+  const push = ({ date, startMin, endMin, text, fallbackVenue }) => {
     let body = text;
     const venueM = CV_VENUE_RE.exec(body);
     let venue = fallbackVenue;
@@ -387,13 +387,25 @@ export const parseWorkshopsHtml = (html) => {
     if (hourMin === null) continue;
     const date = FESTIVAL_2026.dates[day];
     if (!date) continue;
-    push(date, hourMin, hourMin + 60, line, 'Community Village');
+    push({
+      date,
+      startMin: hourMin,
+      endMin: hourMin + 60,
+      text: line,
+      fallbackVenue: 'Community Village',
+    });
   }
 
   // ALL DAY, EVERY DAY items span every fair day's open hours.
   for (const text of pendingAllDay) {
     for (const d of FESTIVAL_2026.dayOrder) {
-      push(FESTIVAL_2026.dates[d], CV_DAY_START_MIN, CV_DAY_END_MIN, text, 'Community Village');
+      push({
+        date: FESTIVAL_2026.dates[d],
+        startMin: CV_DAY_START_MIN,
+        endMin: CV_DAY_END_MIN,
+        text,
+        fallbackVenue: 'Community Village',
+      });
     }
   }
 

--- a/examples/ocf-picker/festival-utils.js
+++ b/examples/ocf-picker/festival-utils.js
@@ -245,6 +245,161 @@ export const parseLineupHtml = (html) => {
   return sessions;
 };
 
+// ── The Community Village workshops parser ───────────────────────────────────
+
+export const WORKSHOPS_URL = 'https://www.oregoncountryfair.org/community-village-workshops/';
+
+// The workshops page is Elementor text soup, not structured markup: day headers
+// (FRIDAY/SATURDAY/SUNDAY), hour headers ("11:00" … "6:00", fair-local, 11 AM
+// through 6 PM), and free-text lines of the shape
+//   "Title – Presenter: description. Venue"
+// with the venue as a bare trailing token from a small fixed set. Everything
+// below is driven by that observed shape (2026-07-09).
+const CV_VENUES = [
+  'Comm-Unity House',
+  'Wild Edibles Booth',
+  'Rainbow Village', // before Village Green — both end in a "Village"/"Green" family
+  'Village Green',
+  'Arts Booth',
+  'Yurt',
+  'Dome',
+];
+const CV_VENUE_RE = new RegExp(
+  `[\\s,]*(${CV_VENUES.map((v) => v.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')).join('|')})[\\s.!]*$`
+);
+// "Noon–6pm, " (en dash or hyphen) prefixing an item overrides the hour block's
+// default one-hour slot — the only multi-hour form the page uses.
+const CV_SPAN_RE = /^Noon\s*[–-]\s*(\d{1,2})\s*pm[,:]?\s*/i;
+
+// Fair days open at 11 AM and close at 7 PM; the ALL DAY, EVERY DAY section
+// maps to one full-day entry per fair day.
+const CV_DAY_START_MIN = 11 * 60;
+const CV_DAY_END_MIN = 19 * 60;
+
+// Split an item line into { title, description }: first colon wins, else the
+// first spaced dash (en dash or hyphen), else the whole line is the title.
+const cvTitleSplit = (text) => {
+  const colon = text.indexOf(':');
+  const dash = text.search(/\s[–—-]\s/);
+  let cut = -1;
+  let skip = 0;
+  if (colon >= 0 && (dash < 0 || colon < dash)) {
+    cut = colon;
+    skip = 1;
+  } else if (dash >= 0) {
+    cut = dash;
+    skip = 3;
+  }
+  if (cut < 0) return { title: text.trim(), description: '' };
+  return { title: text.slice(0, cut).trim(), description: text.slice(cut + skip).trim() };
+};
+
+// Parse the Community Village workshops page into the same session objects as
+// parseLineupHtml, marked `isWorkshop: true` and carrying a `description`.
+// eventId is SYNTHETIC and deterministic across refreshes (favorites survive):
+// cv|<date>|<HHMM>|<titleSlug>. Rows outside a day/hour context, or in a day
+// the fair calendar doesn't know, drop out. Returns [] when the page's
+// bracketing markers are missing (markup change → fail empty, not wrong).
+export const parseWorkshopsHtml = (html) => {
+  const s = String(html);
+  const startAt = s.search(/ALL DAY, EVERY DAY/i);
+  const endAt = s.indexOf('Stay Informed');
+  if (startAt < 0) return [];
+  const region = s
+    .slice(startAt, endAt > startAt ? endAt : undefined)
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ');
+  const lines = decodeEntities(region.replace(/<[^>]+>/g, '\n'))
+    .split('\n')
+    .map((l) => l.replace(/\s+/g, ' ').trim())
+    .filter((l) => l !== '');
+
+  const sessions = [];
+  const seen = new Set();
+  let day = null; // null until the first day header → the ALL DAY section
+  let hourMin = null;
+  let pendingAllDay = [];
+  const push = (date, startMin, endMin, text, fallbackVenue) => {
+    let body = text;
+    const venueM = CV_VENUE_RE.exec(body);
+    let venue = fallbackVenue;
+    if (venueM && venueM.index > 0) {
+      venue = venueM[1];
+      body = body.slice(0, venueM.index).trim();
+    }
+    const spanM = CV_SPAN_RE.exec(body);
+    if (spanM) {
+      startMin = 12 * 60;
+      const endH = +spanM[1];
+      if (endH >= 1 && endH <= 11) endMin = (endH + 12) * 60;
+      body = body.slice(spanM[0].length).trim();
+    }
+    const { title, description } = cvTitleSplit(body);
+    if (title === '') return;
+    const startHHMM = `${pad2(Math.floor(startMin / 60))}:${pad2(startMin % 60)}`;
+    const eventId = `cv|${date}|${startHHMM}|${titleSlug(title)}`;
+    if (seen.has(eventId)) return; // repeated titles at one hour would collide
+    seen.add(eventId);
+    sessions.push({
+      eventId,
+      title,
+      start: isoAt(date, startMin),
+      end: isoAt(date, endMin),
+      url: WORKSHOPS_URL,
+      venueTitle: venue === 'Community Village' ? venue : `${venue} · Community Village`,
+      ...(description !== '' ? { description } : {}),
+      isWorkshop: true,
+      lineup: { id: 'Workshop', color: GENRE_COLORS.workshop },
+    });
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^ALL DAY, EVERY DAY$/i.test(line)) continue;
+    const dayM = /^(FRIDAY|SATURDAY|SUNDAY)$/i.exec(line);
+    if (dayM) {
+      day = dayM[1][0].toUpperCase() + dayM[1].slice(1).toLowerCase();
+      hourMin = null;
+      continue;
+    }
+    const hourM = /^(\d{1,2}):(\d{2})$/.exec(line);
+    if (hourM && day !== null) {
+      const h = +hourM[1];
+      // The grid is fair-local 11 AM – 6 PM: 11/12 are AM/noon, 1–10 are PM.
+      hourMin = (h >= 11 ? h : h + 12) * 60 + +hourM[2];
+      continue;
+    }
+    // The page's own footer ends the data even if the end marker moved.
+    if (/^Oregon Country Fair is an independent/i.test(line)) break;
+    // A bare venue line belongs to the PREVIOUS item (the page sometimes wraps
+    // the venue into its own element, e.g. Healthy Bees / Comm-Unity House).
+    if (CV_VENUES.includes(line)) {
+      const prev = sessions[sessions.length - 1];
+      if (prev && prev.venueTitle === 'Community Village') {
+        prev.venueTitle = `${line} · Community Village`;
+      }
+      continue;
+    }
+    if (day === null) {
+      pendingAllDay.push(line);
+      continue;
+    }
+    if (hourMin === null) continue;
+    const date = FESTIVAL_2026.dates[day];
+    if (!date) continue;
+    push(date, hourMin, hourMin + 60, line, 'Community Village');
+  }
+
+  // ALL DAY, EVERY DAY items span every fair day's open hours.
+  for (const text of pendingAllDay) {
+    for (const d of FESTIVAL_2026.dayOrder) {
+      push(FESTIVAL_2026.dates[d], CV_DAY_START_MIN, CV_DAY_END_MIN, text, 'Community Village');
+    }
+  }
+
+  return sessions.sort((a, b) => (a.start < b.start ? -1 : a.start > b.start ? 1 : 0));
+};
+
 // The proxy/snapshot already serve PARSED session objects (backend.js runs the
 // same parser), so "flattening" here is just stamping each session with its
 // fair day (4 AM night cutoff — festivalDayFor is the same rule the faves and

--- a/examples/ocf-picker/schedule.test.js
+++ b/examples/ocf-picker/schedule.test.js
@@ -10,6 +10,7 @@ import {
   decodeEntities,
   GENRE_COLORS,
   GENRE_DEFAULT_COLOR,
+  parseWorkshopsHtml,
 } from './festival-utils.js';
 
 // Everything is anchored through toFestivalDate so events and "now" share one frame.
@@ -378,5 +379,88 @@ describe('scheduleIcsItems — flattening My Faves for the .ics backend', () => 
       shiftEnd,
     });
     expect(items.map((i) => i.id)).toEqual(['shift-ok']);
+  });
+});
+
+describe('parseWorkshopsHtml — the Community Village workshops page', () => {
+  // Distilled from the live page's real shapes (2026-07-09): Elementor text
+  // soup with day headers, hour headers, "Title – Presenter: description. Venue"
+  // lines, a venue wrapped into its own element, a Noon–6pm span prefix, and an
+  // ALL DAY, EVERY DAY section ahead of the first day header.
+  const PAGE = `
+<html><body>
+<h1>Community Village Workshops</h1>
+<h4>ALL DAY, EVERY DAY</h4>
+<h4>Queer &amp; Trans Clothing Swap, Take clothes, leave clothes, build community! Rainbow Village</h4>
+<p>FRIDAY</p>
+<p>11:00</p>
+<p>Bioregional Food Systems – Kelson Gorman: Think global and act local. Village Green</p>
+<p>Story Stick – Weave a story as you add beads. Arts Booth</p>
+<p>12:00</p>
+<p>Noon–6pm, Healthy Bees Observation Hive: Come give love and light to our precious honey bees!</p>
+<p>Comm-Unity House</p>
+<p>1:00</p>
+<p>NA Meeting: Open meeting. Yurt</p>
+<p>SATURDAY</p>
+<p>5:00</p>
+<p>Rainbow Village&#8217;s Cribbage Tournament Dome</p>
+<p>Oregon Country Fair is an independent 501(c)(3) nonprofit organization.</p>
+<h2>Stay Informed</h2>
+</body></html>`;
+  const ws = parseWorkshopsHtml(PAGE);
+  const byId = Object.fromEntries(ws.map((w) => [w.eventId, w]));
+
+  it('parses hour-block items with deterministic cv| eventIds and one-hour slots', () => {
+    const w = byId['cv|2026-07-10|11:00|bioregional-food-systems'];
+    expect(w).toBeDefined();
+    expect(w.start).toBe('2026-07-10T11:00:00');
+    expect(w.end).toBe('2026-07-10T12:00:00');
+    expect(w.venueTitle).toBe('Village Green · Community Village');
+    expect(w.description).toContain('Kelson Gorman');
+    expect(w.isWorkshop).toBe(true);
+    expect(w.lineup).toEqual({ id: 'Workshop', color: GENRE_COLORS.workshop });
+  });
+
+  it('maps the 1:00–6:00 grid hours to PM', () => {
+    expect(byId['cv|2026-07-10|13:00|na-meeting']).toBeDefined();
+    expect(byId['cv|2026-07-11|17:00|rainbow-village-s-cribbage-tournament']).toBeDefined();
+  });
+
+  it('attaches a venue wrapped into its own element to the previous item', () => {
+    const bees = ws.find((w) => w.title === 'Healthy Bees Observation Hive');
+    expect(bees.venueTitle).toBe('Comm-Unity House · Community Village');
+  });
+
+  it('honors the Noon–6pm span prefix over the hour block default', () => {
+    const bees = ws.find((w) => w.title === 'Healthy Bees Observation Hive');
+    expect(bees.start).toBe('2026-07-10T12:00:00');
+    expect(bees.end).toBe('2026-07-10T18:00:00');
+  });
+
+  it('strips a bare trailing venue from a no-description line', () => {
+    const crib = byId['cv|2026-07-11|17:00|rainbow-village-s-cribbage-tournament'];
+    expect(crib.title).toBe('Rainbow Village’s Cribbage Tournament');
+    expect(crib.venueTitle).toBe('Dome · Community Village');
+  });
+
+  it('expands ALL DAY, EVERY DAY items to open-hours entries on every fair day', () => {
+    const swaps = ws.filter((w) => w.title.startsWith('Queer & Trans Clothing Swap'));
+    expect(swaps.map((w) => w.start)).toEqual([
+      '2026-07-10T11:00:00',
+      '2026-07-11T11:00:00',
+      '2026-07-12T11:00:00',
+    ]);
+    expect(swaps.every((w) => w.end.endsWith('19:00:00'))).toBe(true);
+    expect(swaps.every((w) => w.venueTitle === 'Rainbow Village · Community Village')).toBe(true);
+  });
+
+  it('stops at the footer and fails empty (not wrong) when the markers are missing', () => {
+    expect(ws.some((w) => w.title.includes('501(c)(3)'))).toBe(false);
+    expect(parseWorkshopsHtml('<html><body>totally different page</body></html>')).toEqual([]);
+  });
+
+  it('returns the board sorted by start', () => {
+    const starts = ws.map((w) => w.start);
+    expect(starts).toEqual([...starts].sort());
   });
 });


### PR DESCRIPTION
Adds the [Community Village workshops](https://www.oregoncountryfair.org/community-village-workshops/) (~80 across Fri/Sat/Sun) to the OCF picker.

- **`parseWorkshopsHtml`** turns the Elementor text-soup page into the same session shape as the lineup parser: day headers → fair dates, the 11:00–6:00 hour grid → PM-mapped one-hour slots, trailing-venue item lines (seven-venue fixed set, including venues wrapped into their own element), the `Noon–6pm,` span prefix, and the ALL DAY EVERY DAY section expanding to one 11 AM–7 PM entry per fair day. eventIds are deterministic `cv|date|time|slug` so favorites survive refreshes.
- Workshops carry `isWorkshop: true`, a `description` (rendered on Browse cards), and the existing `workshop` genre color; they ride the **existing snapshot pipeline** (the vibes.diy ops refresher fetches + parses both pages and writes one merged snapshot — vibes.diy#3492), so no backend change was needed.
- New **Workshops** tab (BrowseView reuse, filtered to `isWorkshop`); workshops stay out of the Artists grouping but flow through All Events, faves, Now/Up Next, friends, and ics unchanged.

Tests 61 → 104; parser verified byte-identical between the canonical copy and the ops copy against the live page (80/80 sessions, zero unresolved venues).

Validated on `qa/ocf-picker` (seeded via the extended refresher: 444 lineup + 80 workshop sessions, 2 chunks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn)_