### PR TITLE
meta-hub: LinkedIn article-card thumbnails via the Images API

### DIFF
--- a/examples/meta-hub/RUNBOOK.md
+++ b/examples/meta-hub/RUNBOOK.md
@@ -79,8 +79,8 @@ bullets). Five platforms publish:
   commentary (≤3000 chars, links clickable, hashtags work) plus an article
   card built from the request's `link` (falls back to the first URL in the
   caption), `title` (falls back to `slug`), and optional `description`.
-  LinkedIn's Posts API does **not** scrape the URL — the card is text-only
-  until an Images-API thumbnail upload lands (v2) — and its commentary is
+  LinkedIn's Posts API does **not** scrape the URL — you set the card fields
+  yourself — and its commentary is
   "little text format", so the backend escapes `\|{}@[]()<>*_~` (parens in
   prose otherwise 400 the post; `#` is left live, `@`-mention templates can't
   be authored from a caption). Synchronous, done in one tick; the permalink is
@@ -90,11 +90,29 @@ bullets). Five platforms publish:
   means bump it), and the post id arrives in the `x-restli-id` response
   header of an empty 201.
 
+  **Card thumbnail** (optional): supply the image bytes the same way Bluesky
+  does — inline **`thumbBase64`** (+ optional `thumbMime`, default
+  `image/jpeg`) on the request, since the backend can't fetch `*.vibes.diy`
+  card images (egress floor denylist, SSRF prevention), so the queuer inlines
+  them. The backend then runs LinkedIn's two-hop Images API — `POST
+/rest/images?action=initializeUpload` for a signed upload URL + image URN,
+  then a `PUT` of the bytes — and references the URN as
+  `content.article.thumbnail`. Best-effort, exactly like bsky: any
+  decode/init/PUT failure logs a `linkedin-thumb-skipped` oplog entry and the
+  post still goes out as the text+link card, never blocked. No status poll (a
+  `w_member_social` token can't GET images), so the URN is referenced
+  immediately and LinkedIn finishes processing async — an occasional
+  still-processing thumb is the accepted trade for never blocking the post.
+
   **Egress**: api.linkedin.com sends no CORS headers, so LinkedIn rides the
   egress **platform allowlist**
   (`vibes.diy/api/svc/intern/egress-platform-list.ts`), not the CORS lane.
   The dashboard's `linkedin lane` probe must show `live` — `denied` means the
-  api worker running that allowlist hasn't deployed (or was rolled back).
+  api worker running that allowlist hasn't deployed (or was rolled back). The
+  thumbnail upload needs two more allowlist entries beyond post/userinfo:
+  `POST /rest/images` (pinned to `?action=initializeUpload`) and `PUT`
+  `www.linkedin.com/dms-uploads/` — if those aren't deployed yet the thumbnail
+  is skipped (best-effort) and the text card still posts.
 
   **Token**: a 60-day **member** token — LinkedIn app associated with a
   LinkedIn Page, products "Share on LinkedIn" + "Sign In with LinkedIn using

--- a/examples/meta-hub/backend.js
+++ b/examples/meta-hub/backend.js
@@ -118,11 +118,11 @@ export function liEscape(s) {
 }
 
 // Build the article-share body, or return { error } for a bad request doc.
-// v1 is article-link posts ONLY: LinkedIn's Posts API does not scrape URLs
-// (docs are explicit — partners set title/description/thumbnail themselves),
-// and a thumbnail needs the Images API upload dance, which is v2. So the card
-// is text-only for now: source link + title (+ optional description).
-export function liPostBody(author, req) {
+// LinkedIn's Posts API does not scrape URLs (docs are explicit — partners set
+// title/description/thumbnail themselves), so the card carries exactly what the
+// request provides: source link + title + optional description, and an optional
+// `thumbnail` image URN (from liUploadThumb) for the card picture.
+export function liPostBody(author, req, thumbnail) {
   const text = req.caption || '';
   const link = req.link || (text.match(/https?:\/\/\S+/) || [])[0];
   if (!link)
@@ -150,6 +150,10 @@ export function liPostBody(author, req) {
           source: link,
           title: req.title || req.slug || link,
           ...(req.description ? { description: req.description } : {}),
+          // A `urn:li:image:…` from the Images API upload (liUploadThumb) gives
+          // the card a picture; LinkedIn never scrapes the URL, so without it
+          // the card is text-only. Best-effort — omitted on any upload failure.
+          ...(thumbnail ? { thumbnail } : {}),
         },
       },
       lifecycleState: 'PUBLISHED',
@@ -161,6 +165,72 @@ export function liPostBody(author, req) {
 // A dead LinkedIn token is an HTTP 401 (Meta's equivalent is code 190).
 export function liTokenDead(r) {
   return r.status === 401;
+}
+
+// --- LinkedIn Images API: article-card thumbnail upload ----------------------
+// Two hops, both Bearer server-to-server (no CORS → they ride the platform
+// egress allowlist, NOT the CORS lane):
+//   1. POST /rest/images?action=initializeUpload {initializeUploadRequest:{owner}}
+//      → { value: { uploadUrl, image } }; uploadUrl is a signed one-time URL on
+//      www.linkedin.com/dms-uploads/<opaque>, image is the urn:li:image:… .
+//   2. PUT the raw bytes to that uploadUrl.
+// The image URN then goes on content.article.thumbnail (see liPostBody). A
+// w_member_social token CANNOT GET /rest/images, so there is NO status poll —
+// we reference the URN immediately and LinkedIn finishes processing async.
+// Everything here is best-effort: the caller posts the text+link card on any
+// error rather than failing the post.
+async function liInitImageUpload(author, token) {
+  const r = await liFetch('rest/images?action=initializeUpload', {
+    method: 'POST',
+    body: { initializeUploadRequest: { owner: author } },
+    token,
+  });
+  if (!r.ok) return { error: r.message || r.egressDenied || `HTTP ${r.status}` };
+  const v = (r.data && r.data.value) || {};
+  if (!v.uploadUrl || !v.image) return { error: 'initializeUpload: missing uploadUrl/image' };
+  return { uploadUrl: v.uploadUrl, image: v.image };
+}
+
+// Raw fetch, not liFetch: the uploadUrl is a full signed URL on www.linkedin.com
+// (not an api.linkedin.com path) and must carry the image bytes, not the
+// version/restli JSON headers. Bearer auth per LinkedIn's upload contract.
+async function liPutImageBytes(uploadUrl, bytes, mimeType, token) {
+  let res;
+  try {
+    res = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': mimeType || 'application/octet-stream',
+      },
+      body: bytes,
+    });
+  } catch (e) {
+    return { error: `image PUT transport: ${String((e && e.message) || e)}` };
+  }
+  // A denied egress PUT (allowlist not deployed) comes back as a JSON marker.
+  if (res.status === 403) {
+    try {
+      const j = await res.json();
+      if (j && j.vibesEgressDenied) return { error: `image PUT egress denied: ${j.gate || true}` };
+    } catch {
+      /* not JSON — fall through to the generic status error */
+    }
+  }
+  if (!res.ok) return { error: `image PUT HTTP ${res.status}` };
+  return { ok: true };
+}
+
+// Orchestrate bytes → init → put → { image } URN, or { error }. Best-effort
+// caller (the linkedin publish branch) turns any error into a text-only post.
+async function liUploadThumb(req, images, author, token) {
+  const src = await cardThumbBytes(req, images);
+  if (!src.bytes) return { error: src.error };
+  const init = await liInitImageUpload(author, token);
+  if (init.error) return { error: init.error };
+  const put = await liPutImageBytes(init.uploadUrl, src.bytes, src.mimeType, token);
+  if (put.error) return { error: put.error };
+  return { image: init.image };
 }
 
 // --- Bluesky (AT Protocol): the sixth channel --------------------------------
@@ -242,14 +312,15 @@ async function bskyUploadBlobBytes(bytes, mimeType, accessJwt) {
   return { blob: data.blob };
 }
 
-// Get the card-thumbnail bytes for a request, or { error }. Bluesky never
-// scrapes the URL, so an external embed is imageless without an uploaded blob.
-// PRIMARY source is `thumbBase64` embedded in the doc — the backend CANNOT
-// fetch our card images: `*.vibes.diy` is on the egress FLOOR denylist (#3048,
-// SSRF prevention, beats every policy), so the queuer (which can read
-// good.vibes.diy) inlines the bytes. FALLBACK is a URL in `images[0]`, which
-// only works for non-floor, CORS-open hosts.
-async function bskyThumbBytes(req, images) {
+// Get the card-thumbnail bytes for a request, or { error }. Platform-neutral:
+// both Bluesky (uploadBlob) and LinkedIn (Images API) upload the same card
+// bytes, they just differ in the upload call. Neither scrapes the URL, so the
+// card is imageless without an upload. PRIMARY source is `thumbBase64` embedded
+// in the doc — the backend CANNOT fetch our card images: `*.vibes.diy` is on
+// the egress FLOOR denylist (#3048, SSRF prevention, beats every policy), so
+// the queuer (which can read good.vibes.diy) inlines the bytes. FALLBACK is a
+// URL in `images[0]`, which only works for non-floor, CORS-open hosts.
+async function cardThumbBytes(req, images) {
   if (req.thumbBase64) {
     try {
       const bytes = Uint8Array.from(atob(req.thumbBase64), (c) => c.charCodeAt(0));
@@ -686,7 +757,7 @@ async function advanceRequest(ctx, req, t) {
       // Bytes come from thumbBase64 (or an images[0] URL fallback).
       if (req.thumbBase64 || images[0]) {
         try {
-          const src = await bskyThumbBytes(req, images);
+          const src = await cardThumbBytes(req, images);
           if (src.bytes) {
             const up = await bskyUploadBlobBytes(src.bytes, src.mimeType, s.accessJwt);
             if (up.blob) body.record.embed.external.thumb = up.blob;
@@ -725,15 +796,33 @@ async function advanceRequest(ctx, req, t) {
       return;
     }
     // LinkedIn: synchronous like fbpage — one POST /rest/posts, no containers.
-    // Article-link shares only for now (see liPostBody); images are v2.
+    // An article-link share, optionally with a card thumbnail uploaded via the
+    // Images API (best-effort — see below). Extra images beyond the thumb are
+    // ignored (the article embed carries a single thumbnail).
     if (platform === 'linkedin') {
-      if (images.length > 0) {
-        return save({
-          status: 'error',
-          error: 'linkedin is article-link only for now — image posts need the Images API (v2)',
-        });
+      // Best-effort card thumbnail: NOTHING here may block the post (same
+      // philosophy as bsky). Bytes come from thumbBase64 (or an images[0] URL
+      // fallback); upload via the Images API and reference the returned URN.
+      // Any failure → log `linkedin-thumb-skipped` and post the text+link card.
+      let thumbUrn = null;
+      if (req.thumbBase64 || images[0]) {
+        try {
+          const up = await liUploadThumb(req, images, t.igUserId, t.token);
+          if (up.image) thumbUrn = up.image;
+          else await log(ctx, { op: 'linkedin-thumb-skipped', slug: req.slug, error: up.error });
+        } catch (e) {
+          try {
+            await log(ctx, {
+              op: 'linkedin-thumb-skipped',
+              slug: req.slug,
+              error: `thumb path threw: ${String((e && e.message) || e)}`,
+            });
+          } catch {
+            /* give up on logging; the post must still go out */
+          }
+        }
       }
-      const body = liPostBody(t.igUserId, req);
+      const body = liPostBody(t.igUserId, req, thumbUrn);
       if (body.error) return save({ status: 'error', error: body.error });
       const r = await liFetch('rest/posts', { method: 'POST', body: body.post, token: t.token });
       if (!r.ok) return fail(r, 'linkedin post');

--- a/examples/meta-hub/backend.test.js
+++ b/examples/meta-hub/backend.test.js
@@ -96,6 +96,18 @@ describe('liPostBody — article-share request body', () => {
     });
     expect(error).toMatch(/max 3000/);
   });
+  it('attaches a thumbnail image URN to the article when one is passed', () => {
+    const { post } = liPostBody(
+      author,
+      { slug: 's', caption: 'https://good.vibes.diy/blog/s', title: 'T' },
+      'urn:li:image:C4E10AQF'
+    );
+    expect(post.content.article.thumbnail).toBe('urn:li:image:C4E10AQF');
+  });
+  it('omits thumbnail when none is passed (text-only card)', () => {
+    const { post } = liPostBody(author, { slug: 's', caption: 'https://good.vibes.diy/blog/s' });
+    expect(post.content.article.thumbnail).toBeUndefined();
+  });
 });
 
 describe('liFetch — LinkedIn REST client', () => {
@@ -827,6 +839,124 @@ describe('scheduled — shared-path invariants (ig/threads/fbpage parity)', () =
     expect(r.status).toBe('done'); // NOT errored
     expect(sentRecord.record.embed.external.thumb).toBeUndefined();
     expect(ctx.dbs.oplog.some((d) => d.op === 'bsky-thumb-skipped')).toBe(true);
+  });
+
+  const liToken = (over = {}) => ({
+    _id: 'token-linkedin',
+    kind: 'token',
+    platform: 'linkedin',
+    token: 'LITOK',
+    igUserId: 'urn:li:person:abc',
+    username: 'Me',
+    refreshedAt: daysAgo(0),
+    ...over,
+  });
+
+  it('linkedin uploads thumbBase64 via the Images API and references the image URN on the article', async () => {
+    let sentPost = null;
+    let putInit = null;
+    const calls = routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      // initializeUpload → signed uploadUrl + image URN
+      [
+        'api.linkedin.com/rest/images',
+        () =>
+          json({
+            value: {
+              uploadUrl: 'https://www.linkedin.com/dms-uploads/C4E10AQF/uploaded-image/0?ca=x',
+              image: 'urn:li:image:C4E10AQF',
+            },
+          }),
+      ],
+      // the byte PUT to the signed URL
+      [
+        'www.linkedin.com/dms-uploads',
+        (url, init) => {
+          putInit = init;
+          return new Response(null, { status: 201 });
+        },
+      ],
+      // the post create — capture the body, return the share URN in x-restli-id
+      [
+        'api.linkedin.com/rest/posts',
+        (url, init) => {
+          sentPost = JSON.parse(init.body);
+          return new Response(null, { status: 201, headers: { 'x-restli-id': 'urn:li:share:77' } });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [liToken()],
+      requests: [
+        {
+          _id: 'r-li',
+          kind: 'publish-request',
+          platform: 'linkedin',
+          slug: 's',
+          images: [],
+          thumbBase64: Buffer.from([1, 2, 3, 4]).toString('base64'),
+          thumbMime: 'image/jpeg',
+          caption: 'hook https://good.vibes.diy/blog/s?src=linkedin',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-li');
+    expect(r.status).toBe('done');
+    expect(r.permalink).toBe('https://www.linkedin.com/feed/update/urn:li:share:77');
+    // the uploaded image URN rode onto the article thumbnail
+    expect(sentPost.content.article.thumbnail).toBe('urn:li:image:C4E10AQF');
+    // PUT carried the declared mime; no fetch to a floor-denied platform host
+    expect(putInit.method).toBe('PUT');
+    expect(putInit.headers['content-type']).toBe('image/jpeg');
+    expect(calls.some((c) => c.url.includes('good.vibes.diy'))).toBe(false);
+    // upload happened before the post
+    const iInit = calls.findIndex((c) => c.url.includes('rest/images'));
+    const iPost = calls.findIndex((c) => c.url.includes('rest/posts'));
+    expect(iInit).toBeGreaterThanOrEqual(0);
+    expect(iInit).toBeLessThan(iPost);
+  });
+
+  it('linkedin posts WITHOUT a thumbnail when initializeUpload fails (best-effort), logging linkedin-thumb-skipped', async () => {
+    let sentPost = null;
+    routedFetch([
+      META_PROBE_LIVE,
+      LI_LANE_LIVE,
+      ['api.linkedin.com/rest/images', () => json({ serviceErrorCode: 0, message: 'nope' }, 500)],
+      [
+        'api.linkedin.com/rest/posts',
+        (url, init) => {
+          sentPost = JSON.parse(init.body);
+          return new Response(null, { status: 201, headers: { 'x-restli-id': 'urn:li:share:88' } });
+        },
+      ],
+    ]);
+    const ctx = mockCtx({
+      vault: [liToken()],
+      requests: [
+        {
+          _id: 'r-li',
+          kind: 'publish-request',
+          platform: 'linkedin',
+          slug: 's',
+          images: [],
+          thumbBase64: Buffer.from([1, 2, 3, 4]).toString('base64'),
+          caption: 'hook https://good.vibes.diy/blog/s?src=linkedin',
+          title: 'T',
+          status: 'pending',
+          attempts: 0,
+        },
+      ],
+    });
+    await scheduled({}, ctx);
+    const r = ctx.dbs.requests.find((d) => d._id === 'r-li');
+    expect(r.status).toBe('done'); // NOT errored — the post still goes out
+    expect(sentPost.content.article.thumbnail).toBeUndefined();
+    expect(ctx.dbs.oplog.some((d) => d.op === 'linkedin-thumb-skipped')).toBe(true);
   });
 
   it('bsky posts even if the skip-logging itself throws (thumb path is fully swallowed)', async () => {


### PR DESCRIPTION
## What

Gives the meta-hub example's LinkedIn posts a **card thumbnail** (they were text + link only). Piggybacks the exact plumbing Bluesky already uses for its card thumb, so the two platforms now share the byte-delivery path.

## How

- **Shared byte delivery**: `bskyThumbBytes` → renamed `cardThumbBytes` (platform-neutral). The queuer inlines the card image as `thumbBase64` on the request because the backend **can't fetch `*.vibes.diy`** (egress floor denylist, SSRF prevention); both platforms decode from there.
- **LinkedIn Images API** (`liInitImageUpload` / `liPutImageBytes` / `liUploadThumb`): `POST /rest/images?action=initializeUpload` → signed `uploadUrl` + `urn:li:image:…`, then `PUT` the bytes, then reference the URN as `content.article.thumbnail` (`liPostBody` gained an optional `thumbnail` arg).
- **Best-effort, mirroring bsky**: the whole thumbnail path is wrapped so nothing can block the post — any decode/init/PUT failure logs a `linkedin-thumb-skipped` oplog entry and the text+link card still goes out.
- **No new token/scope** (`w_member_social` covers image upload) and **no status poll** (that token can't GET images) — the URN is referenced immediately and LinkedIn processes async. An occasional still-processing thumb is the accepted trade for never blocking the post.

## Dependency

The upload needs two egress allowlist entries — `POST /rest/images` (pinned to `?action=initializeUpload`) and `PUT www.linkedin.com/dms-uploads/` — which ship in the paired platform PR **VibesDIY/vibes.diy#3552**. Until that deploys, the `linkedin lane` stays post-only and the thumbnail is skipped (best-effort); the text card still posts. So this can merge independently and lights up when the egress PR ships.

## Tests

48 (was 44): `cardThumbBytes` rename keeps the bsky thumb tests green; new `liPostBody` thumbnail cases plus two `scheduled`-handler tests — the happy path (thumbBase64 → initializeUpload → PUT → article `thumbnail` carries the URN, no floor-denied fetch, upload-before-post ordering) and the best-effort fallback (initializeUpload fails → post still `done`, no thumbnail, `linkedin-thumb-skipped` logged). RUNBOOK updated.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EGGgqUdvEpa4oZHDSBEcjm)_