### PR TITLE
ietf-picker: side meetings appear in All Sessions too

### DIFF
--- a/examples/ietf-picker/App.jsx
+++ b/examples/ietf-picker/App.jsx
@@ -596,9 +596,13 @@ export default function IetfAgendaPicker() {
   );
   const nextSessions = useMemo(() => upNextSessions(allEvents, nowTick), [allEvents, nowTick]);
 
+  // All Sessions spans the merged board — agenda sessions AND side meetings —
+  // so the side lane is browsable/searchable alongside official sessions (they
+  // carry a `side` lineup tag to stay distinguishable, and no acronym so the
+  // acronym match just no-ops for them).
   const filteredEvents = useMemo(
     () =>
-      events
+      allEvents
         .filter(
           (e) =>
             (e.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
@@ -606,7 +610,7 @@ export default function IetfAgendaPicker() {
             (selectedDay === 'all' || e.day === selectedDay)
         )
         .sort((a, b) => toMeetingDate(a.start) - toMeetingDate(b.start)),
-    [events, searchTerm, selectedDay]
+    [allEvents, searchTerm, selectedDay]
   );
 
   const favoriteEvents = useMemo(


### PR DESCRIPTION
The All Sessions (browse) tab was filtering the agenda `events` array only, so side meetings showed up in Now/Up Next, My Faves, and their own tab but not in the main browse list. Point `filteredEvents` at the merged `allEvents` board instead.

Side meetings carry a `side` lineup id, so they render with a teal **SIDE** chip to stay distinguishable from official sessions, and they're searchable by title (no acronym — the acronym match just no-ops). Groups stays agenda-only, which is correct: side meetings have no working-group acronym to group under.

One-line change; 97 tests green. Deployed live to `calendar/ietf-picker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn

---
_Generated by [Claude Code](https://claude.ai/code/session_01NKsSk1KJGVFVoNm4tPZaBn)_