### PR TITLE
mention-hub: allow solicitation + config-solicitation kinds in access.js

### DIFF
--- a/examples/mention-hub/access.js
+++ b/examples/mention-hub/access.js
@@ -14,10 +14,12 @@ export default function (doc, oldDoc, user, ctx) {
   }
   if (
     doc.kind === 'mention' ||
+    doc.kind === 'solicitation' || // proactive search lane, same ops channel as mentions
     doc.kind === 'oplog' ||
     doc.kind === 'token-status' ||
     doc.kind === 'listener-state' ||
-    doc.kind === 'config'
+    doc.kind === 'config' ||
+    doc.kind === 'config-solicitation' // owner-written switch/knobs for the solicitation lane
   ) {
     return { channels: ['ops'], grant: { roles: { owner: ['ops'] } } };
   }


### PR DESCRIPTION
Follow-up to #62 (merged), caught while wiring the lane up on the live bot.

#62 added the `solicitation` and `config-solicitation` doc kinds to `backend.js` but not to the vibe's **access function**. `access.js` throws `unknown document type` for any kind it doesn't whitelist, which blocks the whole lane two ways:

1. The owner-written `config-solicitation` switch doc can't be saved — the write hits the throw (even `--admin` runs the function to assign channels, so the final `throw` still fires).
2. The CI builder lane writes each `solicitation` doc back as the **owner** (not admin), so it would hit the same throw and strand every build before `built` — no reply ever posts.

Fix: whitelist both new kinds onto the same owner-only `ops` channel as `mention`/`config`. No behavior change for existing kinds; no functional code beyond the access predicate.

**Ship note:** this is part of the deployed vibe, so it only takes effect once `jchris/mention-hub` is redeployed (`vibes-diy push`) — same deploy that ships the #62 backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtEnzQh7pkLuHTejAKbgQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtEnzQh7pkLuHTejAKbgQF)_