### PR TITLE
pickathon-picker: remove header trees and swap UI emoji for vector icons

### DIFF
--- a/examples/pickathon-picker/App.jsx
+++ b/examples/pickathon-picker/App.jsx
@@ -21,6 +21,7 @@ import BrowseView from './BrowseView.jsx';
 import FavoritesView from './FavoritesView.jsx';
 import FriendsView, { ALL_FRIENDS } from './FriendsView.jsx';
 import ShiftsView from './ShiftsView.jsx';
+import { ClipboardIcon, CheckIcon } from './icons.jsx';
 
 // Re-stamp a locally-stored doc onto the freshly signed-in handle when useFireproof's
 // anonymousLocal store migrates local → cloud on first login. Owned docs are keyed by
@@ -59,57 +60,6 @@ const clearFriendParamFromUrl = () => {
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
-
-// A layered Pacific-Northwest forestscape for the header's bottom edge: two rows of
-// tiered Christmas trees at varying heights that overlap, drawn once as a static SVG
-// (no animation → zero repaint tax). Each tree is three stacked tiers with stepped
-// ledges down both flanks up to a pointy top. The back row is a shade darker and
-// shorter (depth); the interleaved front row is the nav color so it reads continuous
-// with the green stripe below. viewBox is 1200 wide, baseline y=40.
-const RIDGE_BASELINE = 116;
-const tree = (cx, w, h) => {
-  const B = RIDGE_BASELINE;
-  const y1 = B - h / 3;
-  const y2 = B - (2 * h) / 3;
-  const y3 = B - h;
-  const x = (k) => Math.round((cx + k * w) * 10) / 10;
-  const y = (v) => Math.round(v * 10) / 10;
-  return (
-    `M${x(-1)},${B} L${x(-0.375)},${y(y1)} L${x(-0.7)},${y(y1)} ` +
-    `L${x(-0.275)},${y(y2)} L${x(-0.5)},${y(y2)} L${x(0)},${y(y3)} ` +
-    `L${x(0.5)},${y(y2)} L${x(0.275)},${y(y2)} L${x(0.7)},${y(y1)} ` +
-    `L${x(0.375)},${y(y1)} L${x(1)},${B} Z`
-  );
-};
-// Deterministic PRNG (mulberry32) seeded with a constant so the "random" forest is
-// stable across renders/reloads — the layout is scattered but reproducible.
-const rng = (() => {
-  let s = 0x9e3779b9;
-  return () => {
-    s = (s + 0x6d2b79f5) | 0;
-    let t = Math.imul(s ^ (s >>> 15), 1 | s);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-})();
-// A scattered row: `count` trees across the 1200 viewBox, each centered in its slot
-// but jittered, with randomized width/height. Trees are ~3x larger than before and
-// tall enough that peaks reach near the header top and valleys dip near its bottom.
-const genRow = (count, minW, maxW, minH, maxH) => {
-  const step = 1200 / count;
-  const out = [];
-  for (let i = 0; i < count; i++) {
-    const cx = step * (i + 0.5) + (rng() - 0.5) * step * 0.7;
-    const w = minW + rng() * (maxW - minW);
-    const h = minH + rng() * (maxH - minH);
-    out.push(tree(cx, w, h));
-  }
-  return out.join(' ');
-};
-// Back row: shorter + darker for depth. Front row: taller, nav-colored. ~17 trees
-// total keeps the same average spacing as before, now with much larger trees.
-const FOREST_BACK = genRow(9, 90, 130, 66, 104);
-const FOREST_FRONT = genRow(8, 85, 120, 92, 112);
 
 const migratePickathonDoc = (doc, handle) => {
   if (doc.type === 'favorite')
@@ -718,17 +668,8 @@ export default function PickathonPicker() {
   return (
     <div className={`min-h-screen ${c.pageBg}`} style={{ touchAction: 'manipulation' }}>
       <div className={`max-w-6xl mx-auto ${c.cardBg} shadow-2xl ${c.border} overflow-hidden`}>
-        <div className={`${c.headerBg} ${c.border} p-2.5 relative isolate`}>
-          <svg
-            className="absolute inset-x-0 bottom-0 w-full h-[116px] z-0 pointer-events-none"
-            viewBox="0 0 1200 116"
-            preserveAspectRatio="none"
-            aria-hidden="true"
-          >
-            <path d={FOREST_BACK} className="fill-[#5A8F35] dark:fill-[#17260f]" />
-            <path d={FOREST_FRONT} className="fill-[#71AD44] dark:fill-[#1d3015]" />
-          </svg>
-          <div className="flex items-start justify-between gap-1 flex-wrap relative z-10">
+        <div className={`${c.headerBg} ${c.border} p-2.5`}>
+          <div className="flex items-start justify-between gap-1 flex-wrap">
             <div className="flex items-center gap-1">
               <a
                 href="https://pickathon.com"
@@ -750,7 +691,7 @@ export default function PickathonPicker() {
           </div>
           {error && error.includes('cached') && (
             <div
-              className={`mt-0.5 ${c.pinkBg} text-white px-[3px] py-0.5 rounded-lg text-sm font-bold relative z-10`}
+              className={`mt-0.5 ${c.pinkBg} text-white px-[3px] py-0.5 rounded-lg text-sm font-bold`}
             >
               {error}
             </div>
@@ -776,7 +717,7 @@ export default function PickathonPicker() {
                   {viewName === 'browse' && `All Events`}
                   {viewName === 'bands' && `Bands`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Follows`}
+                  {viewName === 'friends' && `Follows`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -944,7 +885,7 @@ export default function PickathonPicker() {
                             className={c.btnPink}
                             title="Subscribe in your phone's calendar — it follows your faves live. iOS may warn about an insecure connection; tap Continue (the feed itself is served over https). Share the link and friends can subscribe to your picks."
                           >
-                            🔁 Subscribe on iPhone
+                            Subscribe on iPhone
                           </a>
                         )}
                         {icsSubPath && (
@@ -954,7 +895,7 @@ export default function PickathonPicker() {
                             title="Copy the subscription URL — paste into Google Calendar (From URL) or send to a friend"
                             aria-label="Copy subscription link"
                           >
-                            {icsCopied ? '✓' : '📋'}
+                            {icsCopied ? <CheckIcon size={18} /> : <ClipboardIcon size={18} />}
                           </button>
                         )}
                       </div>

--- a/examples/pickathon-picker/BandsView.jsx
+++ b/examples/pickathon-picker/BandsView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fmtDate, fmtTime } from './festival-utils.js';
 import { eventCardBg } from './styles.js';
+import { HeartIcon, StarIcon } from './icons.jsx';
 
 export default function BandsView({
   bandsList,
@@ -116,7 +117,10 @@ export default function BandsView({
                         onClick={() => toggleAllBand(band)}
                         className={`shrink-0 text-2xl p-1.5 rounded-2xl m-0.5  font-bold transition-all ${allFaved ? 'bg-[#CD6C0C] text-white hover:opacity-90' : anyFav ? 'bg-[#CD6C0C]/40 text-white hover:opacity-90' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]'}`}
                       >
-                        {allFaved ? '♥' : anyFav ? '◐' : '♡'}
+                        <HeartIcon
+                          state={allFaved ? 'full' : anyFav ? 'half' : 'empty'}
+                          size={24}
+                        />
                       </button>
                     )}
                     <div className="flex-1 min-w-0">
@@ -126,8 +130,12 @@ export default function BandsView({
                           {lineupLabel}
                         </span>
                         {superMode && band.events.some((e) => favCounts[e.eventId] > 0) && (
-                          <span className={c.badge} title="Total picks across sets">
-                            ★ {band.events.reduce((n, e) => n + (favCounts[e.eventId] || 0), 0)}
+                          <span
+                            className={`${c.badge} inline-flex items-center gap-0.5`}
+                            title="Total picks across sets"
+                          >
+                            <StarIcon size={12} />{' '}
+                            {band.events.reduce((n, e) => n + (favCounts[e.eventId] || 0), 0)}
                           </span>
                         )}
                       </div>
@@ -145,7 +153,10 @@ export default function BandsView({
                                 onClick={() => toggleFavorite(e)}
                                 className={`text-sm px-0.5 py-[0.5px] rounded-lg m-0.5  font-bold transition-all ${myFavIds.has(e.eventId) ? 'bg-[#CD6C0C] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]'}`}
                               >
-                                {myFavIds.has(e.eventId) ? '♥' : '♡'}
+                                <HeartIcon
+                                  state={myFavIds.has(e.eventId) ? 'full' : 'empty'}
+                                  size={16}
+                                />
                               </button>
                             )}
                             <span className={`text-sm font-bold ${c.bodyText}`}>

--- a/examples/pickathon-picker/BrowseView.jsx
+++ b/examples/pickathon-picker/BrowseView.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { fmtTime } from './festival-utils.js';
 import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
 import NoteField from './NoteField.jsx';
+import { HeartIcon, StarIcon } from './icons.jsx';
 
 export default function BrowseView({
   filteredEvents,
@@ -73,8 +74,11 @@ export default function BrowseView({
                       <div className="flex-1">
                         <div className="flex items-center gap-0.5 mb-0.5 flex-wrap">
                           {superMode && favCounts[event.eventId] > 0 && (
-                            <span className={c.badge} title="People who picked this">
-                              ★ {favCounts[event.eventId]}
+                            <span
+                              className={`${c.badge} inline-flex items-center gap-0.5`}
+                              title="People who picked this"
+                            >
+                              <StarIcon size={12} /> {favCounts[event.eventId]}
                             </span>
                           )}
                           <h3 className={`text-xl font-black ${c.bodyText}`}>{event.title}</h3>
@@ -108,7 +112,7 @@ export default function BrowseView({
                             onClick={() => toggleFavorite(event)}
                             className={myFavIds.has(event.eventId) ? c.favToggleOn : c.favToggleOff}
                           >
-                            {myFavIds.has(event.eventId) ? '♥' : '♡'}
+                            <HeartIcon state={myFavIds.has(event.eventId) ? 'full' : 'empty'} />
                           </button>
                         )}
                         <a

--- a/examples/pickathon-picker/FavoritesView.jsx
+++ b/examples/pickathon-picker/FavoritesView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { fmtTime, fmtDate } from './festival-utils.js';
 import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
+import { HeartIcon } from './icons.jsx';
 
 export default function FavoritesView({
   favoriteEvents,
@@ -81,7 +82,7 @@ export default function FavoritesView({
                   </div>
                   {canWrite && (
                     <button onClick={() => toggleFavorite(event)} className={c.favToggleOn}>
-                      <span className="font-black text-lg">♥</span>
+                      <HeartIcon state="full" />
                     </button>
                   )}
                 </div>

--- a/examples/pickathon-picker/NowView.jsx
+++ b/examples/pickathon-picker/NowView.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FESTIVAL_TZ, fmtTime, fmtDate } from './festival-utils.js';
 import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
+import { HeartIcon } from './icons.jsx';
 
 function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, showDate }) {
   const tag = lineupTag(event);
@@ -32,7 +33,7 @@ function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, s
             onClick={() => toggleFavorite(event)}
             className={isMine ? c.favToggleOn : c.favToggleOff}
           >
-            {isMine ? '♥' : '♡'}
+            <HeartIcon state={isMine ? 'full' : 'empty'} />
           </button>
         )}
       </div>

--- a/examples/pickathon-picker/ScheduleView.jsx
+++ b/examples/pickathon-picker/ScheduleView.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { toFestivalDate, festivalDayFor, fmtTime as fmtTimeUtil } from './festival-utils.js';
 import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
 import NoteField from './NoteField.jsx';
+import { HeartIcon } from './icons.jsx';
 
 function GapStrip({ startMs, endMs, allDayEvents, fmtTime }) {
   const count = allDayEvents.filter((e) => {
@@ -164,7 +165,12 @@ export default function ScheduleView({
                               onClick={() => onToggleFavorite(item.data)}
                               className={`p-[1px] rounded-lg m-0.5  text-xs font-bold px-0.5 ${myFavIds && myFavIds.has(item.data.eventId) ? 'bg-[#CD6C0C] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9]'}`}
                             >
-                              {myFavIds && myFavIds.has(item.data.eventId) ? '♥' : '♡'}
+                              <HeartIcon
+                                state={
+                                  myFavIds && myFavIds.has(item.data.eventId) ? 'full' : 'empty'
+                                }
+                                size={16}
+                              />
                             </button>
                           )}
                         </div>

--- a/examples/pickathon-picker/icons.jsx
+++ b/examples/pickathon-picker/icons.jsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+// Inline Feather-style icons so the UI reads as vector marks, not emoji glyphs.
+// Every icon inherits color via `currentColor` and sizes off the `size` prop
+// (default 20), matching the external-link / trash icons already used in the views.
+
+const base = (size) => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+});
+
+const HEART_PATH =
+  'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z';
+
+// state: 'full' (filled), 'half' (left half filled — the "some faved" band state),
+// or 'empty' (outline only).
+export function HeartIcon({ state = 'empty', size = 20, className = '' }) {
+  if (state === 'half') {
+    return (
+      <svg {...base(size)} className={className} aria-hidden="true">
+        <defs>
+          <clipPath id="pk-heart-half">
+            <rect x="0" y="0" width="12" height="24" />
+          </clipPath>
+        </defs>
+        <path d={HEART_PATH} fill="currentColor" clipPath="url(#pk-heart-half)" />
+        <path d={HEART_PATH} fill="none" stroke="currentColor" strokeWidth="2" />
+      </svg>
+    );
+  }
+  const filled = state === 'full';
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path
+        d={HEART_PATH}
+        fill={filled ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+export function StarIcon({ size = 16, className = '' }) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path
+        d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+export function ClipboardIcon({ size = 20, className = '' }) {
+  return (
+    <svg
+      {...base(size)}
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ size = 20, className = '' }) {
+  return (
+    <svg
+      {...base(size)}
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Why

The OG Pickathon picker's header carried a decorative forest of SVG trees, and the rest of the UI leaned on emoji and dingbat glyphs (hearts, stars, a raised-hand, a repeat symbol) for its controls. This cleans both up so the app reads as a plain, professional schedule tool. The header art was purely ornamental, and emoji render inconsistently across platforms — replacing them with the app's existing inline-SVG icon style makes the favorite/rating controls look deliberate and consistent everywhere.

## What changed

- **Header trees removed.** Deleted the forest generator (the `tree`/PRNG/`genRow` helpers and `FOREST_BACK`/`FOREST_FRONT`) and the layered `<svg>` at the header's bottom edge. The header no longer needs its `relative isolate` / `z-` layering, so that's dropped too.
- **Emoji → vector icons.** New shared `examples/pickathon-picker/icons.jsx` holds Feather-style inline SVGs (`HeartIcon` with full/empty/half states, `StarIcon`, `ClipboardIcon`, `CheckIcon`) — matching the external-link/trash icons the views already use.
  - Favorite toggles across Browse, Bands, Now, Favorites, and Schedule: `♥` / `♡` / `◐` → `HeartIcon`. Behavior unchanged.
  - Super-mode pick-count badges: `★` → `StarIcon`.
  - iPhone subscribe copy button: `✓` / `📋` → `CheckIcon` / `ClipboardIcon`.
  - Nav "Follows" and the "Subscribe on iPhone" button drop their leading emoji.

## Validation

- All 66 example tests pass (`vitest run examples/pickathon-picker`) — access, schedule, backend logic untouched.
- Prettier-formatted; no remaining emoji/dingbat glyphs in the UI; no dangling references to the removed forest helpers.
- Rendered the new icons + treeless header in a harness to confirm the marks read cleanly (empty/full/half heart, star badge, clipboard/check).

Note: this is the canonical source for the live `og/pickathon-picker` vibe. Merging the PR does not redeploy it — the owner ships the change with `vibes-diy push` per the example's RUNBOOK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnY1aPJGK56V2acbLqEDvX)_