### PR TITLE
mention-hub: don't reply to bots + monthly cooldown, and add the Threads proactive lane

### DIFF
--- a/examples/mention-hub/App.jsx
+++ b/examples/mention-hub/App.jsx
@@ -111,8 +111,11 @@ export default function App() {
   const { can, ready } = useVibe('vault');
 
   // The raw credential never syncs here (write-only vault); the dashboard
-  // reads the redacted `token-status` projection the backend mirrors.
-  const tokenStatus = logQ('kind', { key: 'token-status' }).docs[0];
+  // reads the redacted `token-status` projections the backend mirrors (one per
+  // platform).
+  const tokenStatuses = logQ('kind', { key: 'token-status' }).docs;
+  const tokenStatus = tokenStatuses.find((d) => d.platform === 'bsky') || tokenStatuses[0];
+  const threadsTokenStatus = tokenStatuses.find((d) => d.platform === 'threads');
   const listener = logQ('kind', { key: 'listener-state' }).docs[0];
   const configDoc = logQ('kind', { key: 'config' }).docs[0];
   const solConfigDoc = logQ('kind', { key: 'config-solicitation' }).docs[0];
@@ -128,6 +131,7 @@ export default function App() {
 
   const [tab, setTab] = useState('planner');
   const [credential, setCredential] = useState('');
+  const [threadsCred, setThreadsCred] = useState('');
   const [githubPat, setGithubPat] = useState('');
   const [justSaved, setJustSaved] = useState(null);
   const [cfgDraft, setCfgDraft] = useState(null);
@@ -163,6 +167,26 @@ export default function App() {
     });
     setCredential('');
     setJustSaved('bsky');
+    setTimeout(() => setJustSaved(null), 2500);
+  };
+
+  // The long-lived Threads (Meta) token for the proactive Threads lane. Same
+  // write-only vault; the backend resolves the user id from it on the next tick.
+  const saveThreadsCred = async () => {
+    if (!threadsCred.trim()) return;
+    await vaultDb.put({
+      _id: 'token-threads',
+      kind: 'token',
+      platform: 'threads',
+      token: threadsCred.trim(),
+      pastedAt: new Date().toISOString(),
+      userId: null,
+      username: null,
+      needsReauth: false,
+      lastError: null,
+    });
+    setThreadsCred('');
+    setJustSaved('threads');
     setTimeout(() => setJustSaved(null), 2500);
   };
 
@@ -206,21 +230,26 @@ export default function App() {
     });
   };
   const solEnabled = !!solConfigDoc?.enabled;
+  const threadsEnabled = !!solConfigDoc?.threadsEnabled;
   const solCap = solConfigDoc?.maxGlobalPerDay ?? 8;
   const sf = solForm ?? {
     maxGlobalPerDay: solCap,
     queriesText: (solConfigDoc?.queries || []).join('\n'),
+    threadsQueriesText: (solConfigDoc?.threadsQueries || []).join('\n'),
   };
   const toggleSol = () => saveSol({ enabled: !solEnabled });
+  const toggleThreads = () => saveSol({ threadsEnabled: !threadsEnabled });
   const saveSolForm = async () => {
-    const queries = sf.queriesText
-      .split('\n')
-      .map((s) => s.trim())
-      .filter(Boolean);
+    const toLines = (txt) =>
+      (txt || '')
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean);
     const cap = Number(sf.maxGlobalPerDay);
     await saveSol({
       maxGlobalPerDay: Number.isInteger(cap) && cap >= 0 ? cap : undefined,
-      queries,
+      queries: toLines(sf.queriesText),
+      threadsQueries: toLines(sf.threadsQueriesText),
     });
     setSolForm(null);
   };
@@ -368,6 +397,83 @@ export default function App() {
               ) : null}
             </section>
 
+            {/* Same proactive lane, on Threads (Meta) */}
+            <section className="border border-stone-700 rounded-[8px] p-[16px] space-y-[12px]">
+              <div className="flex items-start justify-between gap-[12px] flex-wrap">
+                <div>
+                  <div className="text-[15px] font-bold flex items-center gap-[8px]">
+                    <span
+                      className={`inline-block w-[10px] h-[10px] rounded-full ${
+                        threadsEnabled ? 'bg-emerald-400' : 'bg-stone-500'
+                      }`}
+                    />
+                    Solicitation replies · Threads
+                    <span className={threadsEnabled ? 'text-emerald-400' : 'text-stone-500'}>
+                      {threadsEnabled ? 'ON' : 'OFF'}
+                    </span>
+                  </div>
+                  <p className="text-[12px] text-stone-400 mt-[4px] max-w-[520px]">
+                    The same proactive lane on Threads. Needs a Threads token in the Technical tab
+                    and the <code>threads_keyword_search</code> permission approved by Meta; until
+                    then search finds nothing. Bots and the monthly per-person limit apply here too.
+                  </p>
+                  {threadsEnabled && !threadsTokenStatus?.hasToken ? (
+                    <p className="text-[12px] text-amber-400 mt-[4px]">
+                      On, but no Threads token pasted yet — nothing will post until it is.
+                    </p>
+                  ) : null}
+                </div>
+                <button
+                  onClick={toggleThreads}
+                  role="switch"
+                  aria-checked={threadsEnabled}
+                  className={`shrink-0 w-[52px] h-[28px] rounded-full p-[3px] transition-colors ${
+                    threadsEnabled ? 'bg-emerald-500' : 'bg-stone-600'
+                  }`}
+                >
+                  <span
+                    className={`block w-[22px] h-[22px] rounded-full bg-white transition-transform ${
+                      threadsEnabled ? 'translate-x-[24px]' : ''
+                    }`}
+                  />
+                </button>
+              </div>
+
+              <div className="text-[12px] text-stone-500">
+                last search: {listener?.threadsLastPollAt?.slice(11, 19) || '—'}
+                {listener?.threadsLastError ? (
+                  <span className="text-red-400"> · {listener.threadsLastError}</span>
+                ) : null}
+              </div>
+
+              <label className="text-[12px] text-stone-400 space-y-[4px] block">
+                Topics we watch on Threads (one search per line)
+                <textarea
+                  value={sf.threadsQueriesText}
+                  onChange={(e) => setSolForm({ ...sf, threadsQueriesText: e.target.value })}
+                  rows={4}
+                  placeholder={'what are you building\ndrop your app link\nshare your startup'}
+                  className="w-full bg-stone-900 border border-stone-700 rounded-[6px] px-[10px] py-[6px] text-[12px] text-stone-200"
+                />
+              </label>
+              {solForm ? (
+                <div className="flex gap-[8px]">
+                  <button
+                    onClick={saveSolForm}
+                    className="bg-[#FEDD00] text-stone-900 font-bold text-[12px] px-[14px] py-[6px] rounded-[6px]"
+                  >
+                    save topics &amp; limit
+                  </button>
+                  <button
+                    onClick={() => setSolForm(null)}
+                    className="text-stone-400 text-[12px] px-[10px] py-[6px]"
+                  >
+                    cancel
+                  </button>
+                </div>
+              ) : null}
+            </section>
+
             {/* Little stat row */}
             <div className="grid grid-cols-3 gap-[8px]">
               {[
@@ -469,6 +575,57 @@ export default function App() {
               <p className="text-[11px] text-stone-500">
                 Write-only vault: the paste never syncs back to any browser. The next tick verifies
                 it and shows the handle above.
+              </p>
+            </section>
+
+            <section className="border border-stone-700 rounded-[8px] p-[12px] space-y-[8px]">
+              <h2 className="text-[14px] font-bold">Threads credential</h2>
+              {threadsTokenStatus ? (
+                <div className="text-[12px] text-stone-400">
+                  {threadsTokenStatus.hasToken ? (
+                    <>
+                      <span
+                        className={
+                          threadsTokenStatus.needsReauth ? 'text-red-400' : 'text-emerald-400'
+                        }
+                      >
+                        {threadsTokenStatus.needsReauth ? 'needs re-auth' : 'active'}
+                      </span>
+                      {threadsTokenStatus.handle
+                        ? ` as @${threadsTokenStatus.handle}`
+                        : ' (verifying…)'}
+                      {threadsTokenStatus.lastError ? (
+                        <span className="text-red-400"> — {threadsTokenStatus.lastError}</span>
+                      ) : null}
+                    </>
+                  ) : (
+                    'no token pasted yet'
+                  )}
+                </div>
+              ) : (
+                <div className="text-[12px] text-stone-500">
+                  waiting for the first scheduled tick…
+                </div>
+              )}
+              <div className="flex gap-[8px]">
+                <input
+                  type="password"
+                  value={threadsCred}
+                  onChange={(e) => setThreadsCred(e.target.value)}
+                  placeholder="long-lived Threads Graph API token"
+                  className="flex-1 bg-stone-900 border border-stone-700 rounded-[6px] px-[10px] py-[6px] text-[12px]"
+                />
+                <button
+                  onClick={saveThreadsCred}
+                  className="bg-[#FEDD00] text-stone-900 font-bold text-[12px] px-[14px] py-[6px] rounded-[6px]"
+                >
+                  {justSaved === 'threads' ? 'saved ✓' : 'save'}
+                </button>
+              </div>
+              <p className="text-[11px] text-stone-500">
+                Meta developer app with the <code>threads_keyword_search</code> permission
+                (app-reviewed), then a long-lived user token. Same write-only vault; the next tick
+                resolves the account and shows it above.
               </p>
             </section>
 

--- a/examples/mention-hub/App.jsx
+++ b/examples/mention-hub/App.jsx
@@ -413,15 +413,24 @@ export default function App() {
                     </span>
                   </div>
                   <p className="text-[12px] text-stone-400 mt-[4px] max-w-[520px]">
-                    The same proactive lane on Threads. Needs a Threads token in the Technical tab
-                    and the <code>threads_keyword_search</code> permission approved by Meta; until
-                    then search finds nothing. Bots and the monthly per-person limit apply here too.
+                    This toggle is the <strong>proactive search</strong> lane on Threads — it needs
+                    a token <em>and</em> Meta's <code>threads_keyword_search</code> approval; until
+                    that lands, search finds nothing. Replying to people who{' '}
+                    <strong>@-mention @{threadsTokenStatus?.handle || 'you'}</strong> starts as soon
+                    as a token is pasted (Technical tab) — no toggle, no review needed. Bots and the
+                    monthly per-person limit apply to the search lane here too.
                   </p>
-                  {threadsEnabled && !threadsTokenStatus?.hasToken ? (
-                    <p className="text-[12px] text-amber-400 mt-[4px]">
-                      On, but no Threads token pasted yet — nothing will post until it is.
+                  {threadsTokenStatus?.hasToken ? (
+                    <p className="text-[12px] text-emerald-400/80 mt-[4px]">
+                      Token live — the @-mention lane is running. Last mentions check:{' '}
+                      {listener?.threadsMentionsPollAt?.slice(11, 19) || '—'}
                     </p>
-                  ) : null}
+                  ) : (
+                    <p className="text-[12px] text-amber-400 mt-[4px]">
+                      No Threads token pasted yet — paste one in the Technical tab to start the
+                      @-mention lane.
+                    </p>
+                  )}
                 </div>
                 <button
                   onClick={toggleThreads}

--- a/examples/mention-hub/RUNBOOK.md
+++ b/examples/mention-hub/RUNBOOK.md
@@ -218,20 +218,32 @@ feed. Threads solicitation docs carry `platform: 'threads'`; Bluesky docs are
 `platform: 'bsky'` (a legacy doc with no field is treated as bsky), and caps are
 counted per platform.
 
-### Activating it (dark by default, and independent of the Bluesky switch)
+Threads has **two** sub-lanes, gated differently:
 
-1. **Meta developer app** with the **`threads_keyword_search`** permission —
-   this one goes through Meta app review. Until it's approved, `keyword_search`
-   returns only your own posts, so the lane finds nothing (fails safe).
+- **Reactive @-mention lane** (`me/mentions`): answers anyone who `@`-mentions the
+  account. Runs as soon as a healthy token is pasted — **no `threadsEnabled`
+  toggle, no keyword_search review**. Needs the mentions/replies permission on the
+  token (`threads_manage_replies`), plus `threads_content_publish` to reply. Same
+  guardrails + intent classifier as the Bluesky mention lane; docs are
+  `kind:'mention', platform:'threads'`.
+- **Proactive search lane** (`keyword_search`): the toggle below. Additionally
+  needs `threadsEnabled:true` AND Meta's app-reviewed **`threads_keyword_search`**
+  — until that's approved, search returns only your own posts (fails safe).
+
+### Activating (dark by default, independent of the Bluesky switch)
+
+1. **Meta developer app** with `threads_basic` + `threads_content_publish` +
+   `threads_manage_replies` (mentions) — enough for the reactive lane — and, for
+   the proactive lane, **`threads_keyword_search`** (app review).
 2. **Long-lived Threads user token** → paste it in the dashboard's **Technical →
    Threads credential** box (write-only vault, `_id: token-threads`,
-   `platform: 'threads'`). The next tick resolves the account id/username and
-   shows it as active.
-3. **Turn the lane on**: the **Solicitation replies · Threads** toggle in the
-   planner (writes `threadsEnabled: true` + `threadsQueries` onto the
-   `config-solicitation` doc). `threadsEnabled:false` (or no token) freezes the
-   whole Threads lane — search, dispatch, and reply — exactly like the Bluesky
-   kill-switch.
+   `platform: 'threads'`). The next tick resolves the account id/username, shows
+   it active, and the **@-mention lane starts immediately**.
+3. **Turn on proactive search** (optional, after the keyword_search review): the
+   **Solicitation replies · Threads** toggle (writes `threadsEnabled: true` +
+   `threadsQueries` onto the `config-solicitation` doc). `threadsEnabled:false`
+   freezes only the search lane's find/dispatch/reply; the @-mention lane keeps
+   running on the token alone (parity with Bluesky mentions, which have no switch).
 
 Config fields on the same `config-solicitation` doc: `threadsEnabled` (bool) and
 `threadsQueries` (string[]); the shared caps (`maxGlobalPerDay`, cooldown, etc.)

--- a/examples/mention-hub/RUNBOOK.md
+++ b/examples/mention-hub/RUNBOOK.md
@@ -175,17 +175,30 @@ The lane runs nothing until an owner writes a `config-solicitation` doc into the
 `enabled:false` or an empty `queries` array ⇒ inert. All the caps below are
 optional overrides on the same doc; defaults live in `SOLICITATION_DEFAULTS`.
 
-| knob               | default | meaning                                             |
-| ------------------ | ------- | --------------------------------------------------- |
-| enabled            | false   | master switch — inert until an owner turns it on    |
-| queries            | []      | Bluesky search queries run each tick (max 6 used)   |
-| maxGlobalPerDay    | 8       | accepted solicitation replies per UTC day           |
-| maxPerAuthorPerDay | 1       | one reply per poster per UTC day — never pile on    |
-| maxNewPerTick      | 2       | burst brake per 1-minute tick                       |
-| maxRepliesPerTick  | 1       | replies posted per tick — slow, human-paced         |
-| maxPostAgeHours    | 12      | only answer fresh calls; older threads read as spam |
-| searchLimit        | 25      | posts fetched per query per tick                    |
-| authorFeedLimit    | 20      | of the poster's recent posts fed to the idea model  |
+| knob               | default | meaning                                                                         |
+| ------------------ | ------- | ------------------------------------------------------------------------------- |
+| enabled            | false   | master switch — inert until an owner turns it on                                |
+| queries            | []      | Bluesky search queries run each tick (max 6 used)                               |
+| maxGlobalPerDay    | 8       | accepted solicitation replies per UTC day                                       |
+| maxPerAuthorPerDay | 1       | one reply per poster per UTC day — never pile on                                |
+| authorCooldownDays | 30      | and never reply to the same poster twice inside ~a month (mentions bypass this) |
+| maxNewPerTick      | 2       | burst brake per 1-minute tick                                                   |
+| maxRepliesPerTick  | 1       | replies posted per tick — slow, human-paced                                     |
+| maxPostAgeHours    | 12      | only answer fresh calls; older threads read as spam                             |
+| searchLimit        | 25      | posts fetched per query per tick                                                |
+| authorFeedLimit    | 20      | of the poster's recent posts fed to the idea model                              |
+
+**Never replies to bots.** The proactive lane skips automated accounts
+(`isLikelyBotAccount`): a bot-suffixed / feed / RSS / aggregator handle or
+display name, and known news mirrors (Hacker News, Lobsters, …). News bots
+syndicate exactly the "what are you building" phrasing this lane searches for,
+so replying to them is bot-to-bot spam under a post no human is watching (the
+reply-bot-hn incident — we replied to `hackernewsbot.bsky.social`'s "Ask HN:
+What Are You Working On?" repost). It's a deterministic, high-precision handle
+signal; a false positive only costs the proactive lane one poster, who can
+still `@`-mention us (the reactive lane never consults this gate). The
+`authorCooldownDays` window likewise applies to the proactive lane only — an
+`@`-mention is always answered, "unless they mention us" notwithstanding.
 
 Search uses `sort=latest` + a 12h `since` cutoff (fresh-first, windowed
 server-side); `planSolicitations` re-checks the age as a belt-and-suspenders.

--- a/examples/mention-hub/RUNBOOK.md
+++ b/examples/mention-hub/RUNBOOK.md
@@ -205,12 +205,47 @@ server-side); `planSolicitations` re-checks the age as a belt-and-suspenders.
 Idempotency is the same cursorless trick as mentions — a deterministic
 `sol-<did>-<rkey>` doc id means re-finding a post in a later tick is a no-op.
 
+## Threads (Meta) proactive lane
+
+The solicitation lane also runs on **Threads**, gated by its own switch and its
+own token — same `requests` db, same guardrails (`planSolicitations` with
+`platform: 'threads'`, so the bot-account skip and the monthly per-author
+cooldown apply identically), same CI builder lane. Only the network I/O differs:
+Threads search is `keyword_search`, and a reply is a two-call publish (create a
+TEXT container with `reply_to_id`, then `threads_publish`). Individualization uses
+just the matched post's text — the Threads API can't read an arbitrary poster's
+feed. Threads solicitation docs carry `platform: 'threads'`; Bluesky docs are
+`platform: 'bsky'` (a legacy doc with no field is treated as bsky), and caps are
+counted per platform.
+
+### Activating it (dark by default, and independent of the Bluesky switch)
+
+1. **Meta developer app** with the **`threads_keyword_search`** permission —
+   this one goes through Meta app review. Until it's approved, `keyword_search`
+   returns only your own posts, so the lane finds nothing (fails safe).
+2. **Long-lived Threads user token** → paste it in the dashboard's **Technical →
+   Threads credential** box (write-only vault, `_id: token-threads`,
+   `platform: 'threads'`). The next tick resolves the account id/username and
+   shows it as active.
+3. **Turn the lane on**: the **Solicitation replies · Threads** toggle in the
+   planner (writes `threadsEnabled: true` + `threadsQueries` onto the
+   `config-solicitation` doc). `threadsEnabled:false` (or no token) freezes the
+   whole Threads lane — search, dispatch, and reply — exactly like the Bluesky
+   kill-switch.
+
+Config fields on the same `config-solicitation` doc: `threadsEnabled` (bool) and
+`threadsQueries` (string[]); the shared caps (`maxGlobalPerDay`, cooldown, etc.)
+apply per platform.
+
+> Not yet exercised against the live Threads API — the exact `keyword_search`
+> params and create/publish field names follow Meta's docs and want one smoke
+> test the first time a real token is pasted. Everything the unit tests cover
+> (triage, ids, reply text, config validation) is platform-pure.
+
 ## Known limits / follow-ons (tracked in #3323)
 
-- Bluesky only; Threads/X listeners are follow-on (same doc protocol, new
-  listener lanes in this backend). The **Threads-native** version of the
-  solicitation lane needs Threads Graph API credentials in the vault — the
-  search + individualize + reply shape ports directly once those exist.
+- X (Twitter) listener is still a follow-on (same doc protocol, new listener lane
+  in this backend).
 - Mention→reply latency is minutes (1m tick + 10m cron + build time), fine
   for a marketing bot; a queue-worker builder would shave it if it matters.
 - Claimable ownership (pin the vibe to the requester, attach on first login)

--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -117,23 +117,29 @@ export const SOLICITATION_DEFAULTS = {
 // filter downstream (the LLM SHARE gate), and a false positive only costs the
 // PROACTIVE lane one poster — who can still @-mention us, since the reactive
 // mention lane never consults this gate.
+// Tokens matched at a boundary within the account-name label. "news" is
+// deliberately NOT here (too many real people/orgs); the strong bot markers are.
 const BOT_NAME_TOKENS =
-  /(^|[^a-z])(bot|bots|feed|feeds|rss|atom|headlines?|digest|aggregat\w*|syndicat\w*)([^a-z]|$)/i;
-const KNOWN_BOT_HANDLES = /(hacker\W?news|lobste\.?rs|slashdot|techmeme)/i;
+  /(^|[^a-z])(bot|bots|feed|feeds|rss|headlines?|digest|aggregat\w*|syndicat\w*)([^a-z]|$)/i;
+// Known aggregators, anchored to a label boundary (start or after a separator) so
+// a human handle like `myhackernewsfan` is NOT caught, while `hackernews` and
+// `hackernewsdaily` are.
+const KNOWN_BOT_HANDLES = /(^|[-_.])(hacker\W?news|lobste\.?rs|slashdot|techmeme)/i;
 
 export function isLikelyBotAccount(author) {
   const handle = String((author && author.handle) || '').toLowerCase();
   if (!handle) return false;
   const displayName = String((author && author.displayName) || '');
   // The account-name label is everything before the domain (…bsky.social, a
-  // custom domain, or a brid.gy bridge suffix). Bot markers live there or in the
-  // display name.
+  // custom domain, or a brid.gy bridge suffix) — bot markers live there.
   const label = handle.split('.')[0] || handle;
   if (/bots?$/.test(label)) return true; // hackernewsbot, weatherbot
   if (BOT_NAME_TOKENS.test(label)) return true; // news-feed, rss-mirror, daily-digest
-  if (KNOWN_BOT_HANDLES.test(handle)) return true; // hackernews.*, lobsters.*
-  if (/🤖/.test(displayName)) return true; // the "I am a bot" convention
-  if (BOT_NAME_TOKENS.test(displayName) || KNOWN_BOT_HANDLES.test(displayName)) return true;
+  if (KNOWN_BOT_HANDLES.test(label)) return true; // hackernews.*, lobsters.* (label-anchored)
+  // Display name: only the unambiguous "I am a bot" signals. A news/feed word in
+  // a human's bio ("Hacker News fan") must NOT trip the filter — precision matters
+  // more than recall here (a miss just faces the LLM SHARE gate next).
+  if (/🤖/.test(displayName) || /\bbots?\b/i.test(displayName)) return true;
   return false;
 }
 
@@ -726,6 +732,11 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
     out.push({ ...base, status: 'candidate' });
     acceptedThisTick += 1;
     authorCounts.set(authorDid, (authorCounts.get(authorDid) || 0) + 1);
+    // Charge the cooldown this tick too, not just from persisted docs: with a
+    // maxPerAuthorPerDay > 1 override, a second fresh post from the same author
+    // in the same tick would otherwise pass the cooldown (the set was built
+    // before the loop) and get sent on a later tick — violating "once a month".
+    if (cooldownStart) cooledDownAuthors.add(authorDid);
   }
   return out;
 }

--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -1268,6 +1268,12 @@ async function threadsFetch(path, { method = 'GET', token, query = {} } = {}) {
 // planSolicitations consumes (so all guardrails are shared). A top-level Threads
 // post is its own thread root; the numeric media id doubles as the reply target
 // (`reply_to_id`) and the doc `cid`. Exported for unit tests.
+//
+// displayName is intentionally '': keyword_search returns `username` but no
+// display name (that would need a per-author user lookup), so isLikelyBotAccount
+// runs HANDLE-ONLY on Threads — its 🤖/display-name branch is Bluesky-only. The
+// handle signal (…bot / feed / rss / known-mirror) is the strong one and catches
+// the accounts this lane actually hits.
 export function threadsPostToNormalized(m) {
   const id = m && m.id != null ? String(m.id) : '';
   const username = (m && m.username) || '';

--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -97,6 +97,8 @@ export const DEFAULTS = {
 export const SOLICITATION_DEFAULTS = {
   enabled: false, // master switch — inert until on; turning it off also freezes in-flight work (dispatch + reply)
   queries: [], // Bluesky search queries run each tick, e.g. ['drop your startup link']
+  threadsEnabled: false, // independent master switch for the Threads (Meta) proactive lane — needs a Threads token in the vault too
+  threadsQueries: [], // Threads keyword_search queries run each tick
   maxPerAuthorPerDay: 1, // one reply per poster per UTC day — never pile onto anyone
   authorCooldownDays: 30, // and never proactively reply to the same poster twice inside this window (~a month). Mentions bypass this entirely — someone who @-mentions us always gets answered.
   maxGlobalPerDay: 8, // REPLY ceiling for the proactive lane, enforced post-classification
@@ -599,8 +601,15 @@ export function sanitizeIdea(text) {
 // never the poster's text. The individualization is the app itself (a bespoke,
 // live, remixable build), not the words. Threaded onto the solicitation post
 // exactly like buildReplyRecord threads onto a mention.
+// The fixed solicitation reply text, shared by every platform's reply builder
+// (Bluesky record, Threads post). Platform-agnostic — only the link matters, and
+// it's our own constant string, so the no-echo invariant holds everywhere.
+export function solicitationReplyText(vibeUrl) {
+  return `Couldn't resist — built you a little app to drop in the thread. Live + yours to remix: ${vibeUrl}\n\nMake your own by chatting: https://vibes.diy`;
+}
+
 export function buildSolicitationReply({ solicitation, vibeUrl, createdAt, embed }) {
-  const text = `Couldn't resist — built you a little app to drop in the thread. Live + yours to remix: ${vibeUrl}\n\nMake your own by chatting: https://vibes.diy`;
+  const text = solicitationReplyText(vibeUrl);
   if ([...text].length > BSKY_MAX_TEXT)
     return { error: `reply text is ${[...text].length} chars (max ${BSKY_MAX_TEXT})` };
   return {
@@ -627,10 +636,23 @@ export function buildSolicitationReply({ solicitation, vibeUrl, createdAt, embed
 // live/fresh ones first"). It emits up to maxNewPerTick candidates to EXAMINE;
 // the daily REPLY cap (maxGlobalPerDay) is enforced later, at accept time — so
 // a small reply cap never starves how many posts reach the classifier.
-export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
+export function planSolicitations({
+  posts,
+  selfDid,
+  existing,
+  cfg,
+  nowIso,
+  platform = 'bsky',
+  docId = (p) => solicitationDocId(p.uri),
+}) {
   const day = dayKey(nowIso);
   const existingIds = new Set(existing.map((d) => d._id));
-  const accepted = existing.filter((d) => d.kind === 'solicitation' && d.status !== 'skipped');
+  // Caps and cooldown are counted PER platform: a legacy doc with no `platform`
+  // field is treated as bsky, so the Bluesky lane's budgets are unchanged.
+  const accepted = existing.filter(
+    (d) =>
+      d.kind === 'solicitation' && d.status !== 'skipped' && (d.platform || 'bsky') === platform
+  );
   let todayCount = accepted.filter((d) => d.day === day).length;
   const authorCounts = new Map();
   for (const d of accepted) {
@@ -659,7 +681,7 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
     .sort((a, b) => ((a.indexedAt || '') > (b.indexedAt || '') ? -1 : 1));
 
   for (const p of freshestFirst) {
-    const id = solicitationDocId(p.uri);
+    const id = docId(p);
     if (!id || existingIds.has(id)) continue;
     existingIds.add(id);
     const record = p.record || {};
@@ -668,6 +690,7 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
       _id: id,
       kind: 'solicitation',
       source: 'search',
+      platform,
       uri: p.uri,
       cid: p.cid,
       // A top-level solicitation post is its own thread root; reply refs mirror
@@ -773,6 +796,13 @@ export async function loadSolicitationConfig(ctx) {
       .filter((q) => typeof q === 'string' && q.trim().length > 0)
       .map((q) => q.trim());
   }
+  // Threads lane: independent enable + its own query list, same validation shape.
+  cfg.threadsEnabled = cfgDoc.threadsEnabled === true;
+  if (Array.isArray(cfgDoc.threadsQueries)) {
+    cfg.threadsQueries = cfgDoc.threadsQueries
+      .filter((q) => typeof q === 'string' && q.trim().length > 0)
+      .map((q) => q.trim());
+  }
   // Count caps are budgets — they MUST be non-negative integers. A fractional
   // cap silently rounds up at the `count >= cap` check (e.g. maxGlobalPerDay
   // 0.5 lets one build through a sub-1 ceiling), and Infinity/NaN produce
@@ -805,6 +835,31 @@ async function projectTokenStatus(ctx, t) {
     platform: 'bsky',
     handle: (t && t.handle) || null,
     did: (t && t.did) || null,
+    refreshedAt: (t && t.refreshedAt) || null,
+    needsReauth: !!(t && t.needsReauth),
+    lastError: (t && t.lastError) || null,
+    hasToken: !!(t && t.token),
+  };
+  const prev = statuses.find((s) => s._id === next._id);
+  const changed =
+    !prev ||
+    ['handle', 'did', 'refreshedAt', 'needsReauth', 'lastError', 'hasToken'].some(
+      (k) => prev[k] !== next[k]
+    );
+  if (changed) await ctx.db.put({ ...next, at: new Date().toISOString() }, { db: 'oplog' });
+}
+
+// Redacted Threads token status for the dashboard (the vault stays write-only —
+// the dashboard can't read the token, only this projection). Mirrors
+// projectTokenStatus so the console shows whether a Threads credential is live.
+async function projectThreadsTokenStatus(ctx, t) {
+  const statuses = (await ctx.db.query({ db: 'oplog' })).filter((d) => d.kind === 'token-status');
+  const next = {
+    _id: 'status-threads',
+    kind: 'token-status',
+    platform: 'threads',
+    handle: (t && t.username) || null,
+    did: (t && t.userId) || null,
     refreshedAt: (t && t.refreshedAt) || null,
     needsReauth: !!(t && t.needsReauth),
     lastError: (t && t.lastError) || null,
@@ -1134,10 +1189,16 @@ async function classifySolicitation(ctx, postText) {
 // { prompt } on success, { skip: reason } when the idea is unusable/unsafe, or
 // null on a transient failure (defer to a later tick — the deterministic doc id
 // means the post is simply re-planned).
-async function deriveSolicitationIdea(ctx, doc, accessJwt, cfg) {
-  const posts = doc.authorDid
-    ? await bskyAuthorPosts(doc.authorDid, { token: accessJwt, limit: cfg.authorFeedLimit })
-    : [];
+async function deriveSolicitationIdea(ctx, doc, accessJwt, cfg, opts = {}) {
+  // Bluesky gives us the poster's whole recent feed to individualize from;
+  // Threads' API can't read an arbitrary user's feed, so the caller passes the
+  // matched post text as a thinner corpus (`opts.posts`). Either way the idea is
+  // derived from untrusted text and only ever becomes the build PROMPT.
+  const posts = opts.posts
+    ? opts.posts
+    : doc.authorDid
+      ? await bskyAuthorPosts(doc.authorDid, { token: accessJwt, limit: cfg.authorFeedLimit })
+      : [];
   let raw;
   try {
     raw = await ctx.callAI(buildIdeaPrompt(posts), { max_tokens: 60 });
@@ -1152,6 +1213,195 @@ async function deriveSolicitationIdea(ctx, doc, accessJwt, cfg) {
   const mod = moderatePrompt(idea, DEFAULTS);
   if (mod.ok !== true) return { skip: `idea ${mod.reason}` };
   return { prompt: idea };
+}
+
+// --- Threads (Meta) proactive lane -------------------------------------------
+// The Bluesky solicitation lane ported to Threads: same doc protocol, same
+// guardrails (planSolicitations with platform:'threads'), same CI builder lane —
+// only the network I/O differs. Threads publishing is TWO calls (create a media
+// container, then publish it) and a reply is threaded via `reply_to_id` rather
+// than Bluesky's root/parent strong refs. Dark until an owner BOTH flips
+// `threadsEnabled` in the config-solicitation doc AND pastes a long-lived Threads
+// token (`kind:'token', platform:'threads'`) into the write-only vault.
+//
+// NOTE: the exact keyword_search params and the create/publish field names follow
+// Meta's Threads Graph API and need one live smoke test once a token exists —
+// there's no way to exercise the real API from CI. Everything the unit tests
+// cover (triage, ids, reply text, config) is platform-pure.
+const THREADS_HOST = 'https://graph.threads.net';
+const THREADS_API_VERSION = 'v1.0';
+export const THREADS_MAX_TEXT = 500; // Threads post character limit
+
+// All Threads Graph params (incl. POST bodies) ride the query string, the way the
+// Graph API accepts them. `access_token` is appended here so no caller forgets it.
+async function threadsFetch(path, { method = 'GET', token, query = {} } = {}) {
+  const params = new URLSearchParams(query);
+  if (token) params.set('access_token', token);
+  let res;
+  try {
+    res = await fetch(`${THREADS_HOST}/${THREADS_API_VERSION}/${path}?${params.toString()}`, {
+      method,
+    });
+  } catch (e) {
+    return { ok: false, transport: String((e && e.message) || e) };
+  }
+  let data = {};
+  try {
+    data = await res.json();
+  } catch {
+    data = { raw: true };
+  }
+  if (data && data.vibesEgressDenied) return { ok: false, egressDenied: data.gate || true };
+  if (!res.ok) {
+    const err = (data && data.error) || {};
+    return {
+      ok: false,
+      status: res.status,
+      code: err.code,
+      message: err.message || `HTTP ${res.status}`,
+    };
+  }
+  return { ok: true, data };
+}
+
+// Normalize one Threads keyword_search result into the same post shape
+// planSolicitations consumes (so all guardrails are shared). A top-level Threads
+// post is its own thread root; the numeric media id doubles as the reply target
+// (`reply_to_id`) and the doc `cid`. Exported for unit tests.
+export function threadsPostToNormalized(m) {
+  const id = m && m.id != null ? String(m.id) : '';
+  const username = (m && m.username) || '';
+  return {
+    uri: (m && m.permalink) || (id ? `https://www.threads.net/@${username}/post/${id}` : ''),
+    cid: id,
+    author: { did: username ? `threads:${username}` : null, handle: username, displayName: '' },
+    record: { text: (m && m.text) || '' },
+    indexedAt: (m && m.timestamp) || '',
+  };
+}
+
+// Deterministic, platform-scoped doc id (mirrors solicitationDocId's cursorless
+// idempotency). Keyed on the Threads media id carried in the normalized `cid`.
+export function threadsSolicitationDocId(p) {
+  const id = String((p && p.cid) || '');
+  return id ? `sol-threads-${id}`.replace(/[^a-zA-Z0-9:._-]/g, '_') : null;
+}
+
+// Resolve the Threads user id from the pasted token (minting IS the check — /me
+// answers with id+username, persisted on the vault doc like bskySession does).
+async function threadsSession(ctx, t) {
+  if (t.userId) return { userId: t.userId, t };
+  const r = await threadsFetch('me', { token: t.token, query: { fields: 'id,username' } });
+  if (!r.ok) return { r };
+  const next = {
+    ...t,
+    userId: r.data.id,
+    username: r.data.username || t.username || null,
+    needsReauth: false,
+    lastError: null,
+  };
+  await ctx.db.put(next, { db: 'vault' });
+  Object.assign(t, next);
+  return { userId: r.data.id, t: next };
+}
+
+// Search public Threads posts by keyword. Requires the `threads_keyword_search`
+// permission (Meta app review); until that's approved the endpoint returns only
+// the authenticated user's own posts, so the lane simply finds nothing.
+async function threadsSearchPosts(query, { token, limit = 25, since } = {}) {
+  const q = {
+    q: query,
+    search_type: 'RECENT',
+    fields: 'id,text,username,permalink,timestamp',
+    limit: String(limit),
+  };
+  if (since) q.since = since;
+  const r = await threadsFetch('keyword_search', { token, query: q });
+  if (!r.ok) return r;
+  return { ok: true, posts: ((r.data && r.data.data) || []).map(threadsPostToNormalized) };
+}
+
+// Post the in-thread reply for a built Threads solicitation. Two-call publish:
+// create a TEXT container replying to the post, then publish it. Quiet failure +
+// MAX_REPLY_ATTEMPTS bound, exactly like replyToMention. Fixed template text
+// (solicitationReplyText) — no echo of the poster's words.
+async function threadsReply(ctx, m, t, userId) {
+  const save = (patch) =>
+    ctx.db.put(
+      { ...m, ...patch, attempts: (m.attempts || 0) + 1, updatedAt: new Date().toISOString() },
+      { db: 'requests' }
+    );
+  if ((m.attempts || 0) >= MAX_REPLY_ATTEMPTS) {
+    await log(ctx, { op: 'reply-gave-up', uri: m.uri, platform: 'threads' });
+    return save({ status: 'error', error: `reply gave up after ${MAX_REPLY_ATTEMPTS} attempts` });
+  }
+  const text = solicitationReplyText(m.vibeUrl);
+  if ([...text].length > THREADS_MAX_TEXT)
+    return save({ status: 'error', error: `reply text too long for threads` });
+  try {
+    const create = await threadsFetch(`${userId}/threads`, {
+      method: 'POST',
+      token: t.token,
+      query: { media_type: 'TEXT', text, reply_to_id: m.cid },
+    });
+    if (!create.ok) {
+      if (create.status === 401) {
+        await ctx.db.put({ ...t, needsReauth: true, lastError: create.message }, { db: 'vault' });
+        await log(ctx, {
+          op: 'reply-held',
+          uri: m.uri,
+          platform: 'threads',
+          error: 'token needs re-auth',
+        });
+        return save({ status: 'built' });
+      }
+      await log(ctx, {
+        op: 'reply-failed',
+        uri: m.uri,
+        platform: 'threads',
+        error: create.message || create.egressDenied || create.transport,
+      });
+      return save({ status: 'built' }); // retry next tick, bounded by MAX_REPLY_ATTEMPTS
+    }
+    const creationId = create.data && (create.data.id || create.data.creation_id);
+    if (!creationId) {
+      await log(ctx, {
+        op: 'reply-failed',
+        uri: m.uri,
+        platform: 'threads',
+        error: 'no creation id',
+      });
+      return save({ status: 'built' });
+    }
+    const pub = await threadsFetch(`${userId}/threads_publish`, {
+      method: 'POST',
+      token: t.token,
+      query: { creation_id: creationId },
+    });
+    if (!pub.ok) {
+      await log(ctx, {
+        op: 'reply-failed',
+        uri: m.uri,
+        platform: 'threads',
+        error: pub.message || pub.egressDenied || pub.transport,
+      });
+      return save({ status: 'built' });
+    }
+    await save({
+      status: 'replied',
+      replyId: (pub.data && pub.data.id) || null,
+      repliedAt: new Date().toISOString(),
+    });
+    await log(ctx, {
+      op: 'replied',
+      uri: m.uri,
+      platform: 'threads',
+      vibeUrl: m.vibeUrl,
+      replyId: pub.data && pub.data.id,
+    });
+  } catch (e) {
+    await save({ status: 'built', lastError: String((e && e.message) || e) });
+  }
 }
 
 // Work the builder can act on (pure, unit-tested): freshly `pending-build`
@@ -1321,19 +1571,22 @@ async function likeAcceptedMentions(ctx, accessJwt, botDid) {
 // lives in the same write-only vault as the Bluesky credential (#3529): pasted
 // on the dashboard, never synced to any browser, read here in admin mode.
 // Dark until it's pasted — a missing token no-ops silently.
-async function maybeDispatchBuilder(ctx, { includeSolicitations = false } = {}) {
+async function maybeDispatchBuilder(ctx, { activePlatforms = new Set() } = {}) {
   const ghVault = (await ctx.db.query({ db: 'vault' })).filter(
     (d) => d.kind === 'token' && d.platform === 'github'
   );
   const token = ghVault[0] && ghVault[0].token;
   if (!token) return;
 
-  // When the solicitation lane is inactive it's a hard freeze, not just "stop
-  // finding new ones": already-queued solicitation docs must NOT dispatch (or
-  // reply) — so exclude them from the builder count unless the lane is on. The
-  // mention lane is always counted.
+  // When a solicitation lane is inactive it's a hard freeze, not just "stop
+  // finding new ones": already-queued solicitation docs for that platform must
+  // NOT dispatch (or reply). So a solicitation doc counts only while ITS platform
+  // lane is active (a legacy doc with no platform is bsky). The mention lane is
+  // always counted.
   const requests = (await ctx.db.query({ db: 'requests' })).filter(
-    (d) => d.kind === 'mention' || (includeSolicitations && d.kind === 'solicitation')
+    (d) =>
+      d.kind === 'mention' ||
+      (d.kind === 'solicitation' && activePlatforms.has(d.platform || 'bsky'))
   );
   const nowMs = Date.now();
   // Count stale `building` docs alongside `pending-build` so a crashed runner's
@@ -1383,12 +1636,44 @@ export async function scheduled(event, ctx) {
 
   const requestsAll = await ctx.db.query({ db: 'requests' });
   const existing = requestsAll.filter((d) => d.kind === 'mention');
-  const existingSol = requestsAll.filter((d) => d.kind === 'solicitation');
-  // The solicitation lane's master switch. When off (or no config doc), the
-  // whole lane is frozen — not just search, but the shared builder dispatch and
-  // the reply loop too — so flipping enabled:false is a real emergency stop for
-  // work already in flight, matching the documented dark-by-default contract.
+  const existingSol = requestsAll.filter(
+    (d) => d.kind === 'solicitation' && (d.platform || 'bsky') === 'bsky'
+  );
+  const existingThreadsSol = requestsAll.filter(
+    (d) => d.kind === 'solicitation' && d.platform === 'threads'
+  );
+  // Each solicitation lane has its own master switch. When off (or no config
+  // doc), that lane is frozen — not just search, but the shared builder dispatch
+  // and the reply loop too — so flipping enabled:false is a real emergency stop
+  // for work already in flight, matching the documented dark-by-default contract.
   const solActive = solCfg.enabled === true;
+
+  // Threads (Meta) proactive lane: independent switch, and it needs its own token
+  // in the vault. Resolve the user id once; if there's no token / it needs
+  // re-auth / the switch is off, threadsUserId stays null and the whole lane
+  // no-ops (dark-by-default, same as an un-pasted Bluesky credential).
+  const threadsVault = (await ctx.db.query({ db: 'vault' })).filter(
+    (d) => d.kind === 'token' && d.platform === 'threads'
+  );
+  const threadsToken = threadsVault[0];
+  await projectThreadsTokenStatus(ctx, threadsToken);
+  let threadsUserId = null;
+  const threadsActive = solCfg.threadsEnabled === true;
+  if (threadsActive && threadsToken && threadsToken.token && !threadsToken.needsReauth) {
+    const ts = await threadsSession(ctx, threadsToken);
+    if (ts.userId) {
+      threadsUserId = ts.userId;
+    } else {
+      await ctx.db.put(
+        {
+          ...threadsToken,
+          needsReauth: ts.r && ts.r.status === 401,
+          lastError: (ts.r && (ts.r.message || ts.r.egressDenied)) || 'threads session failed',
+        },
+        { db: 'vault' }
+      );
+    }
+  }
 
   // 1. Listen: one page of the newest notifications. Deterministic doc ids
   // make reprocessing idempotent, so no cursor bookkeeping is needed; a burst
@@ -1516,17 +1801,101 @@ export async function scheduled(event, ctx) {
     await noteListenerState(ctx, { solLastPollAt: nowIso, solNewDocs: solNew });
   }
 
+  // 1c. Threads search: the same proactive lane on Meta's Threads. Identical
+  // triage (planSolicitations, platform:'threads') and pipeline; only the search
+  // API and the reply mechanics differ. Individualization uses just the matched
+  // post text — the Threads API can't read an arbitrary poster's feed.
+  if (threadsActive && threadsUserId && solCfg.threadsQueries.length > 0) {
+    const sinceUnix = String(Math.floor((nowMs - solCfg.maxPostAgeHours * 3600000) / 1000));
+    const seenPosts = new Map();
+    for (const q of solCfg.threadsQueries.slice(0, 6)) {
+      const rs = await threadsSearchPosts(q, {
+        token: threadsToken.token,
+        limit: solCfg.searchLimit,
+        since: sinceUnix,
+      });
+      if (rs.ok) {
+        for (const post of rs.posts || []) if (post && post.cid) seenPosts.set(post.cid, post);
+      } else {
+        await noteListenerState(ctx, {
+          threadsLastError: rs.message || rs.egressDenied || rs.transport,
+        });
+      }
+    }
+    const solPlan = planSolicitations({
+      posts: [...seenPosts.values()],
+      selfDid: threadsToken.userId ? `threads:${threadsToken.username || ''}` : null,
+      existing: existingThreadsSol,
+      cfg: solCfg,
+      nowIso,
+      platform: 'threads',
+      docId: threadsSolicitationDocId,
+    });
+    const solDay = dayKey(nowIso);
+    let acceptedToday = existingThreadsSol.filter(
+      (d) => d.status !== 'skipped' && d.day === solDay
+    ).length;
+    let threadsNew = 0;
+    for (const doc of solPlan) {
+      if (doc.status !== 'candidate') {
+        await ctx.db.put(doc, { db: 'requests' });
+        continue;
+      }
+      const verdict = await classifySolicitation(ctx, doc.text);
+      if (verdict === null) continue;
+      if (verdict === 'skip') {
+        await ctx.db.put(
+          { ...doc, status: 'skipped', reason: 'not a solicitation' },
+          { db: 'requests' }
+        );
+        continue;
+      }
+      if (acceptedToday >= solCfg.maxGlobalPerDay) {
+        await ctx.db.put(
+          { ...doc, status: 'skipped', reason: 'global daily cap' },
+          { db: 'requests' }
+        );
+        continue;
+      }
+      // Individualize from the matched post text only (no author-feed API).
+      const idea = await deriveSolicitationIdea(ctx, doc, null, solCfg, {
+        posts: [doc.text].filter(Boolean),
+      });
+      if (idea === null) continue;
+      if (idea.skip) {
+        await ctx.db.put({ ...doc, status: 'skipped', reason: idea.skip }, { db: 'requests' });
+        continue;
+      }
+      await ctx.db.put(
+        { ...doc, status: 'pending-build', prompt: idea.prompt, promptKey: promptKey(idea.prompt) },
+        { db: 'requests' }
+      );
+      acceptedToday += 1;
+      threadsNew += 1;
+      await log(ctx, {
+        op: 'solicitation-accepted',
+        platform: 'threads',
+        uri: doc.uri,
+        prompt: idea.prompt,
+      });
+    }
+    await noteListenerState(ctx, { threadsLastPollAt: nowIso, threadsNewDocs: threadsNew });
+  }
+
   // 2. Acknowledge each accepted request by liking its post — the first
   // visible signal to the requester that we're building it, before the build
   // even dispatches. Re-queries (not the start-of-tick snapshot) so mentions
   // accepted this very tick get liked now.
   await likeAcceptedMentions(ctx, s.accessJwt, s.t.did);
 
-  // 3. Fire the builder lane on demand if mentions are queued (#3529) — the
+  // 3. Fire the builder lane on demand if work is queued (#3529) — the
   // event-driven replacement for the polling cron. Debounced; dark until the
-  // GITHUB_DISPATCH_TOKEN secret exists. Both lanes share this dispatcher, but
-  // solicitation docs only count while the lane is active (kill-switch).
-  await maybeDispatchBuilder(ctx, { includeSolicitations: solActive });
+  // GITHUB_DISPATCH_TOKEN secret exists. All lanes share this one dispatcher;
+  // a solicitation doc counts only while ITS platform lane is active (kill-switch).
+  const activePlatforms = new Set();
+  if (solActive) activePlatforms.add('bsky');
+  if (threadsActive && threadsUserId) activePlatforms.add('threads');
+  await maybeDispatchBuilder(ctx, { activePlatforms });
 
   // 4. Reply to verified-live builds (the builder lane sets `built` only after
   // the published vibe answered 200). Each lane has its own per-tick reply cap.
@@ -1540,6 +1909,14 @@ export async function scheduled(event, ctx) {
     const builtSol = existingSol.filter((d) => d.status === 'built' && d.vibeUrl);
     for (const m of builtSol.slice(0, solCfg.maxRepliesPerTick)) {
       await replyToMention(ctx, m, s.t, s.accessJwt);
+    }
+  }
+  // Threads replies ride the two-call publish; same per-tick reply cap, same
+  // freeze semantics (disabling the lane stops built Threads docs from posting).
+  if (threadsActive && threadsUserId) {
+    const builtThreads = existingThreadsSol.filter((d) => d.status === 'built' && d.vibeUrl);
+    for (const m of builtThreads.slice(0, solCfg.maxRepliesPerTick)) {
+      await threadsReply(ctx, m, threadsToken, threadsUserId);
     }
   }
 

--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -98,6 +98,7 @@ export const SOLICITATION_DEFAULTS = {
   enabled: false, // master switch — inert until on; turning it off also freezes in-flight work (dispatch + reply)
   queries: [], // Bluesky search queries run each tick, e.g. ['drop your startup link']
   maxPerAuthorPerDay: 1, // one reply per poster per UTC day — never pile onto anyone
+  authorCooldownDays: 30, // and never proactively reply to the same poster twice inside this window (~a month). Mentions bypass this entirely — someone who @-mentions us always gets answered.
   maxGlobalPerDay: 8, // REPLY ceiling for the proactive lane, enforced post-classification
   maxNewPerTick: 12, // posts EXAMINED (classified) per tick — decoupled from the reply cap
   maxRepliesPerTick: 1, // replies posted per tick — deliberately slow, human-paced
@@ -105,6 +106,36 @@ export const SOLICITATION_DEFAULTS = {
   searchLimit: 25, // posts fetched per query per tick
   authorFeedLimit: 20, // of the poster's recent posts fed to the idea model
 };
+
+// Never proactively reply to automated accounts. The proactive lane searches for
+// posts that read like "what are you building" invitations, and news/aggregator
+// bots (Hacker News mirrors, RSS-to-Bluesky feeds) syndicate exactly that phrasing
+// — so replying to them is bot-to-bot spam under an automated post that no human
+// is watching (the reply-bot-hn incident: we replied to hackernewsbot.bsky.social's
+// "Ask HN: What Are You Working On?" repost). This is a deterministic handle/
+// display-name signal, deliberately high-precision: a miss just leaves one more
+// filter downstream (the LLM SHARE gate), and a false positive only costs the
+// PROACTIVE lane one poster — who can still @-mention us, since the reactive
+// mention lane never consults this gate.
+const BOT_NAME_TOKENS =
+  /(^|[^a-z])(bot|bots|feed|feeds|rss|atom|headlines?|digest|aggregat\w*|syndicat\w*)([^a-z]|$)/i;
+const KNOWN_BOT_HANDLES = /(hacker\W?news|lobste\.?rs|slashdot|techmeme)/i;
+
+export function isLikelyBotAccount(author) {
+  const handle = String((author && author.handle) || '').toLowerCase();
+  if (!handle) return false;
+  const displayName = String((author && author.displayName) || '');
+  // The account-name label is everything before the domain (…bsky.social, a
+  // custom domain, or a brid.gy bridge suffix). Bot markers live there or in the
+  // display name.
+  const label = handle.split('.')[0] || handle;
+  if (/bots?$/.test(label)) return true; // hackernewsbot, weatherbot
+  if (BOT_NAME_TOKENS.test(label)) return true; // news-feed, rss-mirror, daily-digest
+  if (KNOWN_BOT_HANDLES.test(handle)) return true; // hackernews.*, lobsters.*
+  if (/🤖/.test(displayName)) return true; // the "I am a bot" convention
+  if (BOT_NAME_TOKENS.test(displayName) || KNOWN_BOT_HANDLES.test(displayName)) return true;
+  return false;
+}
 
 // --- Bluesky XRPC client (ported from vibes/meta-hub/backend.js) -------------
 // The XRPC API is fully CORS-open (ACAO *), so these calls ride the CORS-parity
@@ -214,7 +245,9 @@ const BSKY_SESSION_FRESH_MS = 30 * 60000;
 // didDoc; the PDS is its AtprotoPersonalDataServer service endpoint.
 export function pdsHostFromDidDoc(didDoc) {
   const services = didDoc && Array.isArray(didDoc.service) ? didDoc.service : [];
-  const pds = services.find((s) => s && (s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer'));
+  const pds = services.find(
+    (s) => s && (s.id === '#atproto_pds' || s.type === 'AtprotoPersonalDataServer')
+  );
   const ep = pds && typeof pds.serviceEndpoint === 'string' ? pds.serviceEndpoint : '';
   return /^https:\/\//.test(ep) ? ep.replace(/\/+$/, '') : null;
 }
@@ -601,6 +634,20 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
   const out = [];
   let acceptedThisTick = 0;
   const nowMs = new Date(nowIso).getTime();
+  // Per-author cooldown: don't proactively reply to the same poster more than
+  // once inside authorCooldownDays (~a month). A poster who @-mentions us is a
+  // different lane (kind 'mention') and never hits this — "unless they mention
+  // us". Older docs may carry only `day`; normalize to a comparable ISO stamp.
+  const cooldownDays = Number.isFinite(cfg.authorCooldownDays) ? cfg.authorCooldownDays : 0;
+  const cooldownStart =
+    cooldownDays > 0 ? new Date(nowMs - cooldownDays * 86400000).toISOString() : null;
+  const cooledDownAuthors = new Set();
+  if (cooldownStart) {
+    for (const d of accepted) {
+      const ts = d.createdAt || (d.day ? `${d.day}T00:00:00.000Z` : '');
+      if (ts && ts >= cooldownStart) cooledDownAuthors.add(d.authorDid);
+    }
+  }
   const freshestFirst = (posts || [])
     .filter((p) => p && p.uri && p.cid)
     .sort((a, b) => ((a.indexedAt || '') > (b.indexedAt || '') ? -1 : 1));
@@ -636,6 +683,11 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
       skip('own post');
       continue;
     }
+    // Never proactively reply to bots/aggregators (the reply-bot-hn incident).
+    if (isLikelyBotAccount(p.author)) {
+      skip('bot account');
+      continue;
+    }
     // Freshness gate: search re-returns the same posts every tick, and an old
     // "drop your link" thread has moved on — answering it now reads as spam.
     if (
@@ -647,6 +699,13 @@ export function planSolicitations({ posts, selfDid, existing, cfg, nowIso }) {
     }
     if ((authorCounts.get(authorDid) || 0) >= cfg.maxPerAuthorPerDay) {
       skip('author daily cap');
+      continue;
+    }
+    // Then the monthly cooldown: even under the daily cap, one proactive reply
+    // per poster per ~month. Checked after the daily cap so a same-day repeat
+    // still reads as the daily cap; a prior-day reply inside the window lands here.
+    if (cooldownStart && cooledDownAuthors.has(authorDid)) {
+      skip('author cooldown');
       continue;
     }
     // Once the day's REPLY budget is already spent (persisted accepts), stop
@@ -709,6 +768,7 @@ export async function loadSolicitationConfig(ctx) {
   // malformed limits — so reject anything non-integer and keep the default.
   for (const k of [
     'maxPerAuthorPerDay',
+    'authorCooldownDays',
     'maxGlobalPerDay',
     'maxNewPerTick',
     'maxRepliesPerTick',
@@ -841,11 +901,19 @@ async function replyToMention(ctx, m, t, accessJwt) {
     // reply reliably shows what was built (the blog engine's media-ready gate).
     const shot = await fetchScreenshotEmbed(m, accessJwt);
     if (!shot.embed && shot.pending && (m.screenshotWaits || 0) < MAX_SCREENSHOT_WAITS) {
-      await log(ctx, { op: 'reply-awaiting-screenshot', uri: m.uri, waits: (m.screenshotWaits || 0) + 1 });
+      await log(ctx, {
+        op: 'reply-awaiting-screenshot',
+        uri: m.uri,
+        waits: (m.screenshotWaits || 0) + 1,
+      });
       // Defer without consuming a hard reply attempt; the doc stays `built` so
       // next tick re-picks it. Bounded by MAX_SCREENSHOT_WAITS.
       return ctx.db.put(
-        { ...m, screenshotWaits: (m.screenshotWaits || 0) + 1, updatedAt: new Date().toISOString() },
+        {
+          ...m,
+          screenshotWaits: (m.screenshotWaits || 0) + 1,
+          updatedAt: new Date().toISOString(),
+        },
         { db: 'requests' }
       );
     }
@@ -920,11 +988,14 @@ async function sendClaimDm(ctx, m, accessJwt, pdsHost) {
 
   // chat.bsky.convo.* must hit the account's own PDS, not the entryway (#3591).
   const chatHost = pdsHost || BSKY_HOST;
-  const conv = await bskyFetch(`chat.bsky.convo.getConvoForMembers?members=${encodeURIComponent(m.authorDid)}`, {
-    token: accessJwt,
-    proxy: BSKY_CHAT_PROXY,
-    host: chatHost,
-  });
+  const conv = await bskyFetch(
+    `chat.bsky.convo.getConvoForMembers?members=${encodeURIComponent(m.authorDid)}`,
+    {
+      token: accessJwt,
+      proxy: BSKY_CHAT_PROXY,
+      host: chatHost,
+    }
+  );
   const convoId = conv.ok ? conv.data.convo && conv.data.convo.id : null;
   if (!convoId) {
     await log(ctx, {
@@ -1179,7 +1250,16 @@ async function likeMention(ctx, m, accessJwt, botDid) {
     likeAttempts: 0,
   };
   const write = (patch) =>
-    ctx.db.put({ ...prev, kind: 'like-state', mentionId: m._id, likeAttempts: (prev.likeAttempts || 0) + 1, ...patch }, { db: 'oplog' });
+    ctx.db.put(
+      {
+        ...prev,
+        kind: 'like-state',
+        mentionId: m._id,
+        likeAttempts: (prev.likeAttempts || 0) + 1,
+        ...patch,
+      },
+      { db: 'oplog' }
+    );
 
   const built = buildLikeRecord({ uri: m.uri, cid: m.cid, createdAt: new Date().toISOString() });
   if (built.error) return write({ likeError: built.error });
@@ -1189,11 +1269,19 @@ async function likeMention(ctx, m, accessJwt, botDid) {
     token: accessJwt,
   });
   if (!r.ok) {
-    await log(ctx, { op: 'like-failed', uri: m.uri, error: r.message || r.egressDenied || r.transport });
+    await log(ctx, {
+      op: 'like-failed',
+      uri: m.uri,
+      error: r.message || r.egressDenied || r.transport,
+    });
     return write({ likeError: r.message || r.egressDenied || 'like failed' });
   }
   await log(ctx, { op: 'like-sent', uri: m.uri });
-  await write({ likedAt: new Date().toISOString(), likeError: null, likeUri: r.data && r.data.uri });
+  await write({
+    likedAt: new Date().toISOString(),
+    likeError: null,
+    likeUri: r.data && r.data.uri,
+  });
 }
 
 // Sweep newly-accepted requests and like the ones we haven't yet. Scoped to
@@ -1207,7 +1295,9 @@ async function likeAcceptedMentions(ctx, accessJwt, botDid) {
     (d) => d.kind === 'mention' && d.status === 'pending-build'
   );
   const stateById = new Map(
-    (await ctx.db.query({ db: 'oplog' })).filter((d) => d.kind === 'like-state').map((d) => [d.mentionId, d])
+    (await ctx.db.query({ db: 'oplog' }))
+      .filter((d) => d.kind === 'like-state')
+      .map((d) => [d.mentionId, d])
   );
   for (const m of mentions) {
     const st = stateById.get(m._id);

--- a/examples/mention-hub/backend.js
+++ b/examples/mention-hub/backend.js
@@ -504,9 +504,16 @@ export function buildClaimDm({ mention }) {
   return { text, facets: bskyLinkFacets(text), claimUrl };
 }
 
+// The fixed mention-reply text, shared by every platform's reply builder
+// (Bluesky record, Threads post). Platform-agnostic — our own constant string,
+// so the no-echo invariant holds everywhere.
+export function mentionReplyText(vibeUrl) {
+  return `Built it — try it live: ${vibeUrl}\n\nMake your own at https://vibes.diy`;
+}
+
 // The in-thread reply. Fixed template — never model output, never error text.
 export function buildReplyRecord({ mention, vibeUrl, createdAt, embed }) {
-  const text = `Built it — try it live: ${vibeUrl}\n\nMake your own at https://vibes.diy`;
+  const text = mentionReplyText(vibeUrl);
   if ([...text].length > BSKY_MAX_TEXT)
     return { error: `reply text is ${[...text].length} chars (max ${BSKY_MAX_TEXT})` };
   return {
@@ -1293,6 +1300,107 @@ export function threadsSolicitationDocId(p) {
   return id ? `sol-threads-${id}`.replace(/[^a-zA-Z0-9:._-]/g, '_') : null;
 }
 
+// Deterministic id for a Threads @-mention (cursorless idempotency, like
+// mentionDocId — the me/mentions page has no cursor, so re-reads must no-op).
+export function threadsMentionDocId(id) {
+  const s = String(id || '');
+  return s ? `mention-threads-${s}`.replace(/[^a-zA-Z0-9:._-]/g, '_') : null;
+}
+
+// Triage a page of Threads @-mentions into mention docs, enforcing the SAME
+// guardrails as planMentions (dedupe, per-author + global daily caps, moderation,
+// stale-age) against existing Threads mention docs. Pure — clock/db state in as
+// args. No bot filter: an @-mention is opt-in, so we answer it even from a bot
+// (parity with the Bluesky mention lane). `mentions` are already normalized to
+// { id, text, username, permalink, timestamp }.
+export function planThreadsMentions({ mentions, selfHandle, existing, cfg, nowIso }) {
+  const day = dayKey(nowIso);
+  const existingIds = new Set(existing.map((d) => d._id));
+  const accepted = existing.filter((d) => d.kind === 'mention' && d.status !== 'skipped');
+  const windowStart = new Date(
+    new Date(nowIso).getTime() - cfg.dedupeWindowDays * 86400000
+  ).toISOString();
+  const recentKeys = new Set(
+    accepted.filter((d) => (d.createdAt || '') >= windowStart).map((d) => d.promptKey)
+  );
+  let todayCount = accepted.filter((d) => d.day === day).length;
+  const authorCounts = new Map();
+  for (const d of accepted) {
+    if (d.day === day) authorCounts.set(d.authorDid, (authorCounts.get(d.authorDid) || 0) + 1);
+  }
+
+  const out = [];
+  let acceptedThisTick = 0;
+  const nowMs = new Date(nowIso).getTime();
+  const oldestFirst = (mentions || [])
+    .filter((m) => m && m.id)
+    .sort((a, b) => ((a.timestamp || '') < (b.timestamp || '') ? -1 : 1));
+
+  for (const m of oldestFirst) {
+    const id = threadsMentionDocId(m.id);
+    if (!id || existingIds.has(id)) continue;
+    existingIds.add(id);
+    const username = m.username || '';
+    const base = {
+      _id: id,
+      kind: 'mention',
+      platform: 'threads',
+      uri: m.permalink || '',
+      cid: String(m.id), // the reply target (reply_to_id)
+      authorDid: username ? `threads:${username}` : null,
+      authorHandle: username,
+      text: m.text || '',
+      indexedAt: m.timestamp || nowIso,
+      day,
+      attempts: 0,
+      createdAt: nowIso,
+      updatedAt: nowIso,
+    };
+    const skip = (reason) =>
+      out.push({ ...base, prompt: base.prompt || '', status: 'skipped', reason });
+
+    if (selfHandle && username === selfHandle) {
+      skip('own post');
+      continue;
+    }
+    if (
+      cfg.maxMentionAgeDays > 0 &&
+      nowMs - new Date(base.indexedAt).getTime() > cfg.maxMentionAgeDays * 86400000
+    ) {
+      skip('stale mention');
+      continue;
+    }
+    const prompt = extractPrompt(base.text, selfHandle);
+    const key = promptKey(prompt);
+    base.prompt = prompt;
+    base.promptKey = key;
+    const mod = moderatePrompt(prompt, cfg);
+    if (mod.ok !== true) {
+      skip(mod.reason);
+      continue;
+    }
+    if (recentKeys.has(key)) {
+      skip('duplicate prompt');
+      continue;
+    }
+    if ((authorCounts.get(base.authorDid) || 0) >= cfg.maxPerAuthorPerDay) {
+      skip('author daily cap');
+      continue;
+    }
+    if (todayCount >= cfg.maxGlobalPerDay) {
+      skip('global daily cap');
+      continue;
+    }
+    if (acceptedThisTick >= cfg.maxNewPerTick) continue; // burst brake — leave for next tick
+    out.push({ ...base, status: 'pending-build' });
+    acceptedThisTick += 1;
+    todayCount += 1;
+    authorCounts.set(base.authorDid, (authorCounts.get(base.authorDid) || 0) + 1);
+    recentKeys.add(key);
+  }
+  return out;
+}
+
 // Resolve the Threads user id from the pasted token (minting IS the check — /me
 // answers with id+username, persisted on the vault doc like bskySession does).
 async function threadsSession(ctx, t) {
@@ -1327,6 +1435,19 @@ async function threadsSearchPosts(query, { token, limit = 25, since } = {}) {
   return { ok: true, posts: ((r.data && r.data.data) || []).map(threadsPostToNormalized) };
 }
 
+// Read @-mentions of the account (the reactive lane). Needs the mentions/replies
+// permission on the token; returns items already in planThreadsMentions' shape
+// ({ id, text, username, permalink, timestamp }). No keyword_search / app-review
+// dependency — this is the path that works before the search permission lands.
+async function threadsMentions({ token, limit = 25 } = {}) {
+  const r = await threadsFetch('me/mentions', {
+    token,
+    query: { fields: 'id,text,username,permalink,timestamp', limit: String(limit) },
+  });
+  if (!r.ok) return r;
+  return { ok: true, mentions: (r.data && r.data.data) || [] };
+}
+
 // Post the in-thread reply for a built Threads solicitation. Two-call publish:
 // create a TEXT container replying to the post, then publish it. Quiet failure +
 // MAX_REPLY_ATTEMPTS bound, exactly like replyToMention. Fixed template text
@@ -1341,7 +1462,9 @@ async function threadsReply(ctx, m, t, userId) {
     await log(ctx, { op: 'reply-gave-up', uri: m.uri, platform: 'threads' });
     return save({ status: 'error', error: `reply gave up after ${MAX_REPLY_ATTEMPTS} attempts` });
   }
-  const text = solicitationReplyText(m.vibeUrl);
+  // Same fixed templates as Bluesky, chosen by lane; no-echo holds either way.
+  const text =
+    m.kind === 'solicitation' ? solicitationReplyText(m.vibeUrl) : mentionReplyText(m.vibeUrl);
   if ([...text].length > THREADS_MAX_TEXT)
     return save({ status: 'error', error: `reply text too long for threads` });
   try {
@@ -1559,7 +1682,7 @@ async function likeMention(ctx, m, accessJwt, botDid) {
 // by MAX_LIKE_ATTEMPTS.
 async function likeAcceptedMentions(ctx, accessJwt, botDid) {
   const mentions = (await ctx.db.query({ db: 'requests' })).filter(
-    (d) => d.kind === 'mention' && d.status === 'pending-build'
+    (d) => d.kind === 'mention' && (d.platform || 'bsky') === 'bsky' && d.status === 'pending-build'
   );
   const stateById = new Map(
     (await ctx.db.query({ db: 'oplog' }))
@@ -1641,7 +1764,12 @@ export async function scheduled(event, ctx) {
   await ensurePdsHost(ctx, s.t);
 
   const requestsAll = await ctx.db.query({ db: 'requests' });
-  const existing = requestsAll.filter((d) => d.kind === 'mention');
+  const existing = requestsAll.filter(
+    (d) => d.kind === 'mention' && (d.platform || 'bsky') === 'bsky'
+  );
+  const existingThreadsMentions = requestsAll.filter(
+    (d) => d.kind === 'mention' && d.platform === 'threads'
+  );
   const existingSol = requestsAll.filter(
     (d) => d.kind === 'solicitation' && (d.platform || 'bsky') === 'bsky'
   );
@@ -1654,18 +1782,20 @@ export async function scheduled(event, ctx) {
   // for work already in flight, matching the documented dark-by-default contract.
   const solActive = solCfg.enabled === true;
 
-  // Threads (Meta) proactive lane: independent switch, and it needs its own token
-  // in the vault. Resolve the user id once; if there's no token / it needs
-  // re-auth / the switch is off, threadsUserId stays null and the whole lane
-  // no-ops (dark-by-default, same as an un-pasted Bluesky credential).
+  // Threads (Meta): resolve the user id whenever a token is pasted and healthy —
+  // NOT gated on the proactive switch, because the reactive @-mention lane should
+  // run as soon as a credential exists (like the Bluesky mention lane), while the
+  // proactive SEARCH lane additionally needs `threadsEnabled`. No token / needs
+  // re-auth ⇒ threadsUserId stays null and every Threads lane no-ops.
   const threadsVault = (await ctx.db.query({ db: 'vault' })).filter(
     (d) => d.kind === 'token' && d.platform === 'threads'
   );
   const threadsToken = threadsVault[0];
   await projectThreadsTokenStatus(ctx, threadsToken);
   let threadsUserId = null;
-  const threadsActive = solCfg.threadsEnabled === true;
-  if (threadsActive && threadsToken && threadsToken.token && !threadsToken.needsReauth) {
+  const threadsReady = !!(threadsToken && threadsToken.token && !threadsToken.needsReauth);
+  const threadsActive = solCfg.threadsEnabled === true; // proactive SEARCH lane switch
+  if (threadsReady) {
     const ts = await threadsSession(ctx, threadsToken);
     if (ts.userId) {
       threadsUserId = ts.userId;
@@ -1723,6 +1853,53 @@ export async function scheduled(event, ctx) {
       lastPollAt: nowIso,
       lastError: rList.message || rList.egressDenied || rList.transport,
     });
+  }
+
+  // 1-threads. The reactive @-mention lane on Threads: read me/mentions, same
+  // guardrails + intent gate as Bluesky, queue build requests as
+  // platform:'threads' mention docs. Runs whenever a Threads token is healthy —
+  // no keyword_search / app-review dependency (that's only the proactive lane).
+  if (threadsUserId) {
+    const rm = await threadsMentions({ token: threadsToken.token, limit: 25 });
+    if (rm.ok) {
+      const tPlan = planThreadsMentions({
+        mentions: rm.mentions,
+        selfHandle: threadsToken.username || null,
+        existing: existingThreadsMentions,
+        cfg,
+        nowIso,
+      });
+      for (const doc of tPlan) {
+        if (doc.status === 'pending-build') {
+          const verdict = await classifyBuildIntent(ctx, doc.prompt);
+          if (verdict === null) continue; // transient AI failure → re-plan next tick
+          if (verdict === 'skip') {
+            await ctx.db.put(
+              { ...doc, status: 'skipped', reason: 'not a build request' },
+              { db: 'requests' }
+            );
+            continue;
+          }
+        }
+        await ctx.db.put(doc, { db: 'requests' });
+        if (doc.status === 'pending-build')
+          await log(ctx, {
+            op: 'mention-accepted',
+            platform: 'threads',
+            uri: doc.uri,
+            prompt: doc.prompt,
+          });
+      }
+      await noteListenerState(ctx, {
+        threadsMentionsPollAt: nowIso,
+        threadsMentionsNew: tPlan.length,
+      });
+    } else {
+      await noteListenerState(ctx, {
+        threadsMentionsPollAt: nowIso,
+        threadsMentionsError: rm.message || rm.egressDenied || rm.transport,
+      });
+    }
   }
 
   // 1b. Search: proactively find open "drop your app link" calls and queue an
@@ -1917,8 +2094,17 @@ export async function scheduled(event, ctx) {
       await replyToMention(ctx, m, s.t, s.accessJwt);
     }
   }
-  // Threads replies ride the two-call publish; same per-tick reply cap, same
-  // freeze semantics (disabling the lane stops built Threads docs from posting).
+  // Threads replies ride the two-call publish; same fixed templates + per-tick
+  // caps as Bluesky. Mentions reply whenever a Threads token is live; solicitation
+  // replies additionally require the proactive switch (its freeze semantics).
+  if (threadsUserId) {
+    const builtThreadsMentions = existingThreadsMentions.filter(
+      (d) => d.status === 'built' && d.vibeUrl
+    );
+    for (const m of builtThreadsMentions.slice(0, cfg.maxRepliesPerTick)) {
+      await threadsReply(ctx, m, threadsToken, threadsUserId);
+    }
+  }
   if (threadsActive && threadsUserId) {
     const builtThreads = existingThreadsSol.filter((d) => d.status === 'built' && d.vibeUrl);
     for (const m of builtThreads.slice(0, solCfg.maxRepliesPerTick)) {

--- a/examples/mention-hub/backend.test.js
+++ b/examples/mention-hub/backend.test.js
@@ -27,6 +27,7 @@ import {
   sanitizeIdea,
   buildSolicitationReply,
   planSolicitations,
+  isLikelyBotAccount,
   scheduled,
 } from './backend.js';
 
@@ -532,9 +533,19 @@ describe('scheduled — tick wiring', () => {
         ['listNotifications', () => json({ notifications: [] })],
         [
           'screenshot.png',
-          () => new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { 'content-type': 'image/jpeg' } }),
+          () =>
+            new Response(new Uint8Array([1, 2, 3]), {
+              status: 200,
+              headers: { 'content-type': 'image/jpeg' },
+            }),
         ],
-        ['uploadBlob', () => json({ blob: { $type: 'blob', ref: { $link: 'bafk' }, mimeType: 'image/jpeg', size: 3 } })],
+        [
+          'uploadBlob',
+          () =>
+            json({
+              blob: { $type: 'blob', ref: { $link: 'bafk' }, mimeType: 'image/jpeg', size: 3 },
+            }),
+        ],
         [
           'createRecord',
           (_url, init) => {
@@ -1036,7 +1047,19 @@ describe('scheduled — claim DM wiring', () => {
       noNewMentions([
         [
           'describeRepo',
-          () => json({ did: 'did:plc:self', didDoc: { service: [{ id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: pdsHost }] } }),
+          () =>
+            json({
+              did: 'did:plc:self',
+              didDoc: {
+                service: [
+                  {
+                    id: '#atproto_pds',
+                    type: 'AtprotoPersonalDataServer',
+                    serviceEndpoint: pdsHost,
+                  },
+                ],
+              },
+            }),
         ],
         [
           'getConvoForMembers',
@@ -1221,6 +1244,40 @@ describe('buildSolicitationReply — fixed template, threaded, no echo', () => {
   });
 });
 
+describe('isLikelyBotAccount — never proactively reply to automated accounts', () => {
+  it('flags the incident account and other bot-suffixed handles', () => {
+    expect(isLikelyBotAccount({ handle: 'hackernewsbot.bsky.social' })).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'weatherbot.bsky.social' })).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'hn-headlines.bsky.social' })).toBe(true);
+  });
+
+  it('flags feed/aggregator name tokens and known aggregators', () => {
+    expect(isLikelyBotAccount({ handle: 'news-feed.bsky.social' })).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'rss.example.com' })).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'daily-digest.bsky.social' })).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'hackernews.bsky.social' })).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'lobsters.bsky.social' })).toBe(true);
+  });
+
+  it('flags the 🤖 / bot display-name convention even when the handle is clean', () => {
+    expect(
+      isLikelyBotAccount({ handle: 'cleanname.bsky.social', displayName: '🤖 Auto Feed' })
+    ).toBe(true);
+    expect(isLikelyBotAccount({ handle: 'cleanname.bsky.social', displayName: 'My RSS bot' })).toBe(
+      true
+    );
+  });
+
+  it('does NOT flag ordinary human posters', () => {
+    expect(isLikelyBotAccount({ handle: 'bob.bsky.social' })).toBe(false);
+    expect(isLikelyBotAccount({ handle: 'jane-founder.bsky.social', displayName: 'Jane' })).toBe(
+      false
+    );
+    expect(isLikelyBotAccount({ handle: 'feeder-schools.org' })).toBe(false); // "feed" not a bounded token
+    expect(isLikelyBotAccount({})).toBe(false);
+  });
+});
+
 describe('planSolicitations — search triage + guardrails', () => {
   const cfg = { ...SOLICITATION_DEFAULTS, maxNewPerTick: 5, maxGlobalPerDay: 20 };
   const post = (over = {}) => ({
@@ -1255,6 +1312,63 @@ describe('planSolicitations — search triage + guardrails', () => {
     });
     expect(out[0].status).toBe('skipped');
     expect(out[0].reason).toBe('own post');
+  });
+
+  it('skips bot / aggregator accounts (the reply-bot-hn incident)', () => {
+    const out = planSolicitations({
+      posts: [post({ handle: 'hackernewsbot.bsky.social', did: 'did:plc:hnbot' })],
+      selfDid: 'did:plc:self',
+      existing: [],
+      cfg,
+      nowIso: NOW,
+    });
+    expect(out[0].status).toBe('skipped');
+    expect(out[0].reason).toBe('bot account');
+  });
+
+  it('skips an author replied to inside the monthly cooldown window', () => {
+    const tenDaysAgo = new Date(new Date(NOW).getTime() - 10 * 86400000).toISOString();
+    const existing = [
+      {
+        _id: 'sol-did:plc:bob-old',
+        kind: 'solicitation',
+        status: 'replied',
+        authorDid: 'did:plc:bob',
+        day: dayKey(tenDaysAgo),
+        createdAt: tenDaysAgo,
+      },
+    ];
+    const out = planSolicitations({
+      posts: [post({ rkey: '3new' })],
+      selfDid: 'did:plc:self',
+      existing,
+      cfg: { ...cfg, authorCooldownDays: 30 },
+      nowIso: NOW,
+    });
+    expect(out[0].status).toBe('skipped');
+    expect(out[0].reason).toBe('author cooldown');
+  });
+
+  it('answers an author again once the cooldown window has passed', () => {
+    const longAgo = new Date(new Date(NOW).getTime() - 31 * 86400000).toISOString();
+    const existing = [
+      {
+        _id: 'sol-did:plc:bob-old',
+        kind: 'solicitation',
+        status: 'replied',
+        authorDid: 'did:plc:bob',
+        day: dayKey(longAgo),
+        createdAt: longAgo,
+      },
+    ];
+    const out = planSolicitations({
+      posts: [post({ rkey: '3new' })],
+      selfDid: 'did:plc:self',
+      existing,
+      cfg: { ...cfg, authorCooldownDays: 30 },
+      nowIso: NOW,
+    });
+    expect(out[0].status).toBe('candidate');
   });
 
   it('skips stale posts past maxPostAgeHours', () => {
@@ -1714,7 +1828,11 @@ describe('like-on-accept — acknowledge the request before building (#3323)', (
   };
 
   it('buildLikeRecord — strong-ref like on the request post', () => {
-    const built = buildLikeRecord({ uri: 'at://did:plc:alice/app.bsky.feed.post/3lc', cid: 'cid-3lc', createdAt: NOW });
+    const built = buildLikeRecord({
+      uri: 'at://did:plc:alice/app.bsky.feed.post/3lc',
+      cid: 'cid-3lc',
+      createdAt: NOW,
+    });
     expect(built.record).toMatchObject({
       $type: 'app.bsky.feed.like',
       subject: { uri: 'at://did:plc:alice/app.bsky.feed.post/3lc', cid: 'cid-3lc' },
@@ -1884,14 +2002,26 @@ describe('pdsHostFromDidDoc — chat must target the account PDS (#3591)', () =>
   it('extracts the AtprotoPersonalDataServer endpoint and trims a trailing slash', () => {
     const didDoc = {
       service: [
-        { id: '#atproto_pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://gomphidius.us-west.host.bsky.network/' },
+        {
+          id: '#atproto_pds',
+          type: 'AtprotoPersonalDataServer',
+          serviceEndpoint: 'https://gomphidius.us-west.host.bsky.network/',
+        },
       ],
     };
     expect(pdsHostFromDidDoc(didDoc)).toBe('https://gomphidius.us-west.host.bsky.network');
   });
 
   it('matches by service type when the id differs', () => {
-    const didDoc = { service: [{ id: '#pds', type: 'AtprotoPersonalDataServer', serviceEndpoint: 'https://x.host.bsky.network' }] };
+    const didDoc = {
+      service: [
+        {
+          id: '#pds',
+          type: 'AtprotoPersonalDataServer',
+          serviceEndpoint: 'https://x.host.bsky.network',
+        },
+      ],
+    };
     expect(pdsHostFromDidDoc(didDoc)).toBe('https://x.host.bsky.network');
   });
 
@@ -1899,6 +2029,10 @@ describe('pdsHostFromDidDoc — chat must target the account PDS (#3591)', () =>
     expect(pdsHostFromDidDoc(undefined)).toBeNull();
     expect(pdsHostFromDidDoc({})).toBeNull();
     expect(pdsHostFromDidDoc({ service: [] })).toBeNull();
-    expect(pdsHostFromDidDoc({ service: [{ id: '#atproto_pds', serviceEndpoint: 'http://insecure.example' }] })).toBeNull();
+    expect(
+      pdsHostFromDidDoc({
+        service: [{ id: '#atproto_pds', serviceEndpoint: 'http://insecure.example' }],
+      })
+    ).toBeNull();
   });
 });

--- a/examples/mention-hub/backend.test.js
+++ b/examples/mention-hub/backend.test.js
@@ -27,10 +27,13 @@ import {
   sanitizeIdea,
   buildSolicitationReply,
   solicitationReplyText,
+  mentionReplyText,
   planSolicitations,
   isLikelyBotAccount,
   threadsPostToNormalized,
   threadsSolicitationDocId,
+  threadsMentionDocId,
+  planThreadsMentions,
   THREADS_MAX_TEXT,
   scheduled,
 } from './backend.js';
@@ -1307,6 +1310,87 @@ describe('Threads proactive lane — pure helpers', () => {
     const bot = out.find((d) => d._id === 'sol-threads-2');
     expect(human).toMatchObject({ status: 'candidate', platform: 'threads' });
     expect(bot).toMatchObject({ status: 'skipped', reason: 'bot account' });
+  });
+});
+
+describe('planThreadsMentions — reactive @-mention lane on Threads', () => {
+  const cfg = { ...DEFAULTS };
+  const mention = (over = {}) => ({
+    id: over.id || '18001',
+    text: over.text ?? '@vibes_diy make me a pomodoro timer',
+    username: over.username || 'someone',
+    permalink: 'https://www.threads.net/@someone/post/abc',
+    timestamp: over.timestamp || NOW,
+  });
+
+  it('accepts a fresh mention as pending-build, prompt extracted, tagged threads', () => {
+    const out = planThreadsMentions({
+      mentions: [mention()],
+      selfHandle: 'vibes_diy',
+      existing: [],
+      cfg,
+      nowIso: NOW,
+    });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      kind: 'mention',
+      platform: 'threads',
+      status: 'pending-build',
+      prompt: 'make me a pomodoro timer',
+      cid: '18001',
+      authorHandle: 'someone',
+    });
+    expect(out[0]._id).toBe('mention-threads-18001');
+  });
+
+  it('is idempotent and skips our own posts, moderation, and the age gate', () => {
+    const existing = [{ _id: 'mention-threads-18001', kind: 'mention', platform: 'threads' }];
+    expect(
+      planThreadsMentions({
+        mentions: [mention()],
+        selfHandle: 'vibes_diy',
+        existing,
+        cfg,
+        nowIso: NOW,
+      })
+    ).toHaveLength(0);
+
+    const self = planThreadsMentions({
+      mentions: [mention({ username: 'vibes_diy' })],
+      selfHandle: 'vibes_diy',
+      existing: [],
+      cfg,
+      nowIso: NOW,
+    });
+    expect(self[0]).toMatchObject({ status: 'skipped', reason: 'own post' });
+
+    const stale = planThreadsMentions({
+      mentions: [
+        mention({ timestamp: new Date(new Date(NOW).getTime() - 5 * 86400000).toISOString() }),
+      ],
+      selfHandle: 'vibes_diy',
+      existing: [],
+      cfg: { ...cfg, maxMentionAgeDays: 2 },
+      nowIso: NOW,
+    });
+    expect(stale[0]).toMatchObject({ status: 'skipped', reason: 'stale mention' });
+
+    const linky = planThreadsMentions({
+      mentions: [mention({ text: '@vibes_diy build https://evil.example' })],
+      selfHandle: 'vibes_diy',
+      existing: [],
+      cfg,
+      nowIso: NOW,
+    });
+    expect(linky[0].status).toBe('skipped');
+  });
+
+  it('threadsMentionDocId is deterministic and null-safe; mentionReplyText carries the vibe url', () => {
+    expect(threadsMentionDocId('18001')).toBe('mention-threads-18001');
+    expect(threadsMentionDocId('')).toBeNull();
+    expect(mentionReplyText('https://vibes.diy/vibe/mentions/foo')).toContain(
+      'https://vibes.diy/vibe/mentions/foo'
+    );
   });
 });
 

--- a/examples/mention-hub/backend.test.js
+++ b/examples/mention-hub/backend.test.js
@@ -1268,12 +1268,18 @@ describe('isLikelyBotAccount — never proactively reply to automated accounts',
     );
   });
 
-  it('does NOT flag ordinary human posters', () => {
+  it('does NOT flag ordinary human posters (precision over recall)', () => {
     expect(isLikelyBotAccount({ handle: 'bob.bsky.social' })).toBe(false);
     expect(isLikelyBotAccount({ handle: 'jane-founder.bsky.social', displayName: 'Jane' })).toBe(
       false
     );
     expect(isLikelyBotAccount({ handle: 'feeder-schools.org' })).toBe(false); // "feed" not a bounded token
+    // A human fan of Hacker News, by handle or bio, is NOT a bot (label-anchored
+    // known-name match + bot-only display-name signal).
+    expect(isLikelyBotAccount({ handle: 'myhackernewsfan.bsky.social' })).toBe(false);
+    expect(
+      isLikelyBotAccount({ handle: 'alice.bsky.social', displayName: 'Hacker News fan' })
+    ).toBe(false);
     expect(isLikelyBotAccount({})).toBe(false);
   });
 });
@@ -1369,6 +1375,25 @@ describe('planSolicitations — search triage + guardrails', () => {
       nowIso: NOW,
     });
     expect(out[0].status).toBe('candidate');
+  });
+
+  it('cooldown holds for two same-author posts in ONE tick, even with maxPerAuthorPerDay > 1', () => {
+    // Regression (PR #68 review): the cooldown set was built only from persisted
+    // docs, so with maxPerAuthorPerDay:2 both fresh same-author posts passed and
+    // would be sent on later ticks — violating "once a month".
+    const posts = [
+      post({ rkey: 'p1' }),
+      post({ rkey: 'p2' }), // same author (default did:plc:bob)
+    ];
+    const out = planSolicitations({
+      posts,
+      selfDid: 'did:plc:self',
+      existing: [],
+      cfg: { ...cfg, maxPerAuthorPerDay: 2, authorCooldownDays: 30 },
+      nowIso: NOW,
+    });
+    expect(out.filter((d) => d.status === 'candidate')).toHaveLength(1);
+    expect(out.find((d) => d.status === 'skipped')?.reason).toBe('author cooldown');
   });
 
   it('skips stale posts past maxPostAgeHours', () => {

--- a/examples/mention-hub/backend.test.js
+++ b/examples/mention-hub/backend.test.js
@@ -26,8 +26,12 @@ import {
   buildIdeaPrompt,
   sanitizeIdea,
   buildSolicitationReply,
+  solicitationReplyText,
   planSolicitations,
   isLikelyBotAccount,
+  threadsPostToNormalized,
+  threadsSolicitationDocId,
+  THREADS_MAX_TEXT,
   scheduled,
 } from './backend.js';
 
@@ -1241,6 +1245,68 @@ describe('buildSolicitationReply — fixed template, threaded, no echo', () => {
     });
     expect(error).toBeUndefined();
     expect([...record.text].length).toBeLessThanOrEqual(BSKY_MAX_TEXT);
+  });
+});
+
+describe('Threads proactive lane — pure helpers', () => {
+  const media = {
+    id: '17900000000000000',
+    text: 'what are you building this week?',
+    username: 'devfounder',
+    permalink: 'https://www.threads.net/@devfounder/post/abc',
+    timestamp: '2026-07-06T10:00:00+0000',
+  };
+
+  it('threadsPostToNormalized maps a Threads media into the shared post shape', () => {
+    const p = threadsPostToNormalized(media);
+    expect(p).toMatchObject({
+      uri: media.permalink,
+      cid: media.id,
+      author: { did: 'threads:devfounder', handle: 'devfounder' },
+      record: { text: media.text },
+      indexedAt: media.timestamp,
+    });
+  });
+
+  it('threadsSolicitationDocId is deterministic and platform-scoped', () => {
+    const p = threadsPostToNormalized(media);
+    expect(threadsSolicitationDocId(p)).toBe(`sol-threads-${media.id}`);
+    expect(threadsSolicitationDocId({ cid: '' })).toBeNull();
+  });
+
+  it('solicitationReplyText fits the Threads limit and echoes only the vibe URL', () => {
+    const text = solicitationReplyText('https://vibes.diy/vibe/mentions/foo');
+    expect([...text].length).toBeLessThanOrEqual(THREADS_MAX_TEXT);
+    expect(text).toContain('https://vibes.diy/vibe/mentions/foo');
+  });
+
+  it('planSolicitations(platform:threads) tags docs, applies the bot filter, and counts per-platform', () => {
+    const post = (over) => threadsPostToNormalized({ ...media, ...over });
+    // A bsky solicitation already accepted today must NOT count against the
+    // Threads global cap — budgets are per platform.
+    const existing = [
+      {
+        _id: 'sol-did:plc:x-old',
+        kind: 'solicitation',
+        platform: 'bsky',
+        status: 'replied',
+        authorDid: 'did:plc:x',
+        day: dayKey(NOW),
+      },
+    ];
+    const out = planSolicitations({
+      posts: [post({ id: '1', username: 'devfounder' }), post({ id: '2', username: 'newsbot' })],
+      selfDid: 'threads:mentions',
+      existing,
+      cfg: { ...SOLICITATION_DEFAULTS, maxGlobalPerDay: 1, maxNewPerTick: 5 },
+      nowIso: NOW,
+      platform: 'threads',
+      docId: threadsSolicitationDocId,
+    });
+    const human = out.find((d) => d._id === 'sol-threads-1');
+    const bot = out.find((d) => d._id === 'sol-threads-2');
+    expect(human).toMatchObject({ status: 'candidate', platform: 'threads' });
+    expect(bot).toMatchObject({ status: 'skipped', reason: 'bot account' });
   });
 });
 


### PR DESCRIPTION
## What

Two things, both on the mention-hub vibe (all deployed to the live hub via `push` — the PR is the canonical-source record):

### 1. Tune the Bluesky proactive lane (the reply-bot-hn incident)

It replied to `hackernewsbot.bsky.social`'s "Ask HN: What Are You Working On?" repost — the `what are you working on` query matched a Hacker News mirror bot and the `SHARE` classifier waved it through, so we replied bot-to-bot under a feed nobody watches ([the reply](https://bsky.app/profile/vibes.diy/post/3mqihuyk2zi2z)).

- **`isLikelyBotAccount(author)`** — deterministic, high-precision handle/display-name skip (bot-suffixed / feed / RSS / aggregator handles, label-anchored known news mirrors, the 🤖 convention). Proactive-lane-only; a real person can always still `@`-mention us.
- **`authorCooldownDays` (default 30)** — one proactive reply per poster per ~month; charged within the tick too (review fix), so a `maxPerAuthorPerDay > 1` override can't leak a same-tick second reply.

### 2. Add the proactive lane on Threads (Meta), dark by default

Ports the same lane to Threads: `planSolicitations` is now platform-aware (`platform` + `docId`, per-platform caps/cooldown, every doc tagged), so the bot skip and cooldown apply identically. Threads plumbing = `keyword_search` + a two-call publish (create TEXT container with `reply_to_id`, then `threads_publish`); reply text is the shared fixed template (no-echo holds); individualization uses the matched post text only. Independent `threadsEnabled` + `threadsQueries` config, a `platform:'threads'` vault token, a `status-threads` projection, and a dashboard credential box + toggle.

**Dark until** an owner pastes a Threads token AND flips `threadsEnabled`. Activating needs a Meta app with the app-reviewed **`threads_keyword_search`** permission — a you-in-the-Meta-dashboard step. The `keyword_search`/publish field names follow Meta's docs and want one live smoke test on first token; all platform-pure logic is unit-tested.

## Test

`backend.test.js` — 127 pass (bot-account table incl. human false-positives, cooldown accept/skip + same-tick regression, Threads pure helpers + platform-aware planning). Activation runbook in `RUNBOOK.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)