### PR TITLE
mention-hub go-live fixes: like-on-accept, reply screenshots, DM PDS routing

### DIFF
--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -30,6 +30,8 @@ const BSKY_HOST = 'https://bsky.social';
 // through. Everything else (notifications, createRecord, DMs) rides parity.
 export const BSKY_MAX_TEXT = 300; // code points, conservative for ZWJ emoji
 const MAX_REPLY_ATTEMPTS = 5;
+const MAX_LIKE_ATTEMPTS = 3;
+const MAX_SCREENSHOT_WAITS = 5; // ticks to wait for the publish-queue screenshot before replying imageless
 // Bluesky DMs (chat.bsky.convo.*) are served by proxying through the PDS with
 // this service header — the same way the official web client sends DMs, so the
 // call still rides the CORS-open egress lane. The app-password must have been
@@ -204,12 +206,28 @@ export function bskyPermalink(uri, handle) {
 // dead-lineage fallback only.
 const BSKY_SESSION_FRESH_MS = 30 * 60000;
 
+// The account's PDS host, read from the session didDoc. chat.bsky.convo.* must
+// be sent HERE (with the atproto-proxy header), NOT to the bsky.social
+// entryway: the entryway transparently forwards com.atproto.repo.* (so
+// likes/replies work against it) but does not proxy authed chat, returning
+// "Method Not Implemented" (#3591). createSession/refreshSession both return the
+// didDoc; the PDS is its AtprotoPersonalDataServer service endpoint.
+export function pdsHostFromDidDoc(didDoc) {
+  const services = didDoc && Array.isArray(didDoc.service) ? didDoc.service : [];
+  const pds = services.find((s) => s && (s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'));
+  const ep = pds && typeof pds.serviceEndpoint === 'string' ? pds.serviceEndpoint : '';
+  return /^https:\/\//.test(ep) ? ep.replace(/\/+$/, '') : null;
+}
+
 async function bskySession(ctx, t) {
   const persist = async (data) => {
     const next = {
       ...t,
       did: data.did || t.did,
       handle: data.handle || t.handle,
+      // Persist the PDS host so chat DMs route correctly (#3591). Keep any
+      // previously-captured host if this response omits the didDoc.
+      pdsHost: pdsHostFromDidDoc(data.didDoc) || t.pdsHost || null,
       accessJwt: data.accessJwt,
       refreshJwt: data.refreshJwt,
       refreshedAt: new Date().toISOString(),
@@ -244,6 +262,21 @@ async function bskySession(ctx, t) {
   });
   if (!r.ok) return { r };
   return persist(r.data);
+}
+
+// Backfill the account PDS host when the session didn't carry a didDoc —
+// refreshSession commonly omits it, so `pdsHost` would otherwise only populate
+// on a credential re-paste (createSession). describeRepo is unauthenticated,
+// works on the entryway, and returns the didDoc. Runs once; no-ops thereafter.
+async function ensurePdsHost(ctx, t) {
+  if (t.pdsHost || !t.did) return t.pdsHost || null;
+  const r = await bskyFetch(`com.atproto.repo.describeRepo?repo=${encodeURIComponent(t.did)}`);
+  const host = r.ok ? pdsHostFromDidDoc(r.data && r.data.didDoc) : null;
+  if (!host) return null;
+  const next = { ...t, pdsHost: host };
+  await ctx.db.put(next, { db: 'vault' });
+  Object.assign(t, next); // later calls this tick see the backfilled host
+  return host;
 }
 
 // --- Pure mention-triage helpers (unit-tested in backend.test.js) ------------
@@ -747,31 +780,47 @@ async function enrichToken(ctx, t) {
 // Fetch the publish screenshot and turn it into an images embed. Best-effort:
 // any failure (egress-blocked, not yet captured, wrong content type) degrades
 // to the external link-card embed — the reply still ships.
-async function screenshotEmbed(m, accessJwt) {
-  if (!m.screenshotUrl) return null;
+// Fetch the app screenshot and upload it as a Bluesky image blob. Returns a
+// discriminated result so the reply can WAIT for a not-yet-captured screenshot
+// (the blog engine's wait-for-media-ready pattern) instead of posting an
+// imageless card the moment the app serves:
+//   { embed }         — ready and uploaded (app.bsky.embed.images)
+//   { pending: true } — not captured yet; retry next tick. The publish queue
+//                       writes the JPEG a beat after the app first answers 200,
+//                       so `built` can briefly precede the screenshot.
+//   { pending: false }— present but unusable (oversized / upload rejected);
+//                       don't spin — fall straight to the link card.
+// Bytes ride the CORS-parity egress lane: the screenshot host serves image/jpeg
+// with `Access-Control-Allow-Origin: *`, so this is a browser-faithful GET.
+async function fetchScreenshotEmbed(m, accessJwt) {
+  if (!m.screenshotUrl) return { pending: false };
   let res;
   try {
     res = await fetch(m.screenshotUrl);
   } catch {
-    return null;
+    return { pending: true }; // transient / not-yet-served
   }
   const contentType = (res.headers && res.headers.get && res.headers.get('content-type')) || '';
-  if (!res.ok || !contentType.startsWith('image/')) return null;
+  if (res.status === 404) return { pending: true }; // queue hasn't written it yet
+  if (!res.ok || !contentType.startsWith('image/')) return { pending: true }; // placeholder/HTML → still settling
   const bytes = await res.arrayBuffer();
+  if (bytes.byteLength === 0) return { pending: true };
   // Bluesky rejects blobs >~1MB; the publish screenshot is a q85 720p JPEG
-  // (well under), but guard anyway rather than fail the createRecord.
-  if (bytes.byteLength === 0 || bytes.byteLength > 950000) return null;
+  // (well under), but a giant one won't shrink by waiting — give up on the image.
+  if (bytes.byteLength > 950000) return { pending: false };
   const up = await bskyUploadBlob(bytes, contentType, accessJwt);
-  if (!up.ok) return null;
+  if (!up.ok) return { pending: false };
   return {
-    $type: 'app.bsky.embed.images',
-    images: [
-      {
-        image: up.blob,
-        alt: 'Screenshot of the app built from this post',
-        aspectRatio: { width: 1280, height: 720 },
-      },
-    ],
+    embed: {
+      $type: 'app.bsky.embed.images',
+      images: [
+        {
+          image: up.blob,
+          alt: 'Screenshot of the app built from this post',
+          aspectRatio: { width: 1280, height: 720 },
+        },
+      ],
+    },
   };
 }
 
@@ -787,10 +836,23 @@ async function replyToMention(ctx, m, t, accessJwt) {
     return save({ status: 'error', error: `reply gave up after ${MAX_REPLY_ATTEMPTS} attempts` });
   }
   try {
+    // Prefer the app screenshot as a full image embed; wait a few ticks for the
+    // publish queue to write it before settling for a bare link card, so the
+    // reply reliably shows what was built (the blog engine's media-ready gate).
+    const shot = await fetchScreenshotEmbed(m, accessJwt);
+    if (!shot.embed && shot.pending && (m.screenshotWaits || 0) < MAX_SCREENSHOT_WAITS) {
+      await log(ctx, { op: 'reply-awaiting-screenshot', uri: m.uri, waits: (m.screenshotWaits || 0) + 1 });
+      // Defer without consuming a hard reply attempt; the doc stays `built` so
+      // next tick re-picks it. Bounded by MAX_SCREENSHOT_WAITS.
+      return ctx.db.put(
+        { ...m, screenshotWaits: (m.screenshotWaits || 0) + 1, updatedAt: new Date().toISOString() },
+        { db: 'requests' }
+      );
+    }
     // The fallback card is constant text like everything else we post: the
     // no-echo invariant covers embed metadata too — untrusted prompt text
     // must never ride into our outbound post body (Charlie review, #3329).
-    const embed = (await screenshotEmbed(m, accessJwt)) || {
+    const embed = shot.embed || {
       $type: 'app.bsky.embed.external',
       external: {
         uri: m.vibeUrl,
@@ -845,7 +907,7 @@ async function replyToMention(ctx, m, t, accessJwt) {
 // non-follower DMs, or a credential without DM scope, simply never gets the
 // nudge; the public reply already carried the live link). The doc stays
 // `replied` either way — the DM is an add-on, not a state.
-async function sendClaimDm(ctx, m, accessJwt) {
+async function sendClaimDm(ctx, m, accessJwt, pdsHost) {
   const attempts = (m.dmAttempts || 0) + 1;
   const save = (patch) =>
     ctx.db.put(
@@ -856,13 +918,13 @@ async function sendClaimDm(ctx, m, accessJwt) {
   const dm = buildClaimDm({ mention: m });
   if (dm.error) return save({ dmError: dm.error });
 
-  const conv = await bskyFetch(
-    `chat.bsky.convo.getConvoForMembers?members=${encodeURIComponent(m.authorDid)}`,
-    {
-      token: accessJwt,
-      proxy: BSKY_CHAT_PROXY,
-    }
-  );
+  // chat.bsky.convo.* must hit the account's own PDS, not the entryway (#3591).
+  const chatHost = pdsHost || BSKY_HOST;
+  const conv = await bskyFetch(`chat.bsky.convo.getConvoForMembers?members=${encodeURIComponent(m.authorDid)}`, {
+    token: accessJwt,
+    proxy: BSKY_CHAT_PROXY,
+    host: chatHost,
+  });
   const convoId = conv.ok ? conv.data.convo && conv.data.convo.id : null;
   if (!convoId) {
     await log(ctx, {
@@ -878,6 +940,7 @@ async function sendClaimDm(ctx, m, accessJwt) {
     body: { convoId, message: { text: dm.text, facets: dm.facets } },
     token: accessJwt,
     proxy: BSKY_CHAT_PROXY,
+    host: chatHost,
   });
   if (!r.ok) {
     await log(ctx, {
@@ -1081,6 +1144,79 @@ async function githubDispatch(ctx, token, queued) {
 }
 
 // Fire the builder lane on demand when mentions are waiting. The GitHub PAT
+// --- Accept acknowledgement: like the request post -------------------------
+// The first visible signal to a requester that we're building their vibe: as
+// soon as a mention clears the gates (status `pending-build`), like the post.
+// It fires before the build even dispatches — an instant "got it, on it" — and
+// is quiet + bounded like every other outbound call.
+
+// Pure like record (unit-tested). A like is a record in our own repo pointing
+// at the requester's post by strong ref (uri + cid).
+export function buildLikeRecord({ uri, cid, createdAt }) {
+  if (!uri || !cid) return { error: 'missing subject uri/cid' };
+  return { record: { $type: 'app.bsky.feed.like', subject: { uri, cid }, createdAt } };
+}
+
+// Like-state lives in its OWN doc (`like-<mentionId>` in the oplog db), NOT on
+// the mention doc. The mention doc is co-written by the builder — it claims work
+// with a last-write-wins `status: building` + fresh `updatedAt`. Any like write
+// to the mention doc races that claim: re-reading narrows but can't close the
+// read-to-write window (the builder can land between our query and put), and a
+// stale write would revert the claim and lose the recovery heartbeat (#60 /
+// Charlie review on #61). Keeping like-state in a separate doc means the like
+// path NEVER writes the mention doc, so there is no window to lose a claim in.
+const likeStateId = (mentionId) => `like-${mentionId}`;
+
+// Like one accepted mention. Records `likedAt` on success; on failure records
+// `likeError` and bumps `likeAttempts` (bounded by MAX_LIKE_ATTEMPTS). All
+// writes target the mention's like-state doc — never the mention doc itself.
+async function likeMention(ctx, m, accessJwt, botDid) {
+  const stateId = likeStateId(m._id);
+  const prev = (await ctx.db.query({ db: 'oplog' })).find((d) => d._id === stateId) || {
+    _id: stateId,
+    kind: 'like-state',
+    mentionId: m._id,
+    likeAttempts: 0,
+  };
+  const write = (patch) =>
+    ctx.db.put({ ...prev, kind: 'like-state', mentionId: m._id, likeAttempts: (prev.likeAttempts || 0) + 1, ...patch }, { db: 'oplog' });
+
+  const built = buildLikeRecord({ uri: m.uri, cid: m.cid, createdAt: new Date().toISOString() });
+  if (built.error) return write({ likeError: built.error });
+  const r = await bskyFetch('com.atproto.repo.createRecord', {
+    method: 'POST',
+    body: { repo: botDid, collection: 'app.bsky.feed.like', record: built.record },
+    token: accessJwt,
+  });
+  if (!r.ok) {
+    await log(ctx, { op: 'like-failed', uri: m.uri, error: r.message || r.egressDenied || r.transport });
+    return write({ likeError: r.message || r.egressDenied || 'like failed' });
+  }
+  await log(ctx, { op: 'like-sent', uri: m.uri });
+  await write({ likedAt: new Date().toISOString(), likeError: null, likeUri: r.data && r.data.uri });
+}
+
+// Sweep newly-accepted requests and like the ones we haven't yet. Scoped to
+// `pending-build` (the pre-build acceptance state) so it fires the same tick a
+// mention is accepted and stops once the runner claims it. Idempotency + the
+// attempt bound are read from the per-mention like-state docs, so the sweep
+// only READS the mention docs — a like that failed retries next tick, bounded
+// by MAX_LIKE_ATTEMPTS.
+async function likeAcceptedMentions(ctx, accessJwt, botDid) {
+  const mentions = (await ctx.db.query({ db: 'requests' })).filter(
+    (d) => d.kind === 'mention' && d.status === 'pending-build'
+  );
+  const stateById = new Map(
+    (await ctx.db.query({ db: 'oplog' })).filter((d) => d.kind === 'like-state').map((d) => [d.mentionId, d])
+  );
+  for (const m of mentions) {
+    const st = stateById.get(m._id);
+    if (st && st.likedAt) continue; // already liked
+    if (st && (st.likeAttempts || 0) >= MAX_LIKE_ATTEMPTS) continue; // gave up
+    await likeMention(ctx, m, accessJwt, botDid);
+  }
+}
+
 // lives in the same write-only vault as the Bluesky credential (#3529): pasted
 // on the dashboard, never synced to any browser, read here in admin mode.
 // Dark until it's pasted — a missing token no-ops silently.
@@ -1141,6 +1277,8 @@ export async function scheduled(event, ctx) {
     });
     return;
   }
+  // Resolve the account PDS host once (needed to route claim DMs, #3591).
+  await ensurePdsHost(ctx, s.t);
 
   const requestsAll = await ctx.db.query({ db: 'requests' });
   const existing = requestsAll.filter((d) => d.kind === 'mention');
@@ -1277,13 +1415,19 @@ export async function scheduled(event, ctx) {
     await noteListenerState(ctx, { solLastPollAt: nowIso, solNewDocs: solNew });
   }
 
-  // 2. Fire the builder lane on demand if mentions are queued (#3529) — the
+  // 2. Acknowledge each accepted request by liking its post — the first
+  // visible signal to the requester that we're building it, before the build
+  // even dispatches. Re-queries (not the start-of-tick snapshot) so mentions
+  // accepted this very tick get liked now.
+  await likeAcceptedMentions(ctx, s.accessJwt, s.t.did);
+
+  // 3. Fire the builder lane on demand if mentions are queued (#3529) — the
   // event-driven replacement for the polling cron. Debounced; dark until the
   // GITHUB_DISPATCH_TOKEN secret exists. Both lanes share this dispatcher, but
   // solicitation docs only count while the lane is active (kill-switch).
   await maybeDispatchBuilder(ctx, { includeSolicitations: solActive });
 
-  // 3. Reply to verified-live builds (the builder lane sets `built` only after
+  // 4. Reply to verified-live builds (the builder lane sets `built` only after
   // the published vibe answered 200). Each lane has its own per-tick reply cap.
   const builtMentions = existing.filter((d) => d.status === 'built' && d.vibeUrl);
   for (const m of builtMentions.slice(0, cfg.maxRepliesPerTick)) {
@@ -1298,7 +1442,7 @@ export async function scheduled(event, ctx) {
     }
   }
 
-  // 4. DM the requester a private claim (remix) link once the public reply has
+  // 5. DM the requester a private claim (remix) link once the public reply has
   // landed — an add-on to the public reply, not a new state. Docs replied this
   // tick are picked up next tick (this uses the start-of-tick snapshot, like
   // the reply loop). Quiet failure, bounded by MAX_DM_ATTEMPTS.
@@ -1307,6 +1451,6 @@ export async function scheduled(event, ctx) {
       d.status === 'replied' && d.vibeUrl && !d.dmSentAt && (d.dmAttempts || 0) < MAX_DM_ATTEMPTS
   );
   for (const m of claimable.slice(0, cfg.maxDmsPerTick)) {
-    await sendClaimDm(ctx, m, s.accessJwt);
+    await sendClaimDm(ctx, m, s.accessJwt, s.t.pdsHost);
   }
 }

--- a/examples/mention-hub/backend.test.js
+++ b/examples/mention-hub/backend.test.js
@@ -16,6 +16,8 @@ import {
   claimUrlFor,
   shouldDispatchBuilder,
   dispatchableWork,
+  buildLikeRecord,
+  pdsHostFromDidDoc,
   parseIntentVerdict,
   SOLICITATION_DEFAULTS,
   loadSolicitationConfig,
@@ -421,7 +423,7 @@ describe('scheduled — tick wiring', () => {
     expect(state.lastError).toBeNull();
   });
 
-  it('replies to a built mention with the link card fallback and marks it replied', async () => {
+  it('replies with the link card fallback once the screenshot wait is exhausted', async () => {
     const f = fakeDb();
     f.seed('vault', freshToken);
     f.seed('requests', {
@@ -436,6 +438,7 @@ describe('scheduled — tick wiring', () => {
       vibeUrl: 'https://vibes.diy/vibe/mentions/m-3lcaaa',
       screenshotUrl: 'https://m-3lcaaa--mentions.vibesdiy.app/screenshot.png',
       attempts: 0,
+      screenshotWaits: 5, // wait budget exhausted → post the imageless card now
       day: '2026-07-06',
       createdAt: NOW,
     });
@@ -444,7 +447,7 @@ describe('scheduled — tick wiring', () => {
       'fetch',
       xrpcStub([
         ['listNotifications', () => json({ notifications: [] })],
-        // Screenshot fetch fails → the reply must degrade to the external card.
+        // Screenshot still missing after the wait budget → degrade to the card.
         ['screenshot.png', () => new Response('nope', { status: 404 })],
         [
           'createRecord',
@@ -465,6 +468,87 @@ describe('scheduled — tick wiring', () => {
     // No-echo invariant covers embed metadata too: the card must be constant
     // text, never the requester's prompt (Charlie review, #3329).
     expect(JSON.stringify(created.record.embed)).not.toContain('pomodoro');
+  });
+
+  it('defers the reply while the screenshot is still pending, bumping screenshotWaits', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    f.seed('requests', {
+      _id: 'mention-did:plc:alice-3wait',
+      kind: 'mention',
+      status: 'built',
+      uri: 'at://did:plc:alice/app.bsky.feed.post/3wait',
+      cid: 'cid-3wait',
+      rootUri: 'at://did:plc:alice/app.bsky.feed.post/3wait',
+      rootCid: 'cid-3wait',
+      prompt: 'a drum machine',
+      vibeUrl: 'https://vibes.diy/vibe/mentions/m-3wait',
+      screenshotUrl: 'https://m-3wait--mentions.cli-v2.vibesdiy.net/screenshot.png',
+      attempts: 0,
+      day: '2026-07-06',
+      createdAt: NOW,
+    });
+    const createSpy = vi.fn(() => json({ uri: 'at://x', cid: 'c' }));
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [] })],
+        // Screenshot not written yet: reply must WAIT, not post an imageless card.
+        ['screenshot.png', () => new Response('nope', { status: 404 })],
+        ['createRecord', createSpy],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    const m = f.dbs.requests.get('mention-did:plc:alice-3wait');
+    expect(createSpy).not.toHaveBeenCalled(); // no reply posted this tick
+    expect(m.status).toBe('built'); // still awaiting the screenshot
+    expect(m.screenshotWaits).toBe(1);
+    expect(m.attempts).toBe(0); // a wait is not a hard reply attempt
+  });
+
+  it('embeds the screenshot once it lands after an earlier wait', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    f.seed('requests', {
+      _id: 'mention-did:plc:alice-3land',
+      kind: 'mention',
+      status: 'built',
+      uri: 'at://did:plc:alice/app.bsky.feed.post/3land',
+      cid: 'cid-3land',
+      rootUri: 'at://did:plc:alice/app.bsky.feed.post/3land',
+      rootCid: 'cid-3land',
+      prompt: 'a maze game',
+      vibeUrl: 'https://vibes.diy/vibe/mentions/m-3land',
+      screenshotUrl: 'https://m-3land--mentions.cli-v2.vibesdiy.net/screenshot.png',
+      attempts: 0,
+      screenshotWaits: 2, // already waited twice; the screenshot is ready now
+      day: '2026-07-06',
+      createdAt: NOW,
+    });
+    let created;
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [] })],
+        [
+          'screenshot.png',
+          () => new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { 'content-type': 'image/jpeg' } }),
+        ],
+        ['uploadBlob', () => json({ blob: { $type: 'blob', ref: { $link: 'bafk' }, mimeType: 'image/jpeg', size: 3 } })],
+        [
+          'createRecord',
+          (_url, init) => {
+            created = JSON.parse(init.body);
+            return json({ uri: 'at://did:plc:self/app.bsky.feed.post/3rep', cid: 'cid-rep' });
+          },
+        ],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    const m = f.dbs.requests.get('mention-did:plc:alice-3land');
+    expect(m.status).toBe('replied');
+    expect(created.record.embed.$type).toBe('app.bsky.embed.images');
+    expect(created.record.embed.images[0].image.ref.$link).toBe('bafk');
   });
 
   it('uploads the screenshot and embeds it as an image when the fetch succeeds', async () => {
@@ -909,6 +993,74 @@ describe('scheduled — claim DM wiring', () => {
   });
   const noNewMentions = (routes = []) =>
     xrpcStub([['listNotifications', () => json({ notifications: [] })], ...routes]);
+
+  it('routes chat calls to the account PDS host, not the entryway (#3591)', async () => {
+    const f = fakeDb();
+    const pdsHost = 'https://gomphidius.us-west.host.bsky.network';
+    f.seed('vault', { ...freshToken, pdsHost });
+    f.seed('requests', repliedDoc());
+    const urls = [];
+    vi.stubGlobal(
+      'fetch',
+      noNewMentions([
+        [
+          'getConvoForMembers',
+          (url) => {
+            urls.push(String(url));
+            return json({ convo: { id: 'convo-1' } });
+          },
+        ],
+        [
+          'sendMessage',
+          (url) => {
+            urls.push(String(url));
+            return json({ id: 'msg1' });
+          },
+        ],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    expect(urls).toHaveLength(2);
+    for (const u of urls) expect(u.startsWith(`${pdsHost}/xrpc/chat.bsky.convo.`)).toBe(true);
+    expect(f.dbs.requests.get('mention-did:plc:alice-3lcaaa').dmSentAt).toBeTruthy();
+  });
+
+  it('backfills pdsHost via describeRepo when the token lacks it, then routes the DM there', async () => {
+    const f = fakeDb();
+    const pdsHost = 'https://gomphidius.us-west.host.bsky.network';
+    f.seed('vault', freshToken); // no pdsHost yet (refreshSession omitted the didDoc)
+    f.seed('requests', repliedDoc());
+    const chatUrls = [];
+    vi.stubGlobal(
+      'fetch',
+      noNewMentions([
+        [
+          'describeRepo',
+          () => json({ did: 'did:plc:self', didDoc: { service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: pdsHost }] } }),
+        ],
+        [
+          'getConvoForMembers',
+          (url) => {
+            chatUrls.push(String(url));
+            return json({ convo: { id: 'convo-1' } });
+          },
+        ],
+        [
+          'sendMessage',
+          (url) => {
+            chatUrls.push(String(url));
+            return json({ id: 'msg1' });
+          },
+        ],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    // pdsHost is persisted on the token and the chat calls target it.
+    expect(f.dbs.vault.get('token-bsky').pdsHost).toBe(pdsHost);
+    expect(chatUrls).toHaveLength(2);
+    for (const u of chatUrls) expect(u.startsWith(`${pdsHost}/xrpc/chat.bsky.convo.`)).toBe(true);
+    expect(f.dbs.requests.get('mention-did:plc:alice-3lcaaa').dmSentAt).toBeTruthy();
+  });
 
   it('DMs the requester a claim link and stamps dmSentAt', async () => {
     const f = fakeDb();
@@ -1361,6 +1513,7 @@ describe('scheduled — solicitation lane wiring', () => {
       vibeUrl: 'https://vibes.diy/vibe/mentions/bird-bingo',
       screenshotUrl: 'https://bird-bingo--mentions.vibesdiy.app/screenshot.png',
       attempts: 0,
+      screenshotWaits: 5, // wait budget exhausted → post the imageless card now
       day: '2026-07-06',
       createdAt: NOW,
     });
@@ -1542,5 +1695,210 @@ describe('scheduled — solicitation kill switch freezes in-flight work', () => 
     );
     await scheduled({}, f.ctx);
     expect(dispatchSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe('like-on-accept — acknowledge the request before building (#3323)', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  const freshToken = {
+    _id: 'token-bsky',
+    kind: 'token',
+    platform: 'bsky',
+    token: 'vibesdiy.bsky.social:aaaa-bbbb-cccc-dddd',
+    did: 'did:plc:self',
+    handle: 'vibesdiy.bsky.social',
+    accessJwt: 'jwt-access',
+    refreshJwt: 'jwt-refresh',
+    refreshedAt: new Date().toISOString(),
+  };
+
+  it('buildLikeRecord — strong-ref like on the request post', () => {
+    const built = buildLikeRecord({ uri: 'at://did:plc:alice/app.bsky.feed.post/3lc', cid: 'cid-3lc', createdAt: NOW });
+    expect(built.record).toMatchObject({
+      $type: 'app.bsky.feed.like',
+      subject: { uri: 'at://did:plc:alice/app.bsky.feed.post/3lc', cid: 'cid-3lc' },
+      createdAt: NOW,
+    });
+  });
+
+  it('buildLikeRecord — a missing uri or cid is an error, not a malformed record', () => {
+    expect(buildLikeRecord({ uri: 'at://x', createdAt: NOW }).error).toBeTruthy();
+    expect(buildLikeRecord({ cid: 'c', createdAt: NOW }).error).toBeTruthy();
+  });
+
+  // Like-state lives in its own oplog doc, keyed `like-<mentionId>`, so the like
+  // path never writes the (builder-contended) mention doc.
+  const likeState = (f, mentionId) => f.dbs.oplog.get(`like-${mentionId}`);
+
+  it('likes a freshly-accepted mention and records it in a separate like-state doc', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    let likeBody = null;
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [notif({ rkey: '3like1' })] })],
+        [
+          'createRecord',
+          (_url, init) => {
+            likeBody = JSON.parse(init.body);
+            return json({ uri: 'at://did:plc:self/app.bsky.feed.like/abc', cid: 'cid-like' });
+          },
+        ],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    // The like is a record in OUR repo strong-ref'ing the request post.
+    expect(likeBody.collection).toBe('app.bsky.feed.like');
+    expect(likeBody.repo).toBe('did:plc:self');
+    expect(likeBody.record.$type).toBe('app.bsky.feed.like');
+    expect(likeBody.record.subject.uri).toContain('3like1');
+    // The mention doc is NOT touched by the like path — no like fields on it.
+    const doc = f.dbs.requests.get('mention-did:plc:alice-3like1');
+    expect(doc.status).toBe('pending-build');
+    expect(doc.likedAt).toBeUndefined();
+    // Like-state is recorded separately.
+    const st = likeState(f, 'mention-did:plc:alice-3like1');
+    expect(st.likedAt).toBeTruthy();
+    expect(st.likeError).toBeNull();
+  });
+
+  it('does not like a mention the intent gate rejected', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    f.ctx.callAI = vi.fn(async () => 'SKIP');
+    const createSpy = vi.fn(() => json({ uri: 'at://x', cid: 'c' }));
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [notif({ rkey: '3skip1' })] })],
+        ['createRecord', createSpy],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    expect(createSpy).not.toHaveBeenCalled();
+    const doc = f.dbs.requests.get('mention-did:plc:alice-3skip1');
+    expect(doc.status).toBe('skipped');
+    expect(likeState(f, 'mention-did:plc:alice-3skip1')).toBeUndefined();
+  });
+
+  it('never re-likes a mention whose like-state already has likedAt', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    f.seed('requests', {
+      _id: 'mention-did:plc:alice-3done',
+      kind: 'mention',
+      status: 'pending-build',
+      uri: 'at://did:plc:alice/app.bsky.feed.post/3done',
+      cid: 'cid-3done',
+    });
+    f.seed('oplog', {
+      _id: 'like-mention-did:plc:alice-3done',
+      kind: 'like-state',
+      mentionId: 'mention-did:plc:alice-3done',
+      likedAt: '2026-07-06T00:00:00.000Z',
+      likeAttempts: 1,
+    });
+    const createSpy = vi.fn(() => json({ uri: 'at://x', cid: 'c' }));
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [] })],
+        ['createRecord', createSpy],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it('never writes the mention doc, so a concurrent builder claim cannot be lost', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    f.seed('requests', {
+      _id: 'mention-did:plc:alice-3race',
+      kind: 'mention',
+      status: 'pending-build',
+      uri: 'at://did:plc:alice/app.bsky.feed.post/3race',
+      cid: 'cid-3race',
+      updatedAt: '2026-07-06T00:00:00.000Z',
+    });
+    // The builder claims the doc WHILE the like createRecord is in flight — the
+    // exact read-to-write window Charlie flagged. Because the like path only
+    // writes the separate like-state doc, the claim survives untouched.
+    const claimedAt = '2026-07-06T12:34:56.000Z';
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [] })],
+        [
+          'createRecord',
+          () => {
+            f.seed('requests', {
+              _id: 'mention-did:plc:alice-3race',
+              kind: 'mention',
+              status: 'building',
+              uri: 'at://did:plc:alice/app.bsky.feed.post/3race',
+              cid: 'cid-3race',
+              buildAttempts: 1,
+              updatedAt: claimedAt,
+            });
+            return json({ uri: 'at://did:plc:self/app.bsky.feed.like/x', cid: 'cid-like' });
+          },
+        ],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    const doc = f.dbs.requests.get('mention-did:plc:alice-3race');
+    // The claim is intact — the like never wrote this doc.
+    expect(doc.status).toBe('building');
+    expect(doc.updatedAt).toBe(claimedAt);
+    expect(doc.buildAttempts).toBe(1);
+    expect(doc.likedAt).toBeUndefined();
+    // The like itself still happened, recorded separately.
+    expect(likeState(f, 'mention-did:plc:alice-3race').likedAt).toBeTruthy();
+  });
+
+  it('quiet-fails a like error in the like-state doc; mention doc stays untouched', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [notif({ rkey: '3err1' })] })],
+        ['createRecord', () => json({ error: 'RateLimitExceeded', message: 'slow down' }, 429)],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    const doc = f.dbs.requests.get('mention-did:plc:alice-3err1');
+    expect(doc.status).toBe('pending-build');
+    expect(doc.likeError).toBeUndefined(); // not on the mention doc
+    const st = likeState(f, 'mention-did:plc:alice-3err1');
+    expect(st.likedAt).toBeUndefined();
+    expect(st.likeError).toBeTruthy();
+    expect(st.likeAttempts).toBe(1);
+  });
+});
+
+describe('pdsHostFromDidDoc — chat must target the account PDS (#3591)', () => {
+  it('extracts the AtprotoPersonalDataServer endpoint and trims a trailing slash', () => {
+    const didDoc = {
+      service: [
+        { id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://gomphidius.us-west.host.bsky.network/' },
+      ],
+    };
+    expect(pdsHostFromDidDoc(didDoc)).toBe('https://gomphidius.us-west.host.bsky.network');
+  });
+
+  it('matches by service type when the id differs', () => {
+    const didDoc = { service: [{ id: '#pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://x.host.bsky.network' }] };
+    expect(pdsHostFromDidDoc(didDoc)).toBe('https://x.host.bsky.network');
+  });
+
+  it('returns null for a missing, empty, or non-https didDoc', () => {
+    expect(pdsHostFromDidDoc(undefined)).toBeNull();
+    expect(pdsHostFromDidDoc({})).toBeNull();
+    expect(pdsHostFromDidDoc({ service: [] })).toBeNull();
+    expect(pdsHostFromDidDoc({ service: [{ id: '#atproto_pds', serviceEndpoint: 'http://insecure.example' }] })).toBeNull();
   });
 });


### PR DESCRIPTION
Three fixes for the mention bot, all surfaced while taking #3323/#3333 live and all deployed together to the `jchris/mention-hub` vibe.

## 1. Like the request post the moment a mention is accepted

Instant "got it, on it" — the moment a mention clears the gates (`pending-build`), the bot likes the post, before the build dispatches.

- `buildLikeRecord` (pure `app.bsky.feed.like` strong-ref), `likeMention` / `likeAcceptedMentions`, wired as step 2 of the tick.
- **Race-free by construction:** like-state lives in its own doc (`like-<mentionId>` in oplog), so the like path only *reads* the builder-contended mention doc and never writes it — no read-to-write window in which a builder claim (`status: building` + fresh `updatedAt`) can be lost (Charlie review, two rounds).

## 2. Wait for the publish-queue screenshot before replying imageless

The reply fired the instant the app served 200, but the publish queue writes `screenshot.png` a beat later — so replies raced ahead of the image and degraded to a bare link card (the live candy-crush reply did this). `replyToMention` now uses the blog engine's media-ready gate: `fetchScreenshotEmbed` returns `{embed}`/`{pending}`/`{unusable}`, and the reply defers a `pending` screenshot up to `MAX_SCREENSHOT_WAITS` ticks (without burning a hard reply attempt) before settling for the link card.

## 3. Route claim-DM chat calls to the account PDS, not the entryway

The claim DM failed with `Method Not Implemented` — **not** an app-password scope issue (DM access is enabled). `@vibes.diy` is hosted on `gomphidius.us-west.host.bsky.network`, but the backend sent every XRPC call to the `bsky.social` entryway. The entryway forwards `com.atproto.repo.*` (likes/replies work) but does not proxy authed `chat.bsky.convo.*` — those must hit the account's own PDS. Fix: capture the PDS host from the session `didDoc` (`pdsHostFromDidDoc`), persist it on the vault token as `pdsHost`, and route the DM's chat calls there via a new `host` param on `bskyFetch`. Falls back to the entryway if the didDoc has no PDS endpoint. (Detail: VibesDIY/vibes.diy#3591.)

## Tests

83 total (`backend.test.js`). Both #1 and #3 verified live-deployed; #2 covered by defer/embed/fallback wiring tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdzjQxLALobQEAsPJt5vjh