### PR TITLE
mention-hub: decouple solicitation examine-budget from the reply cap

### DIFF
--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -89,8 +89,8 @@ export const SOLICITATION_DEFAULTS = {
   enabled: false, // master switch — inert until on; turning it off also freezes in-flight work (dispatch + reply)
   queries: [], // Bluesky search queries run each tick, e.g. ['drop your startup link']
   maxPerAuthorPerDay: 1, // one reply per poster per UTC day — never pile onto anyone
-  maxGlobalPerDay: 8, // spend ceiling for the proactive lane (below the mention lane's)
-  maxNewPerTick: 2, // newly accepted solicitations per tick (burst brake)
+  maxGlobalPerDay: 8, // REPLY ceiling for the proactive lane, enforced post-classification
+  maxNewPerTick: 12, // posts EXAMINED (classified) per tick — decoupled from the reply cap
   maxRepliesPerTick: 1, // replies posted per tick — deliberately slow, human-paced
   maxPostAgeHours: 12, // only answer fresh calls; older threads have moved on (reads as spam)
   searchLimit: 25, // posts fetched per query per tick
@@ -544,8 +544,10 @@ export function buildSolicitationReply({ solicitation, vibeUrl, createdAt, embed
 // as args. Unlike planMentions this emits CANDIDATES (status "candidate", no
 // build prompt yet): the prompt is derived later from the poster's feed (a
 // network call), and only LLM-confirmed calls become pending-build. Freshest
-// posts first, so a burst spends the tick's budget on live threads ("do the
-// live/fresh ones first").
+// posts first, so the tick's examine budget goes to live threads ("do the
+// live/fresh ones first"). It emits up to maxNewPerTick candidates to EXAMINE;
+// the daily REPLY cap (maxGlobalPerDay) is enforced later, at accept time — so
+// a small reply cap never starves how many posts reach the classifier.
 export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
   const day = dayKey(nowIso);
   const existingIds = new Set(existing.map((d) => d._id));
@@ -607,17 +609,23 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
       skip('author daily cap');
       continue;
     }
+    // Once the day's REPLY budget is already spent (persisted accepts), stop
+    // examining — no point classifying posts we can't answer today. But the cap
+    // is NOT charged per candidate here: candidates are only *examined*, and
+    // most are skipped by the SHARE gate. The reply cap binds at accept time
+    // (in scheduled) instead, so a small cap can't starve how many posts reach
+    // the classifier — that's what maxNewPerTick controls (the examine budget).
     if (todayCount >= cfg.maxGlobalPerDay) {
       skip('global daily cap');
       continue;
     }
     if (acceptedThisTick >= cfg.maxNewPerTick) {
-      // Burst brake: leave it unwritten so a later tick re-plans it fresh.
+      // Examine budget for this tick — leave the rest unwritten so a later tick
+      // re-plans them fresh (freshest-first, so live threads go first).
       continue;
     }
     out.push({ ...base, status: 'candidate' });
     acceptedThisTick += 1;
-    todayCount += 1;
     authorCounts.set(authorDid, (authorCounts.get(authorDid) || 0) + 1);
   }
   return out;
@@ -1208,11 +1216,18 @@ export async function scheduled(event, ctx) {
       cfg: solCfg,
       nowIso,
     });
-    let solAccepted = 0;
+    // The daily REPLY cap binds here, post-classification: today's persisted
+    // accepts plus any accepted earlier this tick. Examining many posts (above)
+    // never spends more than maxGlobalPerDay replies/day.
+    const solDay = dayKey(nowIso);
+    let acceptedToday = existingSol.filter(
+      (d) => d.status !== 'skipped' && d.day === solDay
+    ).length;
+    let solNew = 0;
     for (const doc of solPlan) {
       if (doc.status !== 'candidate') {
-        // own-post / stale / cap skips: record them (idempotent, keeps them out
-        // of next tick's re-plan) and move on.
+        // own-post / stale / author-cap skips: record them (idempotent, keeps
+        // them out of next tick's re-plan) and move on.
         await ctx.db.put(doc, { db: 'requests' });
         continue;
       }
@@ -1223,6 +1238,15 @@ export async function scheduled(event, ctx) {
       if (verdict === 'skip') {
         await ctx.db.put(
           { ...doc, status: 'skipped', reason: 'not a solicitation' },
+          { db: 'requests' }
+        );
+        continue;
+      }
+      // A genuine call, but the day's replies are already spent: skip without
+      // burning an idea-derivation call. (Checked here, not at examine time.)
+      if (acceptedToday >= solCfg.maxGlobalPerDay) {
+        await ctx.db.put(
+          { ...doc, status: 'skipped', reason: 'global daily cap' },
           { db: 'requests' }
         );
         continue;
@@ -1238,10 +1262,11 @@ export async function scheduled(event, ctx) {
         { ...doc, status: 'pending-build', prompt: idea.prompt, promptKey: promptKey(idea.prompt) },
         { db: 'requests' }
       );
-      solAccepted += 1;
+      acceptedToday += 1;
+      solNew += 1;
       await log(ctx, { op: 'solicitation-accepted', uri: doc.uri, prompt: idea.prompt });
     }
-    await noteListenerState(ctx, { solLastPollAt: nowIso, solNewDocs: solAccepted });
+    await noteListenerState(ctx, { solLastPollAt: nowIso, solNewDocs: solNew });
   }
 
   // 2. Fire the builder lane on demand if mentions are queued (#3529) — the

--- a/examples/mention-hub/backend.test.js
+++ b/examples/mention-hub/backend.test.js
@@ -1166,6 +1166,42 @@ describe('planSolicitations — search triage + guardrails', () => {
     expect(candidates).toHaveLength(1); // the second is left unwritten for next tick
     expect(out.every((d) => d.status !== 'skipped' || d.reason !== 'burst')).toBe(true);
   });
+
+  it('examines up to maxNewPerTick even when the reply cap is tiny (decoupled)', () => {
+    // 5 fresh posts from distinct authors, reply cap 2 but examine budget 5:
+    // ALL 5 become candidates (reply cap binds later, at accept time), so the
+    // real solicitation deeper in the list still reaches the classifier.
+    const posts = ['a', 'b', 'c', 'd', 'e'].map((rk, i) =>
+      post({ rkey: rk, did: `did:plc:${rk}` })
+    );
+    const out = planSolicitations({
+      posts,
+      selfDid: 'did:plc:self',
+      existing: [],
+      cfg: { ...cfg, maxGlobalPerDay: 2, maxNewPerTick: 5 },
+      nowIso: NOW,
+    });
+    expect(out.filter((d) => d.status === 'candidate')).toHaveLength(5);
+  });
+
+  it('stops examining once the day’s persisted replies hit the cap', () => {
+    const existing = [1, 2].map((i) => ({
+      _id: `sol-did:plc:x${i}-old`,
+      kind: 'solicitation',
+      status: 'replied',
+      authorDid: `did:plc:x${i}`,
+      day: dayKey(NOW),
+    }));
+    const out = planSolicitations({
+      posts: [post({ rkey: 'new' })],
+      selfDid: 'did:plc:self',
+      existing,
+      cfg: { ...cfg, maxGlobalPerDay: 2 },
+      nowIso: NOW,
+    });
+    expect(out[0].status).toBe('skipped');
+    expect(out[0].reason).toBe('global daily cap');
+  });
 });
 
 describe('scheduled — solicitation lane wiring', () => {
@@ -1264,6 +1300,47 @@ describe('scheduled — solicitation lane wiring', () => {
     const docs = [...f.dbs.requests.values()];
     expect(docs).toHaveLength(1);
     expect(docs[0].status).toBe('skipped');
+  });
+
+  it('caps replies at accept time: two genuine calls, cap 1 → one built, one capped', async () => {
+    const f = fakeDb();
+    f.seed('vault', freshToken);
+    enableSolicitation(f, { maxGlobalPerDay: 1, maxNewPerTick: 5 });
+    // Both classify SHARE and yield an idea — the cap, not the classifier, is
+    // what limits us to one reply.
+    f.ctx.callAI = vi.fn(async (prompt) =>
+      /SHARE or SKIP/.test(prompt) ? 'SHARE' : 'Build a tiny synth'
+    );
+    const twoPosts = [
+      {
+        uri: 'at://did:plc:aa/app.bsky.feed.post/p1',
+        cid: 'c1',
+        author: { did: 'did:plc:aa', handle: 'aa.bsky.social' },
+        record: { text: 'drop your app link below!' },
+        indexedAt: new Date().toISOString(),
+      },
+      {
+        uri: 'at://did:plc:bb/app.bsky.feed.post/p2',
+        cid: 'c2',
+        author: { did: 'did:plc:bb', handle: 'bb.bsky.social' },
+        record: { text: 'share your startup, lets drive traffic' },
+        indexedAt: new Date().toISOString(),
+      },
+    ];
+    vi.stubGlobal(
+      'fetch',
+      xrpcStub([
+        ['listNotifications', () => json({ notifications: [] })],
+        ['searchPosts', () => json({ posts: twoPosts })],
+        ['getAuthorFeed', () => json({ feed: [] })],
+      ])
+    );
+    await scheduled({}, f.ctx);
+    const sols = [...f.dbs.requests.values()].filter((d) => d.kind === 'solicitation');
+    expect(sols.filter((d) => d.status === 'pending-build')).toHaveLength(1);
+    expect(
+      sols.filter((d) => d.status === 'skipped' && d.reason === 'global daily cap')
+    ).toHaveLength(1);
   });
 
   it('replies to a built solicitation with the solicitation template, no echo', async () => {


### PR DESCRIPTION
Found live-testing the solicitation lane on the bot: it was catching **zero** posts despite the search returning plenty.

**Root cause (structural):** the daily reply cap was enforced at *candidate-emit* time — before classification — and posts are examined freshest-first. With a small cap (2), only the **2 newest** matching posts per tick ever reached the SHARE gate. Broad terms filled those 2 slots with chatter, so genuine "drop your app link" posts were skipped as `global daily cap` overflow and never classified. Broadening made it worse; precise terms returned nothing. Either way, 0 accepts.

**Fix — separate the two budgets:**
- `planSolicitations` no longer charges the daily cap per candidate; it emits up to `maxNewPerTick` candidates to **examine** (still stops early if the day's *persisted* replies already hit the cap).
- The daily **reply** cap now binds in `scheduled` at **accept time** — after SHARE + idea derivation, against today's persisted accepts + this tick's — so examining many posts never spends more than `maxGlobalPerDay` replies/day.
- `maxNewPerTick` default `2 → 12` (it's an examine budget now, not a reply brake).

Net: broad terms can surface the real solicitations while replies stay capped. No change to the no-echo boundary, dark-by-default, or the kill-switch.

**Tests:** +3 (examine-past-cap decoupling, stop-at-persisted-cap, accept-time cap with two genuine calls). **101/101.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtEnzQh7pkLuHTejAKbgQF

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtEnzQh7pkLuHTejAKbgQF)_