### PR TITLE
Pickathon picker: shared feed list item, plain artist link

### DIFF
--- a/examples/pickathon-picker/App.jsx
+++ b/examples/pickathon-picker/App.jsx
@@ -1,135 +1,93 @@
 import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { useFireproof } from 'use-fireproof';
 import { useSocial, useViewer, useVibe } from 'use-vibes';
+import { LOGO_URL, FESTIVAL_TZ, fmtTime, setsOnNow, upNextSets } from './festival-utils.js';
 import {
-  FESTIVAL_2026,
-  LOGO_URL,
-  ensureT,
-  toFestivalDate,
-  festivalDayFor,
-  setsOnNow,
-  upNextSets,
-  fmtTime,
-  fmtDate,
-  decodeEntities,
-} from './festival-utils.js';
+  readFriendParam,
+  writeFriendParamToUrl,
+  readSuperParam,
+  readNowParam,
+} from './url-state.js';
+import {
+  eventsFromScheduleDocs,
+  byStart,
+  getDateForDay as dateForDay,
+  displayDaysFor,
+  buildDaySchedule,
+  makeShiftBounds,
+  retainEvents,
+  parseTestClock,
+} from './schedule-build.js';
+import {
+  favoriteEventsFor,
+  sharedShiftsFor,
+  audienceFavoriteEvents,
+  audienceShifts,
+  picksByEvent,
+  countsByEvent,
+  pickersByCount,
+} from './picks.js';
+import {
+  activeFollowHandles,
+  followStateMap,
+  profilePicksVisible,
+  armPath,
+} from './social-logic.js';
+import { favoriteDocId, noteDocId, migratePickathonDoc, icsSubscribePath, ensureCalToken } from './docs.js';
+import {
+  LOADSHED_TYPE,
+  shedLevelFromDocs,
+  picksPaused as picksPausedAt,
+  socialPaused as socialPausedAt,
+  SHED_BANNER,
+  SHED_SOCIAL_LINE,
+} from './loadshed.js';
 import { c } from './styles.js';
 import ScheduleView from './ScheduleView.jsx';
 import BandsView from './BandsView.jsx';
-import NowView from './NowView.jsx';
 import BrowseView from './BrowseView.jsx';
 import FavoritesView from './FavoritesView.jsx';
 import FriendsView, { ALL_FRIENDS } from './FriendsView.jsx';
+import ProfileView from './ProfileView.jsx';
+import NowView from './NowView.jsx';
 import ShiftsView from './ShiftsView.jsx';
+import { ClipboardIcon, CheckIcon } from './icons.jsx';
 
-// Re-stamp a locally-stored doc onto the freshly signed-in handle when useFireproof's
-// anonymousLocal store migrates local → cloud on first login. Owned docs are keyed by
-// user, so favorites/notes re-key deterministically; shifts get a fresh _id.
-// A friend-connect link arrives as `?friend=<handle>` on the vibes.diy URL, which
-// the platform mirrors onto the app's own iframe URL. Read it, then strip it so a
-// visitor who copies their address bar doesn't re-share someone else's friend link.
-const readFriendParam = () => {
-  try {
-    const own = new URLSearchParams(window.location.search).get('friend');
-    if (own) return own;
-  } catch (e) {}
-  try {
-    if (window.top && window.top !== window)
-      return new URLSearchParams(window.top.location.search).get('friend');
-  } catch (e) {}
-  return null;
-};
-const clearFriendParamFromUrl = () => {
-  const strip = (loc, hist) => {
-    try {
-      const u = new URL(loc.href);
-      if (u.searchParams.has('friend')) {
-        u.searchParams.delete('friend');
-        hist.replaceState(null, '', u.pathname + u.search + u.hash);
-      }
-    } catch (e) {}
-  };
-  strip(window.location, window.history);
-  // The parent vibes.diy URL is cross-origin, so this usually no-ops — best effort.
-  try {
-    if (window.top && window.top !== window) strip(window.top.location, window.top.history);
-  } catch (e) {}
-};
+// The on-site home screen. Temporarily on for owner testing — flip to false (or drop
+// 'now' from the tab array below) to hide the tab, its render, and its feeders.
+const NOW_VIEW_ENABLED = true;
 
 // Stable index functions — passed to useLiveQuery so Fireproof doesn't rebuild the
 // query on every render (an inline arrow is a new reference each time).
 const byTypeUser = (doc) => [doc.type, doc.userId];
 
-// A layered Pacific-Northwest forestscape for the header's bottom edge: two rows of
-// tiered Christmas trees at varying heights that overlap, drawn once as a static SVG
-// (no animation → zero repaint tax). Each tree is three stacked tiers with stepped
-// ledges down both flanks up to a pointy top. The back row is a shade darker and
-// shorter (depth); the interleaved front row is the nav color so it reads continuous
-// with the green stripe below. viewBox is 1200 wide, baseline y=40.
-const RIDGE_BASELINE = 116;
-const tree = (cx, w, h) => {
-  const B = RIDGE_BASELINE;
-  const y1 = B - h / 3;
-  const y2 = B - (2 * h) / 3;
-  const y3 = B - h;
-  const x = (k) => Math.round((cx + k * w) * 10) / 10;
-  const y = (v) => Math.round(v * 10) / 10;
+// Header logo with an offline-safe fallback: the remote PNG is decoration, so when it
+// can't load (offline, or the cached view's CSP blocks remote images) swap in an
+// inline placeholder instead of a broken-image icon.
+function Logo() {
+  const [failed, setFailed] = useState(false);
+  if (failed)
+    return (
+      <div
+        className="h-32 w-20 shrink-0 flex items-center justify-center text-center leading-tight font-black text-lg text-[#4A4A4A] dark:text-[#e9e9e9]"
+        role="img"
+        aria-label="Pickathon"
+      >
+        Pickathon
+      </div>
+    );
   return (
-    `M${x(-1)},${B} L${x(-0.375)},${y(y1)} L${x(-0.7)},${y(y1)} ` +
-    `L${x(-0.275)},${y(y2)} L${x(-0.5)},${y(y2)} L${x(0)},${y(y3)} ` +
-    `L${x(0.5)},${y(y2)} L${x(0.275)},${y(y2)} L${x(0.7)},${y(y1)} ` +
-    `L${x(0.375)},${y(y1)} L${x(1)},${B} Z`
+    <img src={LOGO_URL} alt="Pickathon" className="h-32 w-auto" onError={() => setFailed(true)} />
   );
-};
-// Deterministic PRNG (mulberry32) seeded with a constant so the "random" forest is
-// stable across renders/reloads — the layout is scattered but reproducible.
-const rng = (() => {
-  let s = 0x9e3779b9;
-  return () => {
-    s = (s + 0x6d2b79f5) | 0;
-    let t = Math.imul(s ^ (s >>> 15), 1 | s);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-})();
-// A scattered row: `count` trees across the 1200 viewBox, each centered in its slot
-// but jittered, with randomized width/height. Trees are ~3x larger than before and
-// tall enough that peaks reach near the header top and valleys dip near its bottom.
-const genRow = (count, minW, maxW, minH, maxH) => {
-  const step = 1200 / count;
-  const out = [];
-  for (let i = 0; i < count; i++) {
-    const cx = step * (i + 0.5) + (rng() - 0.5) * step * 0.7;
-    const w = minW + rng() * (maxW - minW);
-    const h = minH + rng() * (maxH - minH);
-    out.push(tree(cx, w, h));
-  }
-  return out.join(' ');
-};
-// Back row: shorter + darker for depth. Front row: taller, nav-colored. ~17 trees
-// total keeps the same average spacing as before, now with much larger trees.
-const FOREST_BACK = genRow(9, 90, 130, 66, 104);
-const FOREST_FRONT = genRow(8, 85, 120, 92, 112);
-
-const migratePickathonDoc = (doc, handle) => {
-  if (doc.type === 'favorite')
-    return { ...doc, userId: handle, _id: `favorite-${handle}-${doc.eventId}` };
-  if (doc.type === 'note') return { ...doc, userId: handle, _id: `note-${handle}-${doc.eventId}` };
-  if (doc.type === 'shift') {
-    const { _id, ...rest } = doc;
-    return { ...rest, userId: handle };
-  }
-  return { ...doc, userId: handle };
-};
+}
 
 export default function PickathonPicker() {
   const { viewer, ViewerTag } = useViewer();
   // Optimistic writes + anonymous local writes (with sign-in migration) now come from
-  // useFireproof itself: `anonymousLocal` runs put/del/useLiveQuery against a local
-  // store while logged out and migrates on first sign-in; the returning-signed-out
-  // guard is handled internally. So nothing below branches on auth.
+  // useFireproof itself: local-first writes with cloud+overlay reads are the default
+  // for every vibe (the old `anonymousLocal` flag is deprecated and ignored), and the
+  // returning-signed-out guard is handled internally. So nothing below branches on auth.
   const { database, useLiveQuery, useDocument } = useFireproof('pickathon', {
-    anonymousLocal: true,
     migrate: migratePickathonDoc,
   });
   const { can, ready } = useVibe('pickathon');
@@ -148,6 +106,9 @@ export default function PickathonPicker() {
     unfollow,
     approve,
     removeFollower,
+    followersEnabled,
+    requestFollowersAccess,
+    setVisibility,
   } = useSocial();
 
   const myHandle = viewer?.userHandle || 'anonymous';
@@ -162,25 +123,147 @@ export default function PickathonPicker() {
     : true;
   const canWrite = ready && signedIn && Boolean(can?.create?.({ type: 'shift', userId })?.ok);
 
-  const [events, setEvents] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  // ── Load shedding (loadshed.js) ─────────────────────────────────────────────
+  // One owner-written doc (`0-load-shed`) whose `level` lets the owner pause the
+  // expensive viewer-driven parts of the app during the festival rush, with no
+  // redeploy. It replicates to EVERY client — anonymous included — because
+  // access.js publishes it on the same public channel as the schedule, so this
+  // read is a local-store read like the schedule's, not a network round-trip.
+  //   ABSENT doc, level "off", or any unrecognized level = FULLY NORMAL
+  //   OPERATION. The switch fails open by construction (shedLevelOf): a typo'd
+  //   `db put` at 11pm on a Saturday must never brick the app.
+  //   "read-only"     — schedule/browse/bands/now keep full function; every write
+  //                     affordance goes inert (hearts, band heart, notes, extras).
+  //   "schedule-only" — read-only, PLUS the Friends tab and profile views render
+  //                     one paused line INSTEAD of mounting their live queries
+  //                     (the lazy wrappers below are what makes that a real
+  //                     saving: the query lives inside the component).
+  // Signed-in and anonymous behave identically. This costs one extra live query
+  // — at most one doc — which is the price of the switch being readable at all.
+  const { docs: shedDocs } = useLiveQuery('type', { key: LOADSHED_TYPE });
+  const shedLevel = shedLevelFromDocs(shedDocs);
+  // `picksHeld`: writes are paused. `socialHeld`: the follower fan-out views are
+  // paused too. Named as state of the app, not as a permission — `canWrite` and
+  // `canFavorite` above stay exactly what access.js says, and the tab bar keeps
+  // using those, so shedding never makes a tab vanish.
+  const picksHeld = picksPausedAt(shedLevel);
+  const socialHeld = socialPausedAt(shedLevel);
+
+  // Docs-first schedule: the festival schedule is server-maintained. A 1-minute
+  // `scheduled` tick in backend.js mirrors the pickathon.com feed into public,
+  // world-readable `scheduleitem` docs in this same `pickathon` db (access.js).
+  // Every client — including anonymous/signed-out — pulls those docs into its
+  // LOCAL store on first use of the db, so the schedule renders OFFLINE with no
+  // network fetch and no per-user keying. There is no client-side feed fetch.
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedDay, setSelectedDay] = useState('all');
-  const [view, setView] = useState('now');
+  const [view, setView] = useState('browse');
   const [superMode, setSuperMode] = useState(false);
   const [viewingUser, setViewingUser] = useState(null);
   const [selectedFriend, setSelectedFriend] = useState(null);
   const [includeMyFaves, setIncludeMyFaves] = useState(false);
-  const [linkedFriend, setLinkedFriend] = useState(null);
-  const friendScrolledRef = useRef(false);
-  // Handles this session already followed from a link, so a re-render doesn't
-  // re-fire the follow.
-  const handledFriendRef = useRef(new Set());
-  const [pendingDelete, setPendingDelete] = useState(null);
+  // Whose profile is open (null = none). It takes over the content area rather than
+  // being a tab, and is mirrored to `#friend=` in the URL — so the URL, not a tab
+  // selection, is what says a profile is showing.
+  const [profileHandle, setProfileHandle] = useState(null);
+
+  // Platform audience-arm consent (#3484): followers see your picks only after
+  // YOU arm audience visibility for this app — default off, so every user who
+  // shared picks before the gate landed reads as "hasn't picked anything" to
+  // their followers. Opening the Follows tab is the clear social-intent moment:
+  // invite the not-yet-armed viewer once per session (the platform modal handles
+  // prior deny / never-ask policies by resolving quietly — invite, never nag).
+  // Someone who just turned pick-sharing OFF must not be invited to turn it back on
+  // at the next tab open — that's nagging, not inviting.
+  const disarmedRef = useRef(false);
+  const askedFollowersRef = useRef(false);
+  useEffect(() => {
+    if (view !== 'friends' || !signedIn || !socialReady || followersEnabled) return;
+    // While shedding at "schedule-only" the Friends tab is a paused line, not the
+    // tab — inviting someone to arm pick-sharing for a surface they can't see
+    // would be a modal out of nowhere.
+    if (socialHeld) return;
+    if (askedFollowersRef.current || disarmedRef.current) return;
+    askedFollowersRef.current = true;
+    requestFollowersAccess();
+  }, [view, signedIn, socialReady, followersEnabled, socialHeld, requestFollowersAccess]);
+
+  // The pick-sharing arm is reversible: `setVisibility('private')` turns it back off.
+  // NOTE this is the per-app PICKS knob, not account privacy (whether follows need
+  // approval) — that one has no setter on this hook at all (platform #4319).
+  // Re-arming has two paths and the snapshot can't tell them apart, so we remember who
+  // turned it off: someone who disarmed in this session has already consented, and
+  // requestFollowersAccess() would re-route the consent matrix (a prior standing deny
+  // would no-op confusingly), so that case is a plain level flip. A first-ever arm
+  // still goes through requestFollowersAccess — the invite the platform matrix owns.
+  const [sharingBusy, setSharingBusy] = useState(false);
+  const runSharing = (p) => {
+    setSharingBusy(true);
+    Promise.resolve(p).finally(() => setSharingBusy(false));
+  };
+  const stopSharing = () => {
+    if (!setVisibility) return;
+    disarmedRef.current = true;
+    runSharing(setVisibility('private'));
+  };
+  // `stop` is null on a runtime with no visibility setter — the reverser then simply
+  // isn't offered rather than dead-ending.
+  const sharingControls = {
+    enabled: followersEnabled,
+    busy: sharingBusy,
+    arm: () => armSharing(),
+    stop: setVisibility ? () => stopSharing() : null,
+  };
+  const armSharing = () => {
+    const path = armPath({ disarmed: disarmedRef.current, canSetVisibility: Boolean(setVisibility) });
+    runSharing(path === 'level' ? setVisibility('followers') : requestFollowersAccess());
+  };
+
   const [nowTick, setNowTick] = useState(Date.now());
-  const [icsError, setIcsError] = useState(null);
-  const [icsCopied, setIcsCopied] = useState(false);
+
+  // The docs-first read: the server-maintained `scheduleitem` docs (one per event,
+  // stable _id `schedule-event-<eventId>`) replicated into this client's local
+  // store. Issued unconditionally at every mount with a stable shape so the offline
+  // read mirror stays warm; anonymous viewers read them too (world-readable via
+  // access.js `grant.public`).
+  // `fromCache` (platform #4348) is truthful per database: true while these rows come
+  // from the local replica with no completed initial pull confirming them this session.
+  // It is an affordance, never a paint gate — and it is simply undefined on a runtime
+  // that predates it, which reads as "settled" and shows nothing.
+  const { docs: scheduleItemDocs } = useLiveQuery('type', {
+    key: 'scheduleitem',
+  });
+  const liveEvents = useMemo(() => eventsFromScheduleDocs(scheduleItemDocs), [scheduleItemDocs]);
+
+  // Retention (see retainEvents): a transient zero-row read must not take the screen away
+  // from a visitor who is already looking at the schedule. Writing the ref during render
+  // is idempotent — it only ever caches the value we are about to render.
+  const lastEventsRef = useRef(liveEvents);
+  if (liveEvents.length > 0) lastEventsRef.current = liveEvents;
+  const events = retainEvents(liveEvents, lastEventsRef.current);
+
+  // Writes are refused in the offline cached view — surface a notice instead of
+  // crashing or silently eating the tap. Success returns the put/del result, so
+  // callers that need to know (e.g. the extras form) can check for it.
+  const [writeNotice, setWriteNotice] = useState(null);
+  const writeNoticeTimer = useRef(null);
+  const reportWriteFailure = (e) => {
+    console.warn('write refused (offline?)', e);
+    setWriteNotice(
+      "Couldn't save — you're viewing an offline copy. Make this change again when you're back online."
+    );
+    clearTimeout(writeNoticeTimer.current);
+    writeNoticeTimer.current = setTimeout(() => setWriteNotice(null), 6000);
+    return undefined;
+  };
+  const safeDb = useMemo(
+    () => ({
+      put: (doc) => database.put(doc).catch(reportWriteFailure),
+      del: (id) => database.del(id).catch(reportWriteFailure),
+    }),
+    [database]
+  );
+
 
   useEffect(() => {
     const id = setInterval(() => setNowTick(Date.now()), 30000);
@@ -210,131 +293,79 @@ export default function PickathonPicker() {
   }, []);
 
   useEffect(() => {
-    try {
-      const w =
-        typeof window !== 'undefined' && window.top && window.top !== window ? window.top : window;
-      const params = new URLSearchParams(w.location.search);
-      if (params.get('super') === '1') setSuperMode(true);
-    } catch (e) {
-      const params = new URLSearchParams(window.location.search);
-      if (params.get('super') === '1') setSuperMode(true);
-    }
+    if (readSuperParam()) setSuperMode(true);
   }, []);
 
-  // Capture a `?friend=<handle>` link once, then strip it from the URL. Friend
-  // features need a login, so we hold the handle and act on it after sign-in.
+  // A `#friend=<handle>` link opens that handle's PROFILE — no sign-in required, and
+  // nothing is followed on the visitor's behalf. The platform delivers the host hash
+  // into the iframe around boot and fires hashchange if it lands after mount, so
+  // listen for both. The param is not consumed: it stays as the open profile's URL.
+  // The URL is the source of truth for which profile is open, so a hashchange SETS,
+  // SWITCHES, or (browser back to a fragment-less URL) CLOSES it.
   useEffect(() => {
-    const fp = readFriendParam();
-    if (!fp) return;
-    setLinkedFriend(fp);
-    clearFriendParamFromUrl();
-  }, []);
-
-  // Scroll to the friend's schedule once it's rendered (one-time).
-  useEffect(() => {
-    if (friendScrolledRef.current || !signedIn || !linkedFriend) return;
-    if (view !== 'friends' || selectedFriend !== linkedFriend) return;
-    const el = document.getElementById('friend-schedule');
-    if (el) {
-      friendScrolledRef.current = true;
-      setTimeout(() => el.scrollIntoView({ behavior: 'smooth', block: 'start' }), 200);
-    }
-  }, [signedIn, linkedFriend, view, selectedFriend, events.length]);
-
-  useEffect(() => {
-    if (!pendingDelete) return;
-    const handler = (e) => {
-      if (!e.target.closest('[data-pending-delete]')) setPendingDelete(null);
+    const sync = () => {
+      const fp = readFriendParam();
+      setProfileHandle(fp || null);
+      // Normalizes a legacy `?friend=` QR to the hash form; a hash link is unchanged.
+      if (fp) writeFriendParamToUrl(fp);
     };
-    document.addEventListener('click', handler);
-    return () => document.removeEventListener('click', handler);
-  }, [pendingDelete]);
-
-  useEffect(() => {
-    fetchSchedule();
+    sync();
+    window.addEventListener('hashchange', sync);
+    return () => window.removeEventListener('hashchange', sync);
   }, []);
 
-  const getCached = () => {
-    const data = localStorage.getItem('pickathon-schedule-cache');
-    const ts = +localStorage.getItem('pickathon-schedule-timestamp');
-    if (!data || !ts) return null;
-    return { data: JSON.parse(data), isStale: Date.now() - ts > 600_000 };
-  };
-  const setCached = (d) => {
-    localStorage.setItem('pickathon-schedule-cache', JSON.stringify(d));
-    localStorage.setItem('pickathon-schedule-timestamp', Date.now().toString());
-  };
+  // Stable across renders: both only call the state setter and the URL mirror.
+  // QA scaffolding (`#now=2026-07-31T20:00`): reason from a fixed instant so the Now tab
+  // can be checked before the festival starts. Ships harmlessly — an end user who sets
+  // it only time-travels their own Now tab, and nothing is written.
+  const [testClockRaw, setTestClockRaw] = useState(null);
+  useEffect(() => {
+    const sync = () => setTestClockRaw(readNowParam());
+    sync();
+    window.addEventListener('hashchange', sync);
+    return () => window.removeEventListener('hashchange', sync);
+  }, []);
+  const testClockMs = useMemo(() => parseTestClock(testClockRaw), [testClockRaw]);
+  const nowMs = testClockMs ?? nowTick;
 
-  const fetchSchedule = async () => {
-    const cached = getCached();
-    if (cached && !cached.isStale) {
-      ingest(cached.data);
-      setLoading(false);
-      return;
-    }
-    if (cached && cached.isStale) {
-      ingest(cached.data);
-      setLoading(false);
-    }
-    try {
-      const res = await fetch('https://pickathon.com/wp-content/plugins/pickathon/schedule.php');
-      const data = await res.json();
-      setCached(data);
-      ingest(data);
-      setError(null);
-    } catch (e) {
-      console.error(e);
-      if (cached) {
-        setError('Using cached data');
-        ingest(cached.data);
-      } else {
-        setError('Failed to load schedule');
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
+  const openProfile = useMemo(
+    () => (handle) => {
+      if (!handle) return;
+      setProfileHandle(handle);
+      writeFriendParamToUrl(handle);
+    },
+    []
+  );
+  const closeProfile = useMemo(
+    () => () => {
+      setProfileHandle(null);
+      writeFriendParamToUrl(null);
+    },
+    []
+  );
 
-  const ingest = (data) => {
-    const list = [];
-    for (const vid in data) {
-      const v = data[vid];
-      for (const e of v.events) {
-        const start = ensureT(e.start);
-        const end = ensureT(e.end);
-        list.push({
-          eventId: e.id,
-          title: decodeEntities(e.title),
-          start,
-          end,
-          url: e.url,
-          venueTitle: decodeEntities(v.title),
-          venueColor: v.color,
-          lineup: e.lineup || {},
-          // Pickathon runs late, so a set is grouped by the *festival night* it belongs
-          // to, not its raw calendar date: anything before 4 AM counts as the prior day
-          // (e.g. a 1 AM Sunday set lives under Saturday). festivalDayFor applies that
-          // cutoff, and it's the same rule the faves/friends schedules already use.
-          day: festivalDayFor(start),
-        });
-      }
-    }
-    setEvents(list);
-  };
+  // Every handle in the app is a link to that handle's profile. ViewerTag exposes no
+  // onClick, so wrap it. Most tags sit INSIDE another control (a chip that selects a
+  // schedule, a row with an × remove) — stopPropagation lets the tag claim its own hit
+  // area without breaking the control around it. Memoized: a fresh component identity
+  // every render would remount (and re-fetch) every avatar.
+  const ProfileTag = useMemo(() => {
+    const Tag = ({ userHandle, ...rest }) => (
+      <span
+        className="inline-flex cursor-pointer"
+        onClick={(e) => {
+          e.stopPropagation();
+          openProfile(userHandle);
+        }}
+        title={`See @${userHandle}'s profile`}
+      >
+        <ViewerTag userHandle={userHandle} {...rest} />
+      </span>
+    );
+    return Tag;
+  }, [ViewerTag, openProfile]);
 
-  const getDateForDay = (day) => {
-    // Prefer the festival day's canonical calendar date. Since a day now groups
-    // after-midnight sets from the *next* calendar date (4 AM cutoff), we must not
-    // derive the header date from a stray early-morning event's start.
-    if (FESTIVAL_2026.dates[day]) return FESTIVAL_2026.dates[day];
-    const evt = events.find((e) => e.day === day);
-    if (evt) return evt.start.split('T')[0];
-    const base = new Date(FESTIVAL_2026.fallbackStart);
-    const idx = FESTIVAL_2026.dayOrder.indexOf(day);
-    const d = new Date(base);
-    d.setDate(base.getDate() + Math.max(0, idx));
-    return d.toISOString().split('T')[0];
-  };
+  const getDateForDay = (day) => dateForDay(day, events);
 
   const { docs: shifts } = useLiveQuery(byTypeUser, { key: ['shift', userId] });
   const { docs: notesDocs } = useLiveQuery(byTypeUser, { key: ['note', userId] });
@@ -347,23 +378,15 @@ export default function PickathonPicker() {
 
   // Global pick counts / leaderboard are only shown in super mode, and they scan every
   // readable favorite — so don't compute them on normal renders.
-  const favCounts = useMemo(() => {
-    if (!superMode) return {};
-    const m = {};
-    for (const f of allFavorites) m[f.eventId] = (m[f.eventId] || 0) + 1;
-    return m;
-  }, [allFavorites, superMode]);
+  const favCounts = useMemo(
+    () => (superMode ? countsByEvent(allFavorites) : {}),
+    [allFavorites, superMode]
+  );
 
-  const favUsers = useMemo(() => {
-    if (!superMode) return [];
-    const map = new Map();
-    for (const f of allFavorites) {
-      const uid = f.userId || 'anonymous';
-      if (!map.has(uid)) map.set(uid, { userId: uid, count: 0 });
-      map.get(uid).count++;
-    }
-    return [...map.values()].sort((a, b) => b.count - a.count);
-  }, [allFavorites, superMode]);
+  const favUsers = useMemo(
+    () => (superMode ? pickersByCount(allFavorites) : []),
+    [allFavorites, superMode]
+  );
 
   // useFireproof applies the write optimistically, so useLiveQuery already reflects a
   // toggle before the server confirms — no app-side overlay needed. Memoized so a stable
@@ -377,91 +400,84 @@ export default function PickathonPicker() {
   // Whose picks I can see = handles I follow with an ACTIVE edge. A follow into
   // a private account sits at state "requested" until they approve — it grants
   // no reads, so including it would only render empty schedule sections.
-  const followedHandles = useMemo(
-    () => new Set(following.filter((f) => f.state === 'active').map((f) => f.handle)),
-    [following]
+  const followedHandles = useMemo(() => activeFollowHandles(following), [following]);
+
+  // Per-event: the handles of people you FOLLOW who have this set on their picks
+  // (excludes yourself), so the All Events list can show their tags at a glance.
+  // Independent of the friends-schedule selection — always from the follow graph.
+  const nowActive = NOW_VIEW_ENABLED && view === 'now';
+  const nowSets = useMemo(
+    () =>
+      nowActive
+        ? setsOnNow(events, nowMs).sort((a, b) => a.venueTitle.localeCompare(b.venueTitle))
+        : [],
+    [nowActive, events, nowMs]
+  );
+  const nextSets = useMemo(
+    () => (nowActive ? upNextSets(events, nowMs) : []),
+    [nowActive, events, nowMs]
   );
 
-  // A captured ?friend link now just FOLLOWS the scanned handle once signed in.
-  // Following is one-directional — it exposes nothing of YOURS (they see your
-  // picks only if they follow you back) — so the old add-friend confirmation
-  // dialog is gone: the action is low-stakes and one tap undoes it. A follow
-  // into a private account lands as "requested" and their schedule stays empty
-  // until they approve.
-  useEffect(() => {
-    if (!signedIn || !socialReady || !linkedFriend || linkedFriend === viewer.userHandle) return;
-    if (handledFriendRef.current.has(linkedFriend)) return;
-    handledFriendRef.current.add(linkedFriend);
-    const go = () => {
-      setSelectedFriend(linkedFriend);
-      setView('friends');
-    };
-    if (followedHandles.has(linkedFriend)) {
-      go();
-      return;
-    }
-    follow(linkedFriend).then(go, go);
-  }, [signedIn, socialReady, linkedFriend, followedHandles, viewer?.userHandle, follow]);
-
-  const friendFavIds = useMemo(() => {
-    const s = new Set();
-    for (const f of allFavorites) {
-      if (followedHandles.has(f.userId || 'anonymous')) s.add(f.eventId);
-    }
-    return s;
-  }, [allFavorites, followedHandles]);
+  const friendPicksByEvent = useMemo(
+    () => picksByEvent(allFavorites, followedHandles, userId),
+    [allFavorites, followedHandles, userId]
+  );
 
   // Selecting ALL_FRIENDS unifies everyone you FOLLOW (active edges — plus
   // yourself, when "include my faves" is on) into one schedule;
   // each event carries `pickedBy` handles so the unified view can attribute picks.
   // A single friend keeps the plain per-handle filter.
-  const friendFavoriteEvents = useMemo(() => {
-    if (!selectedFriend) return [];
-    const unified = selectedFriend === ALL_FRIENDS;
-    const inUnion = (uid) => followedHandles.has(uid) || (includeMyFaves && uid === userId);
-    const pickedBy = new Map();
-    for (const f of allFavorites) {
-      const uid = f.userId || 'anonymous';
-      if (unified ? inUnion(uid) : uid === selectedFriend) {
-        if (!pickedBy.has(f.eventId)) pickedBy.set(f.eventId, []);
-        pickedBy.get(f.eventId).push(uid);
-      }
-    }
-    return events
-      .filter((e) => pickedBy.has(e.eventId))
-      .map((e) => (unified ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
-      .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [selectedFriend, allFavorites, events, followedHandles, includeMyFaves, userId]);
+  // NowView flags a card as a followed pick from the same join the browse list uses —
+  // its keys are exactly the events someone you follow has picked (never your own).
+  const friendFavIds = useMemo(
+    () => (nowActive ? new Set(friendPicksByEvent.keys()) : new Set()),
+    [nowActive, friendPicksByEvent]
+  );
 
-  const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
-  const friendShifts = useMemo(() => {
-    if (!selectedFriend) return [];
-    const unified = selectedFriend === ALL_FRIENDS;
-    return allShifts
-      .filter((s) => {
-        const uid = s.userId || 'anonymous';
-        return s.shareWithFriends && (unified ? followedHandles.has(uid) : uid === selectedFriend);
-      })
-      .map((s) => (unified ? { ...s, pickedBy: [s.userId || 'anonymous'] } : s));
-  }, [selectedFriend, allShifts, followedHandles]);
+  const friendUnion = useMemo(() => {
+    if (selectedFriend !== ALL_FRIENDS) return null;
+    const u = new Set(followedHandles);
+    if (includeMyFaves) u.add(userId);
+    return u;
+  }, [selectedFriend, followedHandles, includeMyFaves, userId]);
+
+  const friendFavoriteEvents = useMemo(
+    () =>
+      selectedFriend
+        ? audienceFavoriteEvents({
+            allFavorites,
+            events,
+            union: friendUnion,
+            only: selectedFriend,
+          })
+        : [],
+    [selectedFriend, friendUnion, allFavorites, events]
+  );
+
+  // ── Profile page ────────────────────────────────────────────────────────────
+  // The profile renders what a FOLLOWER of `profileHandle` sees. For someone else
+  // that's the same gate the friends schedule uses (an active follow edge). For your
+  // OWN profile we deliberately do NOT fall back to your local favorites: the whole
+  // point of previewing your profile is to see what others get, and an account that
+  // hasn't armed audience visibility (#3484) shows its followers nothing.
+  const followStates = useMemo(() => followStateMap(following), [following]);
+  const profileIsSelf = Boolean(profileHandle) && signedIn && profileHandle === myHandle;
+  const profileVisible = profilePicksVisible({
+    handle: profileHandle,
+    isSelf: profileIsSelf,
+    followersEnabled,
+    followedHandles,
+  });
+
+  const profileFavoriteEvents = useMemo(
+    () => (profileVisible ? favoriteEventsFor(profileHandle, allFavorites, events) : []),
+    [profileHandle, profileVisible, allFavorites, events]
+  );
 
   // Only days that actually have events or shifts, ordered by the festival day order.
   // We deliberately do NOT seed with the full dayOrder — a festival day with nothing on
   // it (e.g. Monday) shouldn't show up in the picker or as an empty section.
-  const displayDays = useMemo(() => {
-    const present = new Set(
-      [...events.map((e) => e.day), ...shifts.map((s) => s.day)].filter(Boolean)
-    );
-    const o = FESTIVAL_2026.dayOrder;
-    return [...present].sort((a, b) => {
-      const ai = o.indexOf(a),
-        bi = o.indexOf(b);
-      if (ai === -1 && bi === -1) return a.localeCompare(b);
-      if (ai === -1) return 1;
-      if (bi === -1) return -1;
-      return ai - bi;
-    });
-  }, [events, shifts]);
+  const displayDays = useMemo(() => displayDaysFor(events, shifts), [events, shifts]);
 
   const {
     doc: shiftForm,
@@ -480,11 +496,12 @@ export default function PickathonPicker() {
 
   const submitShift = async (e) => {
     e?.preventDefault();
+    if (picksHeld) return;
     // A cleared time input is an empty string, which would store a malformed
     // `<date>T:00`; require both times so we never persist an unformattable shift.
     if (!shiftForm.startTime || !shiftForm.endTime) return;
     const dayISO = getDateForDay(shiftForm.day);
-    await database.put({
+    const res = await safeDb.put({
       type: 'shift',
       day: shiftForm.day,
       startTime: shiftForm.startTime,
@@ -495,19 +512,23 @@ export default function PickathonPicker() {
       shareWithFriends: !!shiftForm.shareWithFriends,
       userId,
     });
-    resetShift();
+    if (res) resetShift(); // keep the form on a refused (offline) write
   };
 
   const toggleFavorite = async (event) => {
+    // Belt to the inert-control braces: a render that predates the shed flip (or
+    // a stray keyboard activation) must not write. Silent by design — the banner
+    // above is already on screen saying picks are paused.
+    if (picksHeld) return;
     const id = event.eventId;
     // useFireproof's optimistic overlay flips the heart immediately and rolls back if
-    // the write throws, so this is just the plain put/del.
+    // the write throws; safeDb turns an offline refusal into the notice.
     if (myFavIds.has(id)) {
       const fav = myFavorites.find((f) => f.eventId === id);
-      if (fav) await database.del(fav._id);
+      if (fav) await safeDb.del(fav._id);
     } else {
-      await database.put({
-        _id: `favorite-${userId}-${id}`,
+      await safeDb.put({
+        _id: favoriteDocId(userId, id),
         type: 'favorite',
         eventId: id,
         userId,
@@ -517,11 +538,12 @@ export default function PickathonPicker() {
 
   // Called by NoteField on blur (not per keystroke). NoteField buffers the text.
   const saveNote = async (eventId, noteText) => {
+    if (picksHeld) return;
     const existing = notesDocs.find((n) => n.eventId === eventId);
-    if (existing) await database.put({ ...existing, notes: noteText });
+    if (existing) await safeDb.put({ ...existing, notes: noteText });
     else
-      await database.put({
-        _id: `note-${userId}-${eventId}`,
+      await safeDb.put({
+        _id: noteDocId(userId, eventId),
         type: 'note',
         eventId,
         notes: noteText,
@@ -530,7 +552,8 @@ export default function PickathonPicker() {
   };
 
   const deleteShift = async (shiftId) => {
-    await database.del(shiftId);
+    if (picksHeld) return;
+    await safeDb.del(shiftId);
   };
 
   // The persistent-subscription URL (webcal:// opens the iPhone/macOS Calendar
@@ -544,52 +567,10 @@ export default function PickathonPicker() {
   // extras the user marked shareWithFriends — private extras deliberately never
   // enter the subscription (they're still in the Download .ics), so a
   // private-extras-only schedule must not advertise a live link that syncs empty.
+  // (The token itself is minted and read inside MyFavesTab — see below.)
   const hasSubscribable = signedIn && (myFavIds.size > 0 || shifts.some((s) => s.shareWithFriends));
-  // LOCAL MINTING of the calendar capability token: generated client-side the
-  // moment the schedule tab opens with subscribable content. The optimistic
-  // write makes it visible to the live query (and the button URL) instantly;
-  // until the backend's ≤1m tick learns it, the endpoint serves the valid
-  // anchor-only calendar, so even an immediate subscribe tap can't fail.
-  // Opt-in: users who never open this tab get no token and no ics aggregate.
-  // The token (not the handle) rides the URL — unguessable, revocable.
-  const { docs: calTokens } = useLiveQuery(byTypeUser, { key: ['caltoken', userId] });
-  const calToken = calTokens[0]?.token || null;
-  useEffect(() => {
-    if (view !== 'schedule' || !hasSubscribable || calToken) return;
-    const bytes = new Uint8Array(16);
-    crypto.getRandomValues(bytes);
-    let bin = '';
-    for (const b of bytes) bin += String.fromCharCode(b);
-    const token = btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-    database
-      .put({ _id: `caltoken-${userId}`, type: 'caltoken', userId, token, createdAt: Date.now() })
-      .catch(() => {});
-  }, [view, hasSubscribable, calToken, userId, database]);
-  const icsSubPath =
-    hasSubscribable && calToken
-      ? `/_api/faves.ics?t=${encodeURIComponent(calToken)}&n=${encodeURIComponent(userId)}`
-      : null;
-  // webcal:// — settled ON-DEVICE (2026-07): iOS Safari rejects webcals:// with
-  // "address is invalid", so the secure-scheme variant is a dead button. Bare
-  // webcal maps to http, which costs one "Insecure Connection" prompt whose
-  // Continue works (the actual fetches ride the http→https redirect). Pasting
-  // the Copy-link https URL into Settings → Calendar → Add Subscribed Calendar
-  // is the prompt-free path.
-  const icsSubWebcal = icsSubPath ? `webcal://${window.location.host}${icsSubPath}` : null;
 
-  const copySubscribeLink = async () => {
-    if (!icsSubPath) return;
-    try {
-      await navigator.clipboard.writeText(`https://${window.location.host}${icsSubPath}`);
-      setIcsCopied(true);
-      setTimeout(() => setIcsCopied(false), 2000);
-    } catch (e) {
-      setIcsError("Couldn't copy — long-press the Subscribe button instead");
-    }
-  };
-
-  const shiftStartRaw = (s) => s.start ?? s.startISO ?? `${getDateForDay(s.day)}T${s.startTime}:00`;
-  const shiftEndRaw = (s) => s.end ?? s.endISO ?? `${getDateForDay(s.day)}T${s.endTime}:00`;
+  const { shiftStartRaw, shiftEndRaw } = useMemo(() => makeShiftBounds(events), [events]);
 
   const bandsList = useMemo(() => {
     const map = new Map();
@@ -602,17 +583,11 @@ export default function PickathonPicker() {
       band.venues.add(e.venueTitle);
     }
     for (const b of map.values()) {
-      b.events.sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
+      b.events.sort(byStart);
       b.venueList = [...b.venues];
     }
     return [...map.values()].sort((a, b) => a.title.localeCompare(b.title));
   }, [events]);
-
-  const nowSets = useMemo(
-    () => setsOnNow(events, nowTick).sort((a, b) => a.venueTitle.localeCompare(b.venueTitle)),
-    [events, nowTick]
-  );
-  const nextSets = useMemo(() => upNextSets(events, nowTick), [events, nowTick]);
 
   const filteredEvents = useMemo(
     () =>
@@ -622,7 +597,7 @@ export default function PickathonPicker() {
             e.title.toLowerCase().includes(searchTerm.toLowerCase()) &&
             (selectedDay === 'all' || e.day === selectedDay)
         )
-        .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start)),
+        .sort(byStart),
     [events, searchTerm, selectedDay]
   );
 
@@ -630,105 +605,38 @@ export default function PickathonPicker() {
     () =>
       events
         .filter((e) => myFavIds.has(e.eventId))
-        .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start)),
+        .sort(byStart),
     [events, myFavIds]
   );
 
   // Super-mode peer picker: when a picker is selected, the favorites list must
   // show THEIR picks (from the readable firehose), not the current user's.
-  const viewedFavoriteEvents = useMemo(() => {
-    if (!viewingUser || viewingUser === userId) return favoriteEvents;
-    const ids = new Set(
-      allFavorites.filter((f) => (f.userId || 'anonymous') === viewingUser).map((f) => f.eventId)
-    );
-    return events
-      .filter((e) => ids.has(e.eventId))
-      .sort((a, b) => toFestivalDate(a.start) - toFestivalDate(b.start));
-  }, [viewingUser, userId, favoriteEvents, allFavorites, events]);
-
-  const makeSchedule = (day) => {
-    const ev = favoriteEvents.filter((e) => festivalDayFor(e.start) === day);
-    const sh = shifts.filter((s) => festivalDayFor(shiftStartRaw(s)) === day);
-    return [
-      ...ev.map((e) => ({
-        type: 'event',
-        id: e.eventId,
-        title: e.title,
-        sort: toFestivalDate(e.start),
-        venue: e.venueTitle,
-        data: e,
-      })),
-      ...sh.map((s) => ({
-        type: 'shift',
-        id: s._id,
-        sort: toFestivalDate(shiftStartRaw(s)),
-        data: s,
-      })),
-    ].sort((a, b) => a.sort - b.sort || (a.type === 'shift' ? -1 : 1));
-  };
-
-  const makeFriendSchedule = (day) => {
-    const ev = friendFavoriteEvents.filter((e) => festivalDayFor(e.start) === day);
-    const sh = friendShifts.filter((s) => festivalDayFor(shiftStartRaw(s)) === day);
-    return [
-      ...ev.map((e) => ({
-        type: 'event',
-        id: e.eventId,
-        title: e.title,
-        sort: toFestivalDate(e.start),
-        venue: e.venueTitle,
-        data: e,
-      })),
-      ...sh.map((s) => ({
-        type: 'shift',
-        id: s._id,
-        sort: toFestivalDate(shiftStartRaw(s)),
-        data: s,
-      })),
-    ].sort((a, b) => a.sort - b.sort || (a.type === 'shift' ? -1 : 1));
-  };
-
-  const renderDeleteX = (docId) => (
-    <button
-      data-pending-delete
-      onClick={(e) => {
-        e.stopPropagation();
-        if (pendingDelete === docId) {
-          database.del(docId).catch(() => {});
-          setPendingDelete(null);
-        } else {
-          setPendingDelete(docId);
-        }
-      }}
-      className={c.deleteX(pendingDelete === docId)}
-      title={pendingDelete === docId ? 'Tap to confirm' : 'Remove'}
-    >
-      {pendingDelete === docId ? 'Confirm' : '×'}
-    </button>
+  const viewedFavoriteEvents = useMemo(
+    () =>
+      !viewingUser || viewingUser === userId
+        ? favoriteEvents
+        : favoriteEventsFor(viewingUser, allFavorites, events),
+    [viewingUser, userId, favoriteEvents, allFavorites, events]
   );
 
-  // The schedule feed loads behind the full UI: header + nav render immediately,
-  // and only the content area shows a loading/error state until events arrive.
-  const scheduleLoading = loading && events.length === 0;
-  const scheduleError = error && events.length === 0;
+  const makeSchedule = (day) => buildDaySchedule(day, favoriteEvents, shifts, shiftStartRaw);
+  // The friend/profile schedules also need the SHARED-extras firehose, so they're
+  // built inside the lazy-mounted tab components below (see the block comment there).
 
-  const connectUrl = `https://vibes.diy/vibe/og/pickathon-picker/?friend=${encodeURIComponent(userId)}`;
-  const qrSrc = `https://api.qrserver.com/v1/create-qr-code/?size=320x320&data=${encodeURIComponent(connectUrl)}`;
+  // Hash, not query: hash links stay on the warm HTML-cache path (a query param bypasses
+  // it — full SSR on every visit) and the platform's url-state mirror forwards the hash
+  // into the iframe. No trailing slash (it costs a 301). Old query QR codes keep working
+  // indefinitely via the fallback. The canonical host URL isn't knowable from inside the
+  // sandbox, so the vibe path is hardcoded.
+  // (When iterating on the qa copy, point this at qa/pickathon-picker so scanned QRs
+  // stay inside the test app; flip back to og before promoting.)
+  const connectUrl = `https://vibes.diy/vibe/og/pickathon-picker#friend=${encodeURIComponent(userId)}`;
 
   return (
     <div className={`min-h-screen ${c.pageBg}`} style={{ touchAction: 'manipulation' }}>
       <div className={`max-w-6xl mx-auto ${c.cardBg} shadow-2xl ${c.border} overflow-hidden`}>
-        <div className={`${c.headerBg} ${c.border} p-2.5 relative isolate`}>
-          <svg
-            className="absolute inset-x-0 bottom-0 w-full h-[116px] z-0 pointer-events-none"
-            viewBox="0 0 1200 116"
-            preserveAspectRatio="none"
-            aria-hidden="true"
-          >
-            <path d={FOREST_BACK} className="fill-[#5A8F35] dark:fill-[#17260f]" />
-            <path d={FOREST_FRONT} className="fill-[#71AD44] dark:fill-[#1d3015]" />
-          </svg>
-          <div className="flex items-start justify-between gap-1 flex-wrap relative z-10">
+        <div className={`${c.headerBg} ${c.border} p-2.5`}>
+          <div className="flex items-start justify-between gap-1 flex-wrap">
             <div className="flex items-center gap-1">
               <a
                 href="https://pickathon.com"
@@ -736,7 +644,7 @@ export default function PickathonPicker() {
                 rel="noopener noreferrer"
                 className="shrink-0"
               >
-                <img src={LOGO_URL} alt="Pickathon" className="h-32 w-auto" />
+                <Logo />
               </a>
               <div>
                 <h1 className={`text-4xl font-black ${c.bodyText} mb-[1px]`}>
@@ -748,20 +656,14 @@ export default function PickathonPicker() {
               </div>
             </div>
           </div>
-          {error && error.includes('cached') && (
-            <div
-              className={`mt-0.5 ${c.pinkBg} text-white px-[3px] py-0.5 rounded-lg text-sm font-bold relative z-10`}
-            >
-              {error}
-            </div>
-          )}
         </div>
 
         <div className={`${c.navBg} ${c.border} p-2`}>
           <div className="flex flex-wrap gap-[3px]">
-            {['now', 'browse', 'bands', 'favorites', 'friends', 'shifts', 'schedule']
+            {['browse', 'bands', 'favorites', 'friends', 'shifts', 'schedule', 'now']
               .filter((v) => {
-                if (v === 'now' || v === 'browse' || v === 'bands') return true;
+                if (v === 'now') return NOW_VIEW_ENABLED;
+                if (v === 'browse' || v === 'bands') return true;
                 if (v === 'favorites') return superMode && canWrite; // super-mode peer picker
                 if (v === 'schedule') return canFavorite; // anon can view their own favorites schedule
                 return canWrite; // friends + extras need a real sign-in
@@ -769,14 +671,22 @@ export default function PickathonPicker() {
               .map((viewName) => (
                 <button
                   key={viewName}
-                  onClick={() => setView(viewName)}
-                  className={c.navBtn(view === viewName)}
+                  onClick={() => {
+                    // An open profile supersedes the tab content, so any tab press
+                    // must also leave the profile (and drop #friend= from the URL).
+                    closeProfile();
+                    setView(viewName);
+                  }}
+                  className={c.navBtn(!profileHandle && view === viewName)}
                 >
                   {viewName === 'now' && `Now`}
                   {viewName === 'browse' && `All Events`}
                   {viewName === 'bands' && `Bands`}
                   {viewName === 'favorites' && `Favorites (${myFavIds.size})`}
-                  {viewName === 'friends' && `🙋‍♀️ Follows`}
+                  {/* Display label only (owner's call). The view key, the state and every
+                      descriptive sentence keep the followers/following language — the
+                      platform copy rule governs data-visibility wording, not this tab. */}
+                  {viewName === 'friends' && `Friends`}
                   {viewName === 'shifts' && `Extras`}
                   {viewName === 'schedule' &&
                     `My Faves${myFavIds.size > 0 ? ` (${myFavIds.size})` : ''}`}
@@ -796,36 +706,88 @@ export default function PickathonPicker() {
         </div>
 
         <div className="p-1.5">
-          {scheduleLoading ? (
-            <div className="flex flex-col items-center justify-center gap-[5px] py-5">
-              <div className="w-16 h-16 rounded-full border-4 border-current border-t-transparent animate-spin"></div>
-              <h2 className={`text-3xl font-black text-center ${c.bodyText}`}>
-                Loading the schedule...
-              </h2>
-            </div>
-          ) : scheduleError ? (
-            <div className="py-4 text-center">
-              <h2 className={`text-3xl font-black mb-1 ${c.bodyText}`}>
-                Couldn't load the schedule
-              </h2>
-              <p className={`text-lg ${c.bodyText} mb-1`}>{error}</p>
-              <button onClick={fetchSchedule} className={c.btnPink}>
-                Retry
-              </button>
+          {/* Load shedding: ONE calm line, above whatever view is open, in the
+              same style as the app's other notices. Copy rule
+              (agents/local-first-copy-rules.md): say what is paused and that
+              nothing is lost — never imply data loss, never promise a time. */}
+          {picksHeld && <div className={c.readOnlyBanner}>{SHED_BANNER}</div>}
+          {/* An open profile takes over the content area — header and nav stay put,
+              and any tab press exits it. */}
+          {/* Local-first: the schedule arrives once and then lives in this device's
+              store, so this state is a first-visit thing only — never a spinner the
+              user meets again. A search with no hits is NOT this state. */}
+          {profileHandle && socialHeld ? (
+            // "schedule-only": gate BEFORE mounting ProfileTab, which is where the
+            // all-users shared-extras live query lives — the whole point of the
+            // lazy wrapper. Rendering a line instead of the component is what
+            // actually drops the subscription; hiding it with CSS would not.
+            <div className={c.readOnlyBanner}>{SHED_SOCIAL_LINE}</div>
+          ) : profileHandle ? (
+            <ProfileTab
+              useLiveQuery={useLiveQuery}
+              visible={profileVisible}
+              profileFavoriteEvents={profileFavoriteEvents}
+              shiftStartRaw={shiftStartRaw}
+              handle={profileHandle}
+              isSelf={profileIsSelf}
+              signedIn={signedIn}
+              socialReady={socialReady}
+              followState={followStates.get(profileHandle) || null}
+              follow={follow}
+              unfollow={unfollow}
+              sharing={sharingControls}
+              schedule={{
+                days: displayDays,
+                getDateForDay,
+                shiftEndRaw,
+                fmtTime,
+              }}
+              ViewerTag={ViewerTag}
+              ProfileTag={ProfileTag}
+              c={c}
+            />
+          ) : events.length === 0 && ['now', 'browse', 'bands'].includes(view) ? (
+            // Retention means this is now reachable ONLY when the session never held a
+            // non-empty schedule — a genuinely empty first visit, which this states
+            // correctly. A transient empty read keeps the schedule on screen instead.
+            <div className="text-center py-3">
+              <h3 className={`text-2xl font-black mb-0.5 ${c.bodyText}`}>
+                Downloading the schedule for offline access
+              </h3>
             </div>
           ) : (
             <>
-              {view === 'now' && (
-                <NowView
-                  nowSets={nowSets}
-                  nextSets={nextSets}
-                  nowTick={nowTick}
-                  myFavIds={myFavIds}
-                  friendFavIds={friendFavIds}
-                  canWrite={canFavorite}
-                  toggleFavorite={toggleFavorite}
-                  c={c}
-                />
+              {NOW_VIEW_ENABLED && view === 'now' && (
+                <>
+                  {testClockMs !== null && (
+                    <div className={c.readOnlyBanner}>
+                      Test clock:{' '}
+                      {new Date(testClockMs)
+                        .toLocaleString('en-US', {
+                          weekday: 'short',
+                          hour: 'numeric',
+                          minute: '2-digit',
+                          timeZone: FESTIVAL_TZ,
+                        })
+                        .replace(',', '')}
+                    </div>
+                  )}
+                  <NowView
+                    nowSets={nowSets}
+                    nextSets={nextSets}
+                    nowTick={nowMs}
+                    myFavIds={myFavIds}
+                    friendPicksByEvent={friendPicksByEvent}
+                    ViewerTag={ProfileTag}
+                    notes={notes}
+                    superMode={superMode}
+                    favCounts={favCounts}
+                    canWrite={canFavorite}
+                    picksPaused={picksHeld}
+                    toggleFavorite={toggleFavorite}
+                    c={c}
+                  />
+                </>
               )}
 
               {view === 'browse' && (
@@ -840,11 +802,15 @@ export default function PickathonPicker() {
                   myFavIds={myFavIds}
                   canWrite={canWrite}
                   canFavorite={canFavorite}
+                  picksPaused={picksHeld}
                   toggleFavorite={toggleFavorite}
                   notes={notes}
                   saveNote={saveNote}
                   superMode={superMode}
                   favCounts={favCounts}
+                  friendPicksByEvent={friendPicksByEvent}
+                  ViewerTag={ProfileTag}
+                  nowTick={nowTick}
                   c={c}
                 />
               )}
@@ -854,11 +820,12 @@ export default function PickathonPicker() {
                   bandsList={bandsList}
                   myFavIds={myFavIds}
                   canWrite={canFavorite}
+                  picksPaused={picksHeld}
                   toggleFavorite={toggleFavorite}
                   favCounts={favCounts}
                   superMode={superMode}
                   c={c}
-                  database={database}
+                  database={safeDb}
                   userId={userId}
                 />
               )}
@@ -872,15 +839,24 @@ export default function PickathonPicker() {
                   userId={userId}
                   myFavIds={myFavIds}
                   canWrite={canFavorite}
+                  picksPaused={picksHeld}
                   toggleFavorite={toggleFavorite}
                   notes={notes}
-                  ViewerTag={ViewerTag}
+                  ViewerTag={ProfileTag}
                   c={c}
                 />
               )}
 
-              {view === 'friends' && (
-                <FriendsView
+              {/* "schedule-only": same gate as the profile above — the Friends tab
+                  is the per-viewer follower fan-out (shared-extras firehose + the
+                  social lists), so it is not mounted at all while shedding. */}
+              {view === 'friends' && socialHeld && (
+                <div className={c.readOnlyBanner}>{SHED_SOCIAL_LINE}</div>
+              )}
+              {view === 'friends' && !socialHeld && (
+                <FriendsTab
+                  useLiveQuery={useLiveQuery}
+                  followedHandles={followedHandles}
                   socialReady={socialReady}
                   following={following}
                   followers={followers}
@@ -889,28 +865,32 @@ export default function PickathonPicker() {
                   unfollow={unfollow}
                   approve={approve}
                   removeFollower={removeFollower}
+                  sharing={sharingControls}
                   selectedFriend={selectedFriend}
                   setSelectedFriend={setSelectedFriend}
                   includeMyFaves={includeMyFaves}
                   setIncludeMyFaves={setIncludeMyFaves}
                   friendFavoriteEvents={friendFavoriteEvents}
-                  friendShifts={friendShifts}
                   canWrite={canWrite}
+                  picksPaused={picksHeld}
                   toggleFavorite={toggleFavorite}
                   myFavIds={myFavIds}
                   displayDays={displayDays}
                   getDateForDay={getDateForDay}
-                  makeFriendSchedule={makeFriendSchedule}
                   shiftStartRaw={shiftStartRaw}
                   shiftEndRaw={shiftEndRaw}
                   fmtTime={fmtTime}
                   connectUrl={connectUrl}
-                  qrSrc={qrSrc}
-                  ViewerTag={ViewerTag}
+                  myHandle={signedIn ? myHandle : null}
+                  onOpenProfile={openProfile}
+                  ViewerTag={ProfileTag}
                   c={c}
                 />
               )}
 
+              {/* The extras list still reads; only the form and its delete/share
+                  controls stand down while shedding (canWrite is their only gate,
+                  so it arrives already ANDed with the shed level). */}
               {view === 'shifts' && (
                 <ShiftsView
                   shifts={shifts}
@@ -921,69 +901,49 @@ export default function PickathonPicker() {
                   getDateForDay={getDateForDay}
                   shiftStartRaw={shiftStartRaw}
                   shiftEndRaw={shiftEndRaw}
-                  canWrite={canWrite}
+                  canWrite={canWrite && !picksHeld}
                   deleteShift={deleteShift}
-                  database={database}
+                  database={safeDb}
                   c={c}
                 />
               )}
 
               {view === 'schedule' && (
-                <div>
-                  <div className="flex items-center justify-between flex-wrap gap-0.5 mb-1.5">
-                    <h2 className={`text-2xl font-black ${c.bodyText}`}>
-                      My Personal Festival Schedule
-                    </h2>
-                    {(favoriteEvents.length > 0 || shifts.length > 0) && (
-                      <div className="flex items-center flex-wrap gap-0">
-                        {icsSubWebcal && (
-                          <a
-                            href={icsSubWebcal}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className={c.btnPink}
-                            title="Subscribe in your phone's calendar — it follows your faves live. iOS may warn about an insecure connection; tap Continue (the feed itself is served over https). Share the link and friends can subscribe to your picks."
-                          >
-                            🔁 Subscribe on iPhone
-                          </a>
-                        )}
-                        {icsSubPath && (
-                          <button
-                            onClick={copySubscribeLink}
-                            className={c.linkBtn}
-                            title="Copy the subscription URL — paste into Google Calendar (From URL) or send to a friend"
-                            aria-label="Copy subscription link"
-                          >
-                            {icsCopied ? '✓' : '📋'}
-                          </button>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                  {icsError && <div className={c.readOnlyBanner}>{icsError}</div>}
-                  <ScheduleView
-                    days={displayDays}
-                    getDateForDay={getDateForDay}
-                    buildSchedule={makeSchedule}
-                    fmtTime={fmtTime}
-                    notes={notes}
-                    c={c}
-                    shiftStartRaw={shiftStartRaw}
-                    shiftEndRaw={shiftEndRaw}
-                    emptyMessage="No events or shifts scheduled"
-                    saveNote={saveNote}
-                    canWrite={canWrite}
-                    onToggleFavorite={canFavorite ? toggleFavorite : null}
-                    myFavIds={myFavIds}
-                    allEvents={events}
-                    showGaps={true}
-                  />
-                </div>
+                <MyFavesTab
+                  useLiveQuery={useLiveQuery}
+                  database={database}
+                  userId={userId}
+                  hasSubscribable={hasSubscribable}
+                  favoriteEvents={favoriteEvents}
+                  shifts={shifts}
+                  displayDays={displayDays}
+                  getDateForDay={getDateForDay}
+                  buildSchedule={makeSchedule}
+                  notes={notes}
+                  saveNote={saveNote}
+                  canWrite={canWrite && !picksHeld}
+                  canFavorite={canFavorite}
+                  picksPaused={picksHeld}
+                  toggleFavorite={toggleFavorite}
+                  myFavIds={myFavIds}
+                  events={events}
+                  shiftStartRaw={shiftStartRaw}
+                  shiftEndRaw={shiftEndRaw}
+                  c={c}
+                />
               )}
             </>
           )}
         </div>
       </div>
+
+      {writeNotice && (
+        <div className="fixed bottom-24 inset-x-3 z-50 flex justify-center pointer-events-none">
+          <div className="bg-[#B22222] text-white px-2.5 py-[7px] rounded-2xl text-sm font-bold shadow-lg text-center max-w-[420px]">
+            {writeNotice}
+          </div>
+        </div>
+      )}
 
       {!signedIn && (
         // Full-width bar on mobile that cradles the Vibes switch; on desktop it shrinks
@@ -992,7 +952,7 @@ export default function PickathonPicker() {
         <div className="fixed bottom-[10px] left-3 right-3 sm:left-auto z-40 pointer-events-none flex justify-end">
           <div className={c.signInCallout}>
             <span className="min-w-0 flex-1 sm:flex-none sm:w-[190px] text-left">
-              {linkedFriend
+              {profileHandle
                 ? 'Sign in via the Vibes DIY logo to follow people'
                 : 'Sign in via the Vibes DIY logo — followers can see your picks'}
             </span>
@@ -1000,6 +960,212 @@ export default function PickathonPicker() {
           </div>
         </div>
       )}
+    </div>
+  );
+}
+
+// ── Lazy-mounted, tab-scoped live queries ───────────────────────────────────
+// Every useLiveQuery a client holds open is a subscription the platform has to
+// service for that viewer's whole visit, and they all land on one single-
+// threaded Sessions Durable Object. Two of this app's queries are read on every
+// tab and stay mounted at the top: the public `scheduleitem` mirror (the
+// schedule itself, and the offline read mirror it keeps warm) and the
+// `favorite` firehose (my picks, follower picks, counts, the tab badges).
+//
+// The rest are not: the all-users SHARED-EXTRAS firehose (`type: 'shift'`) is
+// read only by the Friends tab and an open profile, and the calendar token only
+// by My Faves. React hooks can't be conditional, so the mechanism is to move the
+// hook into the component that is conditionally RENDERED — each of these is
+// genuinely unmounted when its tab isn't showing (the tab bodies are `&&`-gated,
+// not hidden with CSS), so a viewer who only browses the schedule now opens
+// three subscriptions instead of six.
+//
+// NOT lazy-mounted, deliberately: the private `note` docs. They render on
+// Browse — which is the DEFAULT tab, so scoping them would save nothing for the
+// common viewer — as well as on Favorites and My Faves, and saveNote reads the
+// same docs to decide upsert-vs-create. Splitting that across three mounts
+// would trade a real behaviour risk for no measurable fan-out win.
+//
+// The one thing lazy mounting costs: on the first render after the tab opens
+// these queries return [] until the local store answers, so a friend's shared
+// extras can appear a frame after their picks. Nothing destructive — but see
+// MyFavesTab for the one place where an empty first read WOULD have been.
+
+// Friends tab: the unified/per-handle friend schedule needs shared extras.
+function FriendsTab({
+  useLiveQuery,
+  selectedFriend,
+  followedHandles,
+  friendFavoriteEvents,
+  shiftStartRaw,
+  ...rest
+}) {
+  const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
+  // The unified extras deliberately do NOT include your own (unlike the unified picks,
+  // which honour `includeMyFaves`) — that has always been the behaviour here.
+  const friendShifts = useMemo(
+    () =>
+      selectedFriend
+        ? audienceShifts({
+            allShifts,
+            union: selectedFriend === ALL_FRIENDS ? followedHandles : null,
+            only: selectedFriend,
+          })
+        : [],
+    [selectedFriend, allShifts, followedHandles]
+  );
+  const makeFriendSchedule = (day) =>
+    buildDaySchedule(day, friendFavoriteEvents, friendShifts, shiftStartRaw);
+  return (
+    <FriendsView
+      selectedFriend={selectedFriend}
+      friendFavoriteEvents={friendFavoriteEvents}
+      friendShifts={friendShifts}
+      makeFriendSchedule={makeFriendSchedule}
+      shiftStartRaw={shiftStartRaw}
+      {...rest}
+    />
+  );
+}
+
+// An open profile: same firehose, filtered to the one handle's SHARED extras.
+// `visible` is the follower-visibility gate computed in App — an unarmed or
+// unfollowed profile shows nothing, exactly as before.
+function ProfileTab({
+  useLiveQuery,
+  visible,
+  handle,
+  profileFavoriteEvents,
+  shiftStartRaw,
+  schedule,
+  ...rest
+}) {
+  const { docs: allShifts } = useLiveQuery('type', { key: 'shift' });
+  const profileShifts = useMemo(
+    () => (visible ? sharedShiftsFor(handle, allShifts) : []),
+    [handle, visible, allShifts]
+  );
+  const build = (day) =>
+    buildDaySchedule(day, profileFavoriteEvents, profileShifts, shiftStartRaw);
+  return (
+    <ProfileView handle={handle} schedule={{ ...schedule, build, shiftStartRaw }} {...rest} />
+  );
+}
+
+// My Faves tab: my own schedule plus the calendar-subscription controls, which
+// are the only readers of the caltoken doc.
+function MyFavesTab({
+  useLiveQuery,
+  database,
+  userId,
+  hasSubscribable,
+  favoriteEvents,
+  shifts,
+  displayDays,
+  getDateForDay,
+  buildSchedule,
+  notes,
+  saveNote,
+  canWrite,
+  canFavorite,
+  toggleFavorite,
+  myFavIds,
+  events,
+  shiftStartRaw,
+  shiftEndRaw,
+  c,
+}) {
+  const [icsError, setIcsError] = useState(null);
+  const [icsCopied, setIcsCopied] = useState(false);
+  // LOCAL MINTING of the calendar capability token: generated client-side the
+  // moment the schedule tab opens with subscribable content. The optimistic
+  // write makes it visible to the live query (and the button URL) instantly;
+  // until the backend's ≤1m tick learns it, the endpoint serves the valid
+  // anchor-only calendar, so even an immediate subscribe tap can't fail.
+  // Opt-in: users who never open this tab get no token and no ics aggregate.
+  // The token (not the handle) rides the URL — unguessable, revocable.
+  const { docs: calTokens } = useLiveQuery(byTypeUser, { key: ['caltoken', userId] });
+  const calToken = calTokens[0]?.token || null;
+  // Now that the query mounts WITH this tab, its first read is [] even for a user
+  // who already has a token — so the mint asks the store directly rather than
+  // trusting that empty read (ensureCalToken, docs.js). Deps keep the previous
+  // behaviour that deleting the doc while this tab is open re-mints.
+  useEffect(() => {
+    if (!hasSubscribable || calToken) return;
+    ensureCalToken({
+      database,
+      userId,
+      getRandomValues: (b) => crypto.getRandomValues(b),
+    });
+  }, [hasSubscribable, calToken, userId, database]);
+  const icsSubPath = hasSubscribable ? icsSubscribePath(calToken, userId) : null;
+  // webcal:// — settled ON-DEVICE (2026-07): iOS Safari rejects webcals:// with
+  // "address is invalid", so the secure-scheme variant is a dead button. Bare
+  // webcal maps to http, which costs one "Insecure Connection" prompt whose
+  // Continue works (the actual fetches ride the http→https redirect). Pasting
+  // the Copy-link https URL into Settings → Calendar → Add Subscribed Calendar
+  // is the prompt-free path.
+  const icsSubWebcal = icsSubPath ? `webcal://${window.location.host}${icsSubPath}` : null;
+
+  const copySubscribeLink = async () => {
+    if (!icsSubPath) return;
+    try {
+      await navigator.clipboard.writeText(`https://${window.location.host}${icsSubPath}`);
+      setIcsCopied(true);
+      setTimeout(() => setIcsCopied(false), 2000);
+    } catch (e) {
+      setIcsError("Couldn't copy — long-press the Subscribe button instead");
+    }
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between flex-wrap gap-0.5 mb-1.5">
+        <h2 className={`text-2xl font-black ${c.bodyText}`}>My Personal Festival Schedule</h2>
+        {(favoriteEvents.length > 0 || shifts.length > 0) && (
+          <div className="flex items-center flex-wrap gap-0">
+            {icsSubWebcal && (
+              <a
+                href={icsSubWebcal}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={c.btnPink}
+                title="Subscribe in your phone's calendar — it follows your faves live. iOS may warn about an insecure connection; tap Continue (the feed itself is served over https). Share the link and friends can subscribe to your picks."
+              >
+                Subscribe on iPhone
+              </a>
+            )}
+            {icsSubPath && (
+              <button
+                onClick={copySubscribeLink}
+                className={c.linkBtn}
+                title="Copy the subscription URL — paste into Google Calendar (From URL) or send to a friend"
+                aria-label="Copy subscription link"
+              >
+                {icsCopied ? <CheckIcon size={18} /> : <ClipboardIcon size={18} />}
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+      {icsError && <div className={c.readOnlyBanner}>{icsError}</div>}
+      <ScheduleView
+        days={displayDays}
+        getDateForDay={getDateForDay}
+        buildSchedule={buildSchedule}
+        fmtTime={fmtTime}
+        notes={notes}
+        c={c}
+        shiftStartRaw={shiftStartRaw}
+        shiftEndRaw={shiftEndRaw}
+        emptyMessage="No events or shifts scheduled"
+        saveNote={saveNote}
+        canWrite={canWrite}
+        onToggleFavorite={canFavorite ? toggleFavorite : null}
+        myFavIds={myFavIds}
+        allEvents={events}
+        showGaps={false}
+      />
     </div>
   );
 }

--- a/examples/pickathon-picker/BandsView.jsx
+++ b/examples/pickathon-picker/BandsView.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { HeartIcon, StarIcon } from './icons.jsx';
 import { fmtDate, fmtTime } from './festival-utils.js';
 import { eventCardBg } from './styles.js';
 
@@ -6,6 +7,9 @@ export default function BandsView({
   bandsList,
   myFavIds,
   canWrite,
+  // Load shedding: both hearts here (band-level bulk toggle + per-set) go inert
+  // rather than disappearing — the pick state is the information (loadshed.js).
+  picksPaused,
   toggleFavorite,
   favCounts,
   superMode,
@@ -114,9 +118,10 @@ export default function BandsView({
                     {canWrite && (
                       <button
                         onClick={() => toggleAllBand(band)}
-                        className={`shrink-0 text-2xl p-1.5 rounded-2xl m-0.5  font-bold transition-all ${allFaved ? 'bg-[#CD6C0C] text-white hover:opacity-90' : anyFav ? 'bg-[#CD6C0C]/40 text-white hover:opacity-90' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]'}`}
+                        disabled={picksPaused}
+                        className={`shrink-0 text-2xl p-1.5 rounded-2xl m-0.5  font-bold transition-all ${picksPaused ? c.shedInert : ''} ${allFaved ? 'bg-[#CD6C0C] text-white hover:opacity-90' : anyFav ? 'bg-[#CD6C0C]/40 text-white hover:opacity-90' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]'}`}
                       >
-                        {allFaved ? '♥' : anyFav ? '◐' : '♡'}
+                        <HeartIcon state={allFaved ? 'full' : anyFav ? 'half' : 'empty'} size={24} />
                       </button>
                     )}
                     <div className="flex-1 min-w-0">
@@ -126,8 +131,12 @@ export default function BandsView({
                           {lineupLabel}
                         </span>
                         {superMode && band.events.some((e) => favCounts[e.eventId] > 0) && (
-                          <span className={c.badge} title="Total picks across sets">
-                            ★ {band.events.reduce((n, e) => n + (favCounts[e.eventId] || 0), 0)}
+                          <span
+                            className={`${c.badge} inline-flex items-center gap-0.5`}
+                            title="Total picks across sets"
+                          >
+                            <StarIcon size={12} />{' '}
+                            {band.events.reduce((n, e) => n + (favCounts[e.eventId] || 0), 0)}
                           </span>
                         )}
                       </div>
@@ -143,9 +152,10 @@ export default function BandsView({
                             {canWrite && (
                               <button
                                 onClick={() => toggleFavorite(e)}
-                                className={`text-sm px-0.5 py-[0.5px] rounded-lg m-0.5  font-bold transition-all ${myFavIds.has(e.eventId) ? 'bg-[#CD6C0C] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]'}`}
+                                disabled={picksPaused}
+                                className={`text-sm px-0.5 py-[0.5px] rounded-lg m-0.5  font-bold transition-all ${picksPaused ? c.shedInert : ''} ${myFavIds.has(e.eventId) ? 'bg-[#CD6C0C] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]'}`}
                               >
-                                {myFavIds.has(e.eventId) ? '♥' : '♡'}
+                                <HeartIcon state={myFavIds.has(e.eventId) ? 'full' : 'empty'} size={16} />
                               </button>
                             )}
                             <span className={`text-sm font-bold ${c.bodyText}`}>
@@ -160,7 +170,7 @@ export default function BandsView({
                       href={band.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={c.linkBtn}
+                      className={c.linkPlain}
                       title="View on pickathon.com"
                     >
                       <svg

--- a/examples/pickathon-picker/BrowseView.jsx
+++ b/examples/pickathon-picker/BrowseView.jsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { fmtTime } from './festival-utils.js';
-import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
-import NoteField from './NoteField.jsx';
+import React, { useMemo, useRef, useEffect } from 'react';
+import { fmtTime, toFestivalDate } from './festival-utils.js';
+import { groupEventsByTimeSlot } from './schedule-build.js';
+import EventListItem from './EventListItem.jsx';
 
 export default function BrowseView({
   filteredEvents,
@@ -14,13 +14,59 @@ export default function BrowseView({
   myFavIds,
   canWrite,
   canFavorite,
+  // Load shedding: the heart still shows your pick state, it just can't be
+  // flipped right now (loadshed.js). Inert, never hidden.
+  picksPaused,
   toggleFavorite,
   notes,
   saveNote,
   superMode,
   favCounts,
+  friendPicksByEvent,
+  ViewerTag,
+  nowTick,
   c,
 }) {
+  // The event to land on when the page first opens: whatever is on now, else the
+  // next one still to come (during the festival), so you open onto the current
+  // moment. `nowTick` ticks each minute but the scroll fires once (didScrollRef).
+  const nowMs = nowTick || 0;
+  const nowTargetId = useMemo(() => {
+    let upcomingId = null;
+    let upcomingMs = Infinity;
+    let lastId = null;
+    let lastMs = -Infinity;
+    let earliestMs = Infinity;
+    for (const e of filteredEvents) {
+      const startMs = toFestivalDate(e.start).getTime();
+      const endMs = toFestivalDate(e.end).getTime();
+      if (startMs < earliestMs) earliestMs = startMs;
+      if (endMs >= nowMs && startMs < upcomingMs) {
+        upcomingId = e.eventId;
+        upcomingMs = startMs;
+      }
+      if (startMs > lastMs) {
+        lastId = e.eventId;
+        lastMs = startMs;
+      }
+    }
+    // Before the festival starts (now is earlier than every set) there is no
+    // "now" to jump to — stay at the top so the search/day controls stay in view.
+    if (nowMs < earliestMs) return null;
+    return upcomingId || lastId;
+  }, [filteredEvents, nowMs]);
+
+  const targetRef = useRef(null);
+  const didScrollRef = useRef(false);
+  useEffect(() => {
+    if (didScrollRef.current || !nowTargetId || !targetRef.current) return;
+    // Only auto-scroll the pristine, unfiltered list — never yank the view while
+    // someone is actively searching or day-filtering.
+    if (selectedDay !== 'all' || searchTerm) return;
+    targetRef.current.scrollIntoView({ block: 'start', behavior: 'auto' });
+    didScrollRef.current = true;
+  }, [nowTargetId, filteredEvents.length, selectedDay, searchTerm]);
+
   return (
     <div>
       <div className="mb-1.5 flex flex-wrap gap-1">
@@ -57,88 +103,45 @@ export default function BrowseView({
         const daysToShow = displayDays.filter((day) => byDay[day]?.length > 0);
         return daysToShow.map((day) => (
           <div key={day} className={c.schedDay}>
-            <h3 className="text-xl font-black mb-1 text-white">
+            <h3 className="text-xl font-black mb-1 px-[14px] text-white">
               {day} — {getDateForDay(day)}
             </h3>
-            <div className="grid gap-1">
-              {byDay[day].map((event) => {
-                const tag = lineupTag(event);
+            {/* Time slots: the time prints once as a label on the green and the cards
+                under it carry only what differs. Groups form on the FILTERED list, so a
+                search narrows the day and the labels regroup with it. */}
+            {groupEventsByTimeSlot(byDay[day]).map((group) => (
+              <div key={group.key}>
+                {/* Slot labels hug the container edge; only the day header keeps the 14px indent. */}
+                <div className="px-[5px] pt-0.5 text-base font-black text-white">
+                  {fmtTime(group.start)}
+                  {group.end ? ` – ${fmtTime(group.end)}` : ''}
+                </div>
+                <div className="grid gap-1">
+              {group.items.map((event) => {
+                const friendPicks =
+                  (friendPicksByEvent && friendPicksByEvent.get(event.eventId)) || [];
                 return (
-                  <div
+                  <EventListItem
                     key={event.eventId}
-                    className={`rounded-[16px] m-0.5 p-2 shadow-lg ${eventCardBg}`}
-                    style={eventCardStyle(event)}
-                  >
-                    <div className="flex flex-col sm:flex-row justify-between items-start gap-1">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-0.5 mb-0.5 flex-wrap">
-                          {superMode && favCounts[event.eventId] > 0 && (
-                            <span className={c.badge} title="People who picked this">
-                              ★ {favCounts[event.eventId]}
-                            </span>
-                          )}
-                          <h3 className={`text-xl font-black ${c.bodyText}`}>{event.title}</h3>
-                          <span className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5  uppercase bg-[#BACD32] text-[#4A4A4A]">
-                            {tag.label}
-                          </span>
-                        </div>
-                        <div className={`space-y-[1px] text-sm font-bold ${c.bodyText}`}>
-                          <p>{event.venueTitle}</p>
-                          <p>
-                            {fmtTime(event.start)} – {fmtTime(event.end)}
-                          </p>
-                        </div>
-                        {canWrite ? (
-                          <NoteField
-                            saved={notes[event.eventId]}
-                            onSave={(t) => saveNote(event.eventId, t)}
-                            className={c.noteArea}
-                          />
-                        ) : notes[event.eventId] ? (
-                          <div className={c.noteBox}>
-                            <p className={`text-sm font-bold ${c.bodyText}`}>
-                              {notes[event.eventId]}
-                            </p>
-                          </div>
-                        ) : null}
-                      </div>
-                      <div className="flex gap-0.5">
-                        {canFavorite && (
-                          <button
-                            onClick={() => toggleFavorite(event)}
-                            className={myFavIds.has(event.eventId) ? c.favToggleOn : c.favToggleOff}
-                          >
-                            {myFavIds.has(event.eventId) ? '♥' : '♡'}
-                          </button>
-                        )}
-                        <a
-                          href={event.url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className={c.linkBtn}
-                          title="View artist page"
-                        >
-                          <svg
-                            width="20"
-                            height="20"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="2"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          >
-                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                            <polyline points="15 3 21 3 21 9" />
-                            <line x1="10" y1="14" x2="21" y2="3" />
-                          </svg>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
+                    itemRef={event.eventId === nowTargetId ? targetRef : null}
+                    event={event}
+                    isMine={myFavIds.has(event.eventId)}
+                    canFavorite={canFavorite}
+                    picksPaused={picksPaused}
+                    toggleFavorite={toggleFavorite}
+                    superMode={superMode}
+                    favCount={favCounts[event.eventId] || 0}
+                    friendPicks={friendPicks}
+                    ViewerTag={ViewerTag}
+                    note={notes[event.eventId]}
+                    meta={`${event.venueTitle}${group.end ? '' : ` · until ${fmtTime(event.end)}`}`}
+                    c={c}
+                  />
                 );
               })}
-            </div>
+                </div>
+              </div>
+            ))}
           </div>
         ));
       })()}

--- a/examples/pickathon-picker/EventListItem.jsx
+++ b/examples/pickathon-picker/EventListItem.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { HeartIcon, StarIcon } from './icons.jsx';
+import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
+
+// The one card shape every event feed uses. Extracted from the All Events browse
+// list so "Right Now" renders identical items rather than a near-copy that drifts
+// — same title/tag line, same meta line, same heart, same followed-pick chips and
+// saved note. The only per-feed difference is the `meta` line the caller composes
+// (browse prints "venue · until <end>"; now prints "venue · date time–time").
+export default function EventListItem({
+  event,
+  isMine,
+  canFavorite,
+  picksPaused,
+  toggleFavorite,
+  superMode,
+  favCount = 0,
+  friendPicks = [],
+  ViewerTag,
+  note,
+  meta,
+  c,
+  itemRef,
+}) {
+  const tag = lineupTag(event);
+  return (
+    <div
+      ref={itemRef || null}
+      className={`rounded-[16px] m-0.5 p-2 shadow-lg ${eventCardBg}`}
+      style={eventCardStyle(event)}
+    >
+      <div>
+        <div className="flex items-center gap-0.5 mb-0.5 flex-wrap">
+          {superMode && favCount > 0 && (
+            <span
+              className={`${c.badge} inline-flex items-center gap-0.5`}
+              title="People who picked this"
+            >
+              <StarIcon size={12} /> {favCount}
+            </span>
+          )}
+          <h3 className={`text-xl font-black ${c.bodyText}`}>{event.title}</h3>
+          <span className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5  uppercase bg-[#BACD32] text-[#4A4A4A]">
+            {tag.label}
+          </span>
+        </div>
+        {/* Venue/time on the left, heart floated right on the same line — on every
+            screen size (the old layout dropped the button onto its own row on mobile). */}
+        <div className="flex justify-between items-start gap-1">
+          <div className={`space-y-[1px] text-sm font-bold ${c.bodyText}`}>
+            <p>{meta}</p>
+          </div>
+          <div className="flex gap-0.5 shrink-0">
+            {canFavorite && (
+              <button
+                onClick={() => toggleFavorite(event)}
+                disabled={picksPaused}
+                className={`${isMine ? c.favToggleOn : c.favToggleOff} ${picksPaused ? c.shedInert : ''}`}
+              >
+                <HeartIcon state={isMine ? 'full' : 'empty'} />
+              </button>
+            )}
+          </div>
+        </div>
+        {/* People you follow who have this on their picks — glanceable on every
+            feed so you can trail your friends' schedules. */}
+        {ViewerTag && friendPicks.length > 0 && (
+          <div className="flex items-center gap-0.5 flex-wrap mt-0.5">
+            {friendPicks.map((h) => (
+              <ViewerTag key={h} userHandle={h} />
+            ))}
+          </div>
+        )}
+        {/* No "Add note…" editor in the feeds (owner call: too noisy at this
+            density) — notes are edited from the My Faves schedule. An
+            already-saved note still shows. */}
+        {note ? (
+          <div className={c.noteBox}>
+            <p className={`text-sm font-bold ${c.bodyText}`}>{note}</p>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/examples/pickathon-picker/FavoritesView.jsx
+++ b/examples/pickathon-picker/FavoritesView.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { HeartIcon } from './icons.jsx';
 import { fmtTime, fmtDate } from './festival-utils.js';
 import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
 
@@ -10,6 +11,7 @@ export default function FavoritesView({
   userId,
   myFavIds,
   canWrite,
+  picksPaused,
   toggleFavorite,
   notes,
   ViewerTag,
@@ -80,8 +82,12 @@ export default function FavoritesView({
                     )}
                   </div>
                   {canWrite && (
-                    <button onClick={() => toggleFavorite(event)} className={c.favToggleOn}>
-                      <span className="font-black text-lg">♥</span>
+                    <button
+                      onClick={() => toggleFavorite(event)}
+                      disabled={picksPaused}
+                      className={`${c.favToggleOn} ${picksPaused ? c.shedInert : ''}`}
+                    >
+                      <HeartIcon state="full" />
                     </button>
                   )}
                 </div>

--- a/examples/pickathon-picker/FriendsView.jsx
+++ b/examples/pickathon-picker/FriendsView.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { QrCode } from '@vibes.diy/base';
 import ScheduleView from './ScheduleView.jsx';
 
 // Sentinel for selectedFriend meaning "everyone I follow" — the unified
@@ -18,6 +19,7 @@ export default function FriendsView({
   unfollow,
   approve,
   removeFollower,
+  sharing,
   selectedFriend,
   setSelectedFriend,
   includeMyFaves,
@@ -25,6 +27,7 @@ export default function FriendsView({
   friendFavoriteEvents,
   friendShifts,
   canWrite,
+  picksPaused,
   toggleFavorite,
   myFavIds,
   displayDays,
@@ -34,7 +37,8 @@ export default function FriendsView({
   shiftEndRaw,
   fmtTime,
   connectUrl,
-  qrSrc,
+  myHandle,
+  onOpenProfile,
   ViewerTag,
   c,
 }) {
@@ -78,14 +82,47 @@ export default function FriendsView({
 
   return (
     <div>
+      {canWrite && !sharing.enabled && (
+        <div className="mb-1.5 p-2.5 bg-[#CD6C0C] rounded-2xl m-0.5 flex flex-col items-center gap-1">
+          <p className="text-white font-bold text-center">
+            Your picks are currently hidden from your followers — turn on sharing so they can see
+            your schedule.
+          </p>
+          <button
+            onClick={sharing.arm}
+            disabled={sharing.busy}
+            className="py-[7px] px-2.5 font-black rounded-2xl m-0.5 bg-white text-[#CD6C0C] hover:opacity-90 transition-all"
+          >
+            Share my picks with followers
+          </button>
+        </div>
+      )}
+      {/* The arm banner's reverser, in the banner's own slot so the pair is discoverable
+          from here as well as from the profile. Picks-scoped: not account privacy. */}
+      {canWrite && sharing.enabled && sharing.stop && (
+        <div className="mb-1.5 text-center">
+          <button
+            onClick={sharing.stop}
+            disabled={sharing.busy}
+            className={c.quietLink(sharing.busy)}
+            title="Turns pick-sharing back off — your picks stop being shared with followers. You can turn it on again any time."
+          >
+            Stop sharing my picks
+          </button>
+        </div>
+      )}
       <div className="flex flex-col items-center gap-1 p-2.5 bg-[#BACD32] dark:bg-[#2c3510] rounded-2xl m-0.5  mb-1.5">
         <div className="flex items-center gap-0.5 flex-wrap justify-center">
           <p className={`text-lg font-bold ${c.bodyText}`}>
             Share this link so people can follow you
           </p>
         </div>
-        <div className="bg-white dark:bg-[#1d3015] rounded-2xl m-0.5  p-2">
-          <img src={qrSrc} alt="Follow-me QR code" width="320" height="320" />
+        {/* The code is generated locally (no network, so no broken-image state), and the
+            component draws dark-on-white for scannability — so this box stays WHITE in
+            dark mode too, or the quiet zone would fight the code. Padding + matching
+            inner radius keep the square clear of the box's curved corners. */}
+        <div className="bg-white rounded-2xl m-0.5 p-[14px] overflow-hidden">
+          <QrCode value={connectUrl} size={320} className="max-w-full rounded-lg" title="Follow-me QR code" />
         </div>
         <div className="flex items-center gap-[3px]">
           <button
@@ -127,10 +164,20 @@ export default function FriendsView({
               </>
             )}
           </button>
+          {/* The link opens YOUR profile — so the honest way to check what it shows is
+              to open that same profile yourself, through the follower-visible path. */}
+          {myHandle && onOpenProfile && (
+            <button
+              onClick={() => onOpenProfile(myHandle)}
+              className="py-[7px] px-[14px] font-bold rounded-2xl m-0.5 bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510] transition-all"
+            >
+              Preview my profile
+            </button>
+          )}
         </div>
         <p className={`text-sm font-bold text-center max-w-[340px] ${c.bodyText}`}>
-          Whoever opens it follows you — they'll see the picks and shared extras on your schedule.
-          Follow them back to see theirs.
+          Whoever scans it sees your profile with a Follow button. Once they follow you, they see
+          the picks and shared extras on your schedule — follow them back to see theirs.
         </p>
       </div>
 
@@ -204,7 +251,8 @@ export default function FriendsView({
         <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Following ({following.length})</h3>
         {following.length === 0 ? (
           <p className={`font-bold ${c.bodyText} mb-1.5`}>
-            Not following anyone yet — scan a friend's QR code to follow them.
+            Not following anyone yet — scan someone's QR code to open their profile and follow
+            them.
           </p>
         ) : (
           <div className="flex flex-wrap gap-[3px] mb-1.5">
@@ -252,7 +300,9 @@ export default function FriendsView({
 
         <h3 className={`text-xl font-black mb-1 ${c.bodyText}`}>Followers ({followers.length})</h3>
         <p className={`text-sm font-bold mb-1 ${c.bodyText}`}>
-          Followers can see your picks and shared extras.
+          {sharing.enabled
+            ? 'Followers can see your picks and shared extras.'
+            : 'Followers will see your picks and shared extras once you turn on sharing above.'}
         </p>
         {followers.length === 0 ? (
           <p className={`font-bold ${c.bodyText}`}>Nobody follows you yet — share your QR above.</p>
@@ -318,9 +368,10 @@ export default function FriendsView({
             emptyMessage={
               selectedFriend === ALL_FRIENDS
                 ? 'Nobody you follow has picked any events yet.'
-                : "They haven't picked any events yet — or their account is private and hasn't approved you yet."
+                : "No picks to show — they haven't shared any yet."
             }
             canWrite={false}
+            picksPaused={picksPaused}
             onToggleFavorite={canWrite ? toggleFavorite : null}
             myFavIds={myFavIds}
             ViewerTag={ViewerTag}

--- a/examples/pickathon-picker/NoteField.jsx
+++ b/examples/pickathon-picker/NoteField.jsx
@@ -3,15 +3,15 @@ import React, { useState, useRef, useEffect } from 'react';
 // A note editor that buffers keystrokes locally so typing never re-renders the
 // whole app. It only persists (via onSave) when you focus away, and adopts
 // external live-query updates only while you're not editing.
-// collapsedRight: park the small (collapsed) box at the row's right edge; the
-// expanded editor still takes the full row. Used by the schedule listings.
+// Rendered inside a flex-wrap row (beside the time/venue line): collapsed it is a
+// small inline box on that same line; expanded it takes basis-full so it wraps to
+// its own full-width row below.
 export default function NoteField({
   saved,
   onSave,
   className,
   placeholder = 'Add note...',
   collapsedStyle,
-  collapsedRight,
 }) {
   const [text, setText] = useState(saved || '');
   const [focused, setFocused] = useState(false);
@@ -39,9 +39,7 @@ export default function NoteField({
   };
 
   return (
-    <div
-      className={`mt-0.5 flex items-center gap-0.5 ${collapsedRight && !expanded ? 'justify-end' : ''}`}
-    >
+    <div className={`flex items-center gap-0.5 ${expanded ? 'basis-full mt-0.5' : ''}`}>
       <textarea
         placeholder={placeholder}
         value={text}

--- a/examples/pickathon-picker/NowView.jsx
+++ b/examples/pickathon-picker/NowView.jsx
@@ -1,55 +1,43 @@
 import React from 'react';
 import { FESTIVAL_TZ, fmtTime, fmtDate } from './festival-utils.js';
-import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
-
-function EventCard({ event, isMine, isFriendPick, canWrite, toggleFavorite, c, showDate }) {
-  const tag = lineupTag(event);
-  return (
-    <div
-      className={`rounded-[16px] m-0.5 p-2 shadow-lg ${eventCardBg}`}
-      style={eventCardStyle(event)}
-    >
-      <div className="flex justify-between items-start gap-[3px] flex-wrap">
-        <div className="flex-1">
-          <div className="flex items-center gap-0.5 mb-[1px] flex-wrap">
-            <h4 className={`text-lg font-black ${c.bodyText}`}>{event.title}</h4>
-            <span className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5  uppercase bg-[#BACD32] text-[#4A4A4A]">
-              {tag.label}
-            </span>
-            {isFriendPick && (
-              <span className={c.badge} title="A friend favorited this">
-                followed pick
-              </span>
-            )}
-          </div>
-          <p className={`text-sm font-bold ${c.bodyText}`}>
-            {event.venueTitle} · {showDate ? `${fmtDate(event.start)} ` : ''}
-            {fmtTime(event.start)}–{fmtTime(event.end)}
-          </p>
-        </div>
-        {canWrite && (
-          <button
-            onClick={() => toggleFavorite(event)}
-            className={isMine ? c.favToggleOn : c.favToggleOff}
-          >
-            {isMine ? '♥' : '♡'}
-          </button>
-        )}
-      </div>
-    </div>
-  );
-}
+import EventListItem from './EventListItem.jsx';
 
 export default function NowView({
   nowSets,
   nextSets,
   nowTick,
   myFavIds,
-  friendFavIds,
+  friendPicksByEvent,
+  ViewerTag,
+  notes = {},
+  superMode,
+  favCounts = {},
   canWrite,
+  // Load shedding: hearts stay legible but inert (loadshed.js).
+  picksPaused,
   toggleFavorite,
   c,
 }) {
+  // Same list item as the All Events feed — only the meta line differs (the now
+  // feed prints the set's own clock, since there is no time-slot label above it).
+  const renderSet = (event, showDate) => (
+    <EventListItem
+      key={event.eventId}
+      event={event}
+      isMine={myFavIds.has(event.eventId)}
+      canFavorite={canWrite}
+      picksPaused={picksPaused}
+      toggleFavorite={toggleFavorite}
+      superMode={superMode}
+      favCount={favCounts[event.eventId] || 0}
+      friendPicks={(friendPicksByEvent && friendPicksByEvent.get(event.eventId)) || []}
+      ViewerTag={ViewerTag}
+      note={notes[event.eventId]}
+      meta={`${event.venueTitle} · ${showDate ? `${fmtDate(event.start)} ` : ''}${fmtTime(event.start)}–${fmtTime(event.end)}`}
+      c={c}
+    />
+  );
+
   return (
     <div>
       <div className="flex items-center justify-between mb-1.5 flex-wrap gap-[3px]">
@@ -69,20 +57,7 @@ export default function NowView({
           <p className={`font-bold ${c.bodyText}`}>Nothing is on stage right now.</p>
         </div>
       ) : (
-        <div className="grid gap-[3px] mb-2">
-          {nowSets.map((event) => (
-            <EventCard
-              key={event.eventId}
-              event={event}
-              isMine={myFavIds.has(event.eventId)}
-              isFriendPick={friendFavIds.has(event.eventId)}
-              canWrite={canWrite}
-              toggleFavorite={toggleFavorite}
-              c={c}
-              showDate={false}
-            />
-          ))}
-        </div>
+        <div className="grid gap-1 mb-2">{nowSets.map((event) => renderSet(event, false))}</div>
       )}
 
       <h3 className={`text-xl font-black mb-[3px] ${c.bodyText}`}>Up Next</h3>
@@ -91,20 +66,7 @@ export default function NowView({
           <p className={`font-bold ${c.bodyText}`}>No more sets scheduled.</p>
         </div>
       ) : (
-        <div className="grid gap-[3px]">
-          {nextSets.map((event) => (
-            <EventCard
-              key={event.eventId}
-              event={event}
-              isMine={myFavIds.has(event.eventId)}
-              isFriendPick={friendFavIds.has(event.eventId)}
-              canWrite={canWrite}
-              toggleFavorite={toggleFavorite}
-              c={c}
-              showDate={true}
-            />
-          ))}
-        </div>
+        <div className="grid gap-1">{nextSets.map((event) => renderSet(event, true))}</div>
       )}
     </div>
   );

--- a/examples/pickathon-picker/ProfileView.jsx
+++ b/examples/pickathon-picker/ProfileView.jsx
@@ -1,0 +1,221 @@
+import React, { useState } from 'react';
+import ScheduleView from './ScheduleView.jsx';
+import { followButtonState, profileEmptyMessage } from './social-logic.js';
+
+// A handle's public profile — what a FOLLOWER sees of them: identity, a follow
+// button, and their follower-visible picks/shared extras.
+//
+// It is reachable signed-out (a scanned QR is usually someone's first contact with
+// the app), so nothing here may assume a viewer identity. The picks it renders come
+// from the same read path FriendsView uses — the live query only ever returns docs
+// the platform already decided this viewer may read, so "empty" here is honest:
+// they haven't picked, their picks aren't shared, or they haven't approved this
+// viewer's request. The client can't tell those apart, and the follower-facing copy
+// deliberately doesn't guess at a cause the viewer can't fix (see social-logic.js).
+//
+// OWN profile is deliberately rendered through the same follower-visible path rather
+// than the owner's local favorites: the point of previewing your profile is to see
+// what OTHERS get. The pick-sharing control lives here for the same reason — it's
+// what governs everything below it.
+
+// ViewerTag has no size or avatar-only prop: it always renders a pill whose avatar is a
+// fixed 30px circle, inset from the pill's top-left by its 1px border + 5px padding.
+// So scale the WHOLE pill 4× from its top-left corner (the same transform-scale trick
+// the platform's own AccountView uses at 1.3×) — the avatar becomes 120px sitting 24px
+// in (4 × 6px) — then pull the pill back by exactly that 24px so the avatar lands on the
+// 120px clipping circle. The pill's background and username scale out of the circle and
+// are clipped away, leaving avatar only.
+const BIG_AVATAR = 120;
+const BIG_AVATAR_SCALE = 4;
+const BIG_AVATAR_INSET = -(BIG_AVATAR_SCALE * 6); // border + padding, scaled
+const bigAvatarTagStyle = {
+  position: 'absolute',
+  top: BIG_AVATAR_INSET,
+  left: BIG_AVATAR_INSET,
+  transform: `scale(${BIG_AVATAR_SCALE})`,
+  transformOrigin: 'top left',
+};
+
+// Your OWN avatar renders the propless "me" tag, which is the editable shape — that's
+// how you set your photo, so it must not be wrapped in anything that eats the click.
+function BigAvatar({ ViewerTag, handle, isSelf }) {
+  return (
+    <div
+      className="relative shrink-0 rounded-full overflow-hidden"
+      style={{ width: BIG_AVATAR, height: BIG_AVATAR }}
+      title={isSelf ? 'Tap your photo to change it' : undefined}
+    >
+      {isSelf ? (
+        <ViewerTag style={bigAvatarTagStyle} />
+      ) : (
+        <ViewerTag userHandle={handle} style={bigAvatarTagStyle} />
+      )}
+    </div>
+  );
+}
+
+export default function ProfileView({
+  handle,
+  isSelf,
+  signedIn,
+  socialReady,
+  followState, // 'active' | 'requested' | null
+  follow,
+  unfollow,
+  // The pick-sharing knob (NOT account privacy): whether it's armed, whether a
+  // round-trip is in flight, and the two actions.
+  sharing,
+  // Everything ScheduleView needs to render one handle's days.
+  schedule,
+  // Raw tag for the header avatar (unwrapped: it's already this profile, and the self
+  // one must keep its upload click); ProfileTag for handles that link elsewhere.
+  ViewerTag,
+  ProfileTag,
+  c,
+}) {
+  // A follow mutation resolves only once the shell pushes a refreshed graph
+  // snapshot, so this is a double-tap guard, not an optimistic state: when it
+  // clears, followState already carries the answer. Refusals (blocked pair,
+  // unknown handle) resolve quietly — there is no error to render.
+  const [busy, setBusy] = useState(false);
+  const mutate = (fn) => {
+    setBusy(true);
+    fn(handle).finally(() => setBusy(false));
+  };
+
+  const sharingOff = isSelf && !sharing.enabled;
+  const emptyMessage = profileEmptyMessage({ isSelf, sharingOff, followState, signedIn });
+
+  const followBtn = () => {
+    // 'requested' can only appear AFTER the tap — a target handle's account privacy
+    // isn't in the protocol, so the button can't offer "Request to follow" up front
+    // (platform #4319).
+    switch (followButtonState({ isSelf, signedIn, socialReady, followState })) {
+      case 'none':
+        return null;
+      case 'signin':
+        return (
+          <span className={`text-sm font-bold ${c.bodyText}`}>
+            Sign in via the Vibes DIY logo to follow
+          </span>
+        );
+      case 'loading':
+        return <span className={`text-sm font-bold ${c.bodyText}`}>…</span>;
+      case 'following':
+        return (
+          <button
+            onClick={() => mutate(unfollow)}
+            disabled={busy}
+            className={busy ? c.btnWorking : c.btnCyan}
+            title="Tap to unfollow"
+          >
+            Following ✓
+          </button>
+        );
+      case 'requested':
+        return (
+          <button
+            onClick={() => mutate(unfollow)}
+            disabled={busy}
+            className={busy ? c.btnWorking : c.btnCyan}
+            title="Their account is private — tap to cancel the request"
+          >
+            Requested
+          </button>
+        );
+      default:
+        return (
+          <button
+            onClick={() => mutate(follow)}
+            disabled={busy}
+            className={busy ? c.btnWorking : c.btnPink}
+          >
+            Follow
+          </button>
+        );
+    }
+  };
+
+  // Ordinary page content, not an overlay: the app header and nav stay above it and any
+  // tab press navigates away, so there is no Close button to get wrong.
+  return (
+    <div>
+      <div
+        className={`${c.headerBg} rounded-2xl m-0.5 mb-1.5 p-[14px] flex items-center gap-[14px]`}
+      >
+        <BigAvatar ViewerTag={ViewerTag} handle={handle} isSelf={isSelf} />
+        <div className="flex flex-col gap-[6px] min-w-0">
+          <h2 className={`text-2xl font-black ${c.bodyText}`}>
+            {isSelf ? 'Your profile' : 'Profile'}
+          </h2>
+          {/* The scaled tag clips its own username away, so the handle is text here. */}
+          <p className={`text-lg font-bold truncate ${c.bodyText}`}>@{handle}</p>
+          <div>{followBtn()}</div>
+        </div>
+      </div>
+
+      <div>
+        {isSelf && (
+          <div className="mb-1.5 p-[14px] bg-white dark:bg-[#22252d] rounded-2xl m-0.5">
+            <p className={`font-bold ${c.bodyText}`}>
+              This is your public profile — this is what others see.
+            </p>
+          </div>
+        )}
+
+        {/* Account privacy (whether follows need approval) is PLATFORM state with no
+            setter on useSocial — it lives in Settings → Social, not here. This block is
+            the separate per-app pick-sharing arm: without it, even approved followers
+            see an empty schedule. */}
+        {sharingOff && (
+          <div className="mb-1.5 p-[14px] bg-[#CD6C0C] rounded-2xl m-0.5 flex flex-col items-center gap-[8px]">
+            <p className="text-white font-bold text-center">
+              Your picks are hidden from your followers — turn on sharing so your profile shows
+              your schedule.
+            </p>
+            <button
+              onClick={sharing.arm}
+              disabled={sharing.busy}
+              className="py-[7px] px-[14px] font-black rounded-2xl m-0.5 bg-white text-[#CD6C0C] hover:opacity-90 transition-all"
+            >
+              Share my picks with followers
+            </button>
+          </div>
+        )}
+
+        <h3 className={`text-2xl font-black mb-1 ${c.bodyText}`}>
+          {isSelf ? 'What your followers see' : 'Their picks'}
+        </h3>
+        <ScheduleView
+          days={schedule.days}
+          getDateForDay={schedule.getDateForDay}
+          buildSchedule={schedule.build}
+          fmtTime={schedule.fmtTime}
+          notes={null}
+          c={c}
+          shiftStartRaw={schedule.shiftStartRaw}
+          shiftEndRaw={schedule.shiftEndRaw}
+          emptyMessage={emptyMessage}
+          canWrite={false}
+          onToggleFavorite={null}
+          myFavIds={null}
+          ViewerTag={ProfileTag}
+        />
+        {/* The reverser for the arm CTA above, in the same place as what it governs.
+            Picks-scoped by design: this is not account privacy. */}
+        {isSelf && sharing.enabled && sharing.stop && (
+          <div className="mt-1.5 text-center">
+            <button
+              onClick={sharing.stop}
+              disabled={sharing.busy}
+              className={c.quietLink(sharing.busy)}
+              title="Turns pick-sharing back off — your picks stop being shared with followers. You can turn it on again any time."
+            >
+              Stop sharing my picks
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/examples/pickathon-picker/RUNBOOK.md
+++ b/examples/pickathon-picker/RUNBOOK.md
@@ -22,6 +22,35 @@ npx vibes-diy pull og/pickathon-picker
 
 **Warning:** `pull` currently writes the compiled/transpiled JS, not raw JSX (see issue #2056). Use the source in this directory as the authoritative copy and don't overwrite it with a pull unless you manually verify the output is clean JSX.
 
+## Source layout
+
+`App.jsx`, `access.js` and `backend.js` are reserved names the platform loads by
+convention; everything else is free. Decision logic lives in plain `.js` modules so it
+can be tested without a browser — `App.jsx` is wiring (hooks, state, JSX), not rules.
+
+| File                                   | Holds                                                                                     |
+| -------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `App.jsx`                              | Hooks, state, nav, and the JSX shell. Delegates every non-trivial decision to the modules. |
+| `url-state.js`                         | `#friend=` / `?friend=` deep links + `?super=1`. Every fn takes the window, so it's testable. |
+| `schedule-build.js`                    | Docs → events (`day` derived at read time), day ordering, `buildDaySchedule`, shift bounds. |
+| `picks.js`                             | Favorites/extras joined to the schedule for one handle or a unified audience.               |
+| `social-logic.js`                      | Who can see what, which follow control to render, the empty-state copy matrix, arm path.    |
+| `docs.js`                              | `_id` shapes (a contract with `access.js`/`backend.js`), sign-in migration, ics/token.       |
+| `festival-utils.js`                    | Festival timezone/date math (the 4 AM night cutoff), constants.                             |
+| `styles.js`                            | The `c` class bag + lineup card colors. Note Tailwind spacing here is px-scaled.            |
+| `loadshed.js`                          | The load-shed level contract (`0-load-shed` doc → what's paused) + the banner copy.          |
+| `*View.jsx`, `NoteField`, `icons`      | Presentational components; they take `c` and the data they render.                          |
+
+Tests: `backend.test.js` / `access.test.js` / `schedule.test.js` cover the server side and
+the time math; `url-state.test.js` / `schedule-build.test.js` / `picks.test.js` /
+`social-logic.test.js` / `docs.test.js` / `loadshed.test.js` pin the app-side logic above
+(deep-link round trips, the schedule merge/sort, audience joins, the six-arm
+empty-message matrix, doc re-keying, the fail-open shed-level parse). `npx vitest run` from this directory runs all of them; they are pure — no
+jsdom, no network.
+
+`NowView.jsx` is currently not mounted by `App.jsx` (its "on now / up next" tab was
+retired). It is kept intact rather than deleted — reinstating it is a product call.
+
 ## Architecture notes
 
 - **Database**: Fireproof `"pickathon"` — data lives in the browser, syncs across users via the vibes.diy data plane. Read access is scoped by `access.js` channels (below), so a client only syncs what it can read.
@@ -31,7 +60,25 @@ npx vibes-diy pull og/pickathon-picker
   - **Notes** (`note-{userId}-{eventId}`) → private **`user-{userId}`** channel. Never shared.
   - **Shifts** → `share-{userId}` if `shareWithFriends`, else private `user-{userId}`. So a friend can see your shared shifts (via the friend grant) but not your private ones.
   - **Follow graph (PLATFORM)** — who-sees-whose-picks moved out of this db entirely (vibes.diy#3421): edges, privacy, and blocks live in the platform (Settings → Social), read/mutated in-app via `useSocial()`. Favorites and shared extras carry `audience: { followersOf: <owner> }` on their access-fn result, resolved at READ TIME against the live graph — a new follower instantly sees history, unfollow/removeFollower/block instantly revokes. The owner is always in their own audience, so no self-grant is needed.
-- **Super mode** — URL easter egg (`?super=1` / `?super=true`). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
+- **Friend-connect link → profile page** — the QR/share URL is
+  `https://vibes.diy/vibe/og/pickathon-picker#friend=<handle>` (**hash, not query, no trailing
+  slash**): hash links stay on the warm SWR HTML-cache path (a query param bypasses it — every
+  visit pays full SSR, ~2.5-3× slower — and the slash costs a 301), and the platform's
+  url-state mirror (vibes.diy#4308, shipped 2026-07-27) forwards the host hash into the iframe
+  (late — the app listens for `hashchange`, not just mount-time reads) and mirrors the app's
+  `history.replaceState` back to the address bar. Opening the link **renders that handle's
+  profile** (`ProfileView.jsx`) — it never follows anyone on the visitor's behalf. The profile
+  works signed-out; the Follow button appears once signed in (`Follow` → `Requested` for a
+  private account → `Following ✓`, tap to unfollow), and your own profile shows no button.
+  Because the profile is ordinary shareable navigation state and not a one-time secret, the
+  fragment **stays in the URL while the profile is open** and is removed via `replaceState`
+  when it closes; a legacy `?friend=` QR opens the same profile and is normalized to the hash
+  form. `?friend=` keeps working indefinitely as the fallback — old printed QR codes are slow,
+  never broken.
+  **QA iteration status (2026-07-27):** the profile page is being iterated on the QA copy
+  `qa/pickathon-picker`, so `connectUrl` in `App.jsx` is hardcoded to that path behind a
+  `// PROMOTE: revert to og/pickathon-picker` comment. Flip it back before shipping to `og`.
+- **Super mode** — URL easter egg (`?super=1` / `?super=true`, hash form also accepted). Shows `★ N` global pick counts and a peer picker. To see global data you must both (a) open with `?super=1` **and** (b) hold a `super` grant (below) — otherwise the client only has its own + friends' favorites and the counts are friend-scoped.
 
 ## Granting super access
 
@@ -49,6 +96,58 @@ npx vibes-diy db put --vibe og/pickathon-picker --db pickathon \
 
 The grant takes effect on the grantee's next sync. There's intentionally no UI for this.
 (To revoke, `db del` the grant doc by its `_id` — the grantee loses `super` on re-sync.)
+
+## Load shedding (the festival-rush switch)
+
+One owner-written doc turns the expensive, viewer-driven parts of the app off without a
+redeploy. Flip it when the app is under real festival load; flip it back after.
+
+```bash
+# Pause writes (hearts, band heart, notes, extras) — schedule/browse/bands/now stay full:
+npx vibes-diy db put --vibe og/pickathon-picker --db pickathon \
+  '{"_id":"0-load-shed","type":"loadshed","level":"read-only"}'
+
+# Also stop mounting the Friends tab + profile views (the per-viewer follower fan-out):
+npx vibes-diy db put --vibe og/pickathon-picker --db pickathon \
+  '{"_id":"0-load-shed","type":"loadshed","level":"schedule-only"}'
+
+# Back to normal — PUT level "off", do not `db del` the doc (see below):
+npx vibes-diy db put --vibe og/pickathon-picker --db pickathon \
+  '{"_id":"0-load-shed","type":"loadshed","level":"off"}'
+```
+
+| level           | Schedule / Browse / Bands / Now | Favorite toggles, band heart, notes, extras | Friends tab + profiles | `.ics` subscription feed |
+| --------------- | ------------------------------- | ------------------------------------------- | ---------------------- | ------------------------ |
+| absent / `off` / anything unrecognized | full                            | full                                        | full                   | 200, normal              |
+| `read-only`     | full                            | inert (visible, not clickable) + one banner line | full              | 503 + `Retry-After`      |
+| `schedule-only` | full                            | inert + one banner line                     | one paused line, query not mounted | 503 + `Retry-After` |
+
+Notes that cost time if you don't know them:
+
+- **It fails open.** No doc, `level:"off"`, or any unrecognized level (a typo) is fully
+  normal operation, everywhere — client and backend. Shedding is never the default.
+- **Anonymous and signed-in behave identically.** `access.js` publishes the doc on the
+  same world-readable `schedule` channel as the schedule itself, so every client
+  (including anonymous, including offline replicas) sees the level. Write is
+  **owner-only** — a stranger able to flip the app read-only would be a griefing vector.
+- **Turn it off with `level:"off"`, not `db del`.** `backend.js` keeps an in-isolate copy
+  so a doc missing from a capped read means "don't know, keep shedding" (§ the 2000-doc
+  cap) rather than "shedding is off". A deleted doc therefore keeps a warm isolate
+  shedding until it is evicted.
+- **The tick keeps its heartbeat and keeps mirroring the schedule** in both shed levels —
+  liveness evidence must survive exactly the hours we are under load, and the 5-minute
+  mirror is a fixed cost, not viewer amplification. Only the ics aggregate is skipped.
+- **The feed answers 503, not an empty calendar.** Calendar clients back off on a 503 and
+  keep the events they already synced; an empty calendar would read as "your picks are
+  gone".
+- Client-side effect is immediate (it's a replicated doc); the backend follows within one
+  tick (≤1m). Measured on a probe deploy 2026-07-29: `read-only` produced the 503 within
+  25s, and `level:"off"` restored 200 within 50s.
+- **Run the `db put` as the handle that OWNS the app** (`og` for the live app). Measured:
+  a CLI signed in under a different handle gets `Error: owner only` for this doc — and for
+  the pre-existing `grant` doc too — and `--admin` does NOT bypass the access function
+  (tried every flag combination). This is `access.js` working as intended; it just means
+  the flip is an owner-identity operation, not a platform-admin one.
 
 ## Calendar export & subscription (.ics)
 
@@ -103,9 +202,116 @@ timezone helpers are deliberately duplicated from `festival-utils.js`. Its own
 exported handler). Tests: `backend.test.js` (formatter, aggregation, both lanes)
 and `schedule.test.js` (item flattening).
 
-## Schedule data
+## Schedule data (docs-first, offline-ready)
 
-Fetched from `https://pickathon.com/wp-content/plugins/pickathon/schedule.php` and cached in `localStorage` for 10 minutes. All times stored/displayed in `America/Los_Angeles`.
+Rendered **docs-first** from one **server-maintained singleton cache**: the
+`scheduled` lane in `backend.js` fetches
+`https://pickathon.com/wp-content/plugins/pickathon/schedule.php` **every 5 minutes**
+(`SCHEDULE_SYNC_INTERVAL_MS`, not every tick) and mirrors it into public
+`scheduleitem` docs (one per event, `_id: schedule-event-{eventId}`), diffing so
+only changed items are upserted. Those docs sit on the `schedule` channel under
+`grant.public`, so they replicate to every client — anonymous included — and render
+offline with no per-user keying and **no client-side feed fetch at all**. All times
+stored/displayed in `America/Los_Angeles`.
+
+**The mirror keeps its own state doc, and this is load-bearing.** `ctx.db.query`
+is capped host-side at **2000 docs sorted by `_id`**, silently — no error, no
+cursor. Once this db passed 2000 (favorites did it), `schedule-event-*` sorted
+past the cut and the tick could no longer see a single one of its own mirror
+docs: the diff read "nothing is mirrored" and re-put all ~330 events **every 60
+seconds**, holding the vibe's Durable Object at 97% occupancy so every visitor's
+first page load queued behind it. The fix is that the mirror no longer asks the
+db what it mirrored — it remembers, in `_id: 0-schedule-sync-state` (`type:
+schedulesync`, one content fingerprint per event). That `_id` leads with a
+**digit**, which sorts ahead of every id this app mints (`caltoken-`, `favorite-`,
+`note-`, `schedule-event-`, and the `019f…` uuid shifts), so it rides inside the
+cap at any db size. Owner-only write in `access.js`: the tick trusts it, so a
+forged one could freeze the schedule. An unchanged schedule now costs **zero
+writes**.
+
+That last guarantee covers ids *we* mint, not all possible ids — `_id` is a free
+string, and 2000 docs starting with punctuation (below `0`) would evict even this
+one. Nothing in the app writes such an id; a signed-in stranger could, since the
+unknown-type branch in `access.js` accepts a write from anybody and merely routes
+it to `discard`. So the fingerprints are also held **in isolate memory**
+(`lastFingerprints`), and the tick treats a missing state doc as "use the copy",
+never as "nothing is mirrored". Concluding the latter takes a lost state doc *and*
+a cold isolate, and costs one burst rather than one a minute.
+
+> **Watch for:** `pickathon tick: db read hit the 2000-doc query cap` in
+> `wrangler tail`. It is expected today and means the aggregate below is missing
+> the favorites that sort after the cut — those users' `.ics` feeds lose picks.
+> Fixing that needs a filtered or paginated backend read, which the platform
+> does not offer yet.
+
+> **Retired:** the per-user `schedulecache` write-through doc
+> (`_id: schedule-cache-{userId}`) and the client-side background feed fetch. It
+> stored the same public schedule once per user; at 10 copies × ~96 KB it was 74%
+> of the db, and the whole-db `scheduled` query paid for it every minute. Its
+> `access.js` branch is gone and legacy docs now fall through to `discard`
+> (unreadable), same as retired `friend` docs. `localStorage` is likewise no longer
+> a warm source.
+
+**Offline cached view (platform PR #4000) support**: mount-time reads are stable
+(same db, same index fns, same keys every boot) so the read mirror stays warm; all
+`database.put/del` calls route through `safeDb`, which turns the offline frame's
+write-refusal into a "couldn't save — offline copy" toast instead of a crash; the
+remote header logo falls back to an inline placeholder when it can't load (the cached
+frame's CSP blocks remote images). The follow QR is **generated locally** —
+`<QrCode>` from `@vibes.diy/base` (inline SVG over the bundled zero-dep
+`qrcode-generator`, on the vibe-pkg import-map allowlist), so it works offline, makes no
+third-party call, and has no broken-image state to fall back from. It draws dark-on-white
+by design (an inverted QR scans unreliably), so its container stays white in dark mode.
+
+**First-load story**: the server SEEDS the `scheduleitem` docs (~330) into first paint, so
+a first-time anonymous visitor gets the real schedule immediately — there is normally no
+loading state at all. The "Downloading the schedule for offline access" takeover is
+reserved for a session that has never held ANY events (a genuinely empty first visit). It
+is keyed on zero LOADED events, never on zero filtered results — a search with no hits
+keeps its own empty behaviour.
+
+A cold replica's first snapshot can read EMPTY for a moment even so: that empty read is
+treated as authoritative and reaps the seeded rows, and the initial pull then restores
+them — which produced schedule → full-width takeover → schedule for anonymous
+first-timers. The app no longer participates: `retainEvents` (`schedule-build.js`) holds
+the last NON-EMPTY set for the session, so a transient zero-row read keeps the schedule on
+screen and only a never-had-events session can reach the takeover. The platform-side hold
+on seeded rows until initial sync settles is a separate fix in flight; this makes the app
+immune either way. Alongside it, `useLiveQuery`'s `fromCache` (#4348 — true while rows come
+from the local replica with no completed initial pull confirming them this session) drives
+a quiet, non-blocking "updating…" line above the content; it is never a paint gate, and on
+a runtime that predates the flag it is undefined and simply never shows.
+
+## Schedule listing: time-slot groups
+
+`ScheduleView` (My Faves, a followed handle's schedule, and the profile picks all render
+through it) **and `BrowseView` (All Events)** prints each time ONCE, as a slot label on the green day background, with the
+cards for that slot beneath it — a `<dl>` per day, `<dt>` label, `<dd>` cards. The
+grouping rule lives in `groupByTimeSlot` (`schedule-build.js`, pinned by tests):
+consecutive rows of the already-sorted day that start at the same instant form one group;
+shifts group by the same rule as events. The label shows `start – end` when every member
+of the slot shares the end, and only `start` when they don't — in that case each card
+carries its own `until <time>` note, because printing one range over rows that disagree
+would be a lie. Cards keep title/tag/heart, venue (its own line now), notes and pickedBy;
+`GapStrip` is dormant (every call site passes `showGaps` false) but stays wired to the
+slot boundaries. BrowseView uses the sibling `groupEventsByTimeSlot` (a plain event list,
+no shifts) and groups the ALREADY-FILTERED day, so a search narrows the day and the labels
+regroup with it — expected. `BandsView` is alphabetical by artist, so time labels don't
+apply there and it is unchanged.
+
+## Now view (temporarily enabled for owner testing)
+
+`const NOW_VIEW_ENABLED = true` at the top of `App.jsx` is the single switch: the tab
+(first in the row — it's the on-site home screen), the render, and the `setsOnNow` /
+`upNextSets` / followed-pick feeders all key off it, so with it false the view costs
+nothing. Flip it to false (or drop `'now'` from the tab array) to hide it again.
+
+**Test clock**: `#now=2026-07-31T20:00` (or `?now=`) makes Now reason from that instant
+instead of the wall clock — parsed in FESTIVAL time, so it means 8 PM on site whatever the
+device's timezone, and a banner ("Test clock: Fri 8:00 PM") renders above the view so a
+screenshot self-documents. An unparseable value silently falls back to the real clock.
+This is QA scaffolding that ships harmlessly: it writes nothing, and an end user who sets
+it only time-travels their own Now tab.
 
 ## Common edits
 
@@ -135,3 +341,65 @@ reads from them. That graph now lives in the PLATFORM (vibes.diy#3421):
   picks of people I follow), not mutual-edge; a private account's inbound follows sit
   `requested` until approved. Copy discipline everywhere: "following"/"followers",
   never "friends".
+- **Audience-arm consent gate (vibes.diy#3484, added after the migration):** the
+  `followersOf` audience only admits followers once the SUBJECT has armed audience
+  visibility **for this app** — per-user, per-app, default OFF, fail closed
+  (`AudienceArms` table). Until a user consents, their followers see "They haven't
+  picked any events yet" no matter how many picks exist (this bit jchris/marcus,
+  2026-07-15). The app invites consent via `useSocial().requestFollowersAccess()`
+  (platform-rendered modal; quiet under a prior deny/never policy — invite, never
+  nag): auto-invited once per session on opening the Follows tab, plus a persistent
+  "Share my picks with followers" banner there while `followersEnabled` is false.
+  Every user must consent individually; there is no owner-side bulk arm.
+- **Profile page (2026-07-27, replaces link auto-follow):** a scanned link used to
+  silently `follow()` the scanned handle after sign-in. It now opens `ProfileView.jsx`
+  instead — following is an explicit tap, and the page works signed-out. The profile
+  renders the subject's **follower-visible** picks and shared extras, reusing the same
+  read path as the friends schedule (an active follow edge is what makes docs readable;
+  the client can't tell "no picks" from "not armed" from "request not approved", so the
+  empty copy names the possibilities). **Your own profile deliberately renders through
+  that same path, not your local favorites** — if `followersEnabled` is false your
+  followers see nothing, so the preview shows nothing plus the arming CTA. That makes
+  "Preview my profile" (on the Follows tab, by the QR) an honest check of the arm gate.
+- **Two different privacy knobs — don't conflate them.**
+  1. **Account privacy** (a *private profile*): whether a follow of you lands active or
+     as an approval-gated **request**. Account-level PLATFORM state, set in Settings →
+     Social. A private profile is still findable and followable — the QR/share link is
+     never gated on it, and there is no blur or overlay on it. In-app it surfaces only
+     as its consequences, which the app already renders: `useSocial().requests` +
+     `approve()` on the Follows tab, and the follower's `Requested` chip. **Pending
+     platform support** (issue to come): `useSocial()` exposes no setter for it, so the
+     in-app toggle can't be built; the target handle's privacy isn't in the protocol
+     either, so the follow button can't say **"Request to follow"** before the tap — it
+     says `Follow` and the private case surfaces afterwards as `Requested`. Private-by-
+     default is likewise a platform call, not an app one.
+  2. **Pick-sharing arm** (`followersEnabled` / `requestFollowersAccess()`): the
+     unchanged per-app #3484 consent gate for whether your followers can read your
+     picks. Orthogonal to account privacy — an un-armed account shows an empty schedule
+     even to APPROVED followers, which is why the orange "Share my picks with followers"
+     CTA appears on the own profile (and the Follows tab) whenever `followersEnabled` is
+     false. `setVisibility()` on `useSocial()` is this knob's level setter, NOT account
+     privacy. **It is reversible**, and the app says so in both directions: while armed,
+     an understated "Stop sharing my picks" link (`c.quietLink`) sits under the own
+     profile's "What your followers see" section and in the arm banner's slot on the
+     Follows tab → `setVisibility('private')`; the un-armed orange CTA then takes over,
+     so the round trip is visible and undoable in place. Re-arming has two paths and the
+     snapshot can't distinguish them, so App.jsx remembers who turned it off
+     (`disarmedRef`): a viewer who disarmed this session has already consented, so
+     re-arming is a plain `setVisibility('followers')` — routing them back through
+     `requestFollowersAccess()` would re-enter the consent matrix and a prior standing
+     deny would no-op confusingly. A first-ever arm still goes through
+     `requestFollowersAccess()`. That ref also suppresses the Follows-tab auto-invite.
+     Copy on this control is always picks-scoped ("Stop sharing my picks", "your picks
+     are hidden from your followers") and never says "private profile"/"private account"
+     — that wording belongs to knob 1 alone.
+- **Reaching it / leaving it:** the profile is NOT a tab and NOT an overlay — while
+  `profileHandle` is set it takes over the content area under the normal header + nav,
+  and pressing any tab clears it (and scrubs `#friend=`). It is reached by a deep link,
+  "Preview my profile", or **tapping any handle anywhere** — App.jsx wraps `ViewerTag`
+  in a `ProfileTag` (ViewerTag has no `onClick`) and passes that down as every view's
+  `ViewerTag` prop, so the chips in Follows/Favorites/All Events and the `pickedBy` rows
+  in the schedule all open profiles; `stopPropagation` keeps the surrounding chip's own
+  click and its × working. The header avatar is the raw tag scaled 4× and clipped to a
+  120px circle (ViewerTag has no size or avatar-only prop); on your own profile it is
+  the propless "me" tag, which is the editable shape — that is how you set your photo.

--- a/examples/pickathon-picker/ScheduleView.jsx
+++ b/examples/pickathon-picker/ScheduleView.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
+import { HeartIcon } from './icons.jsx';
 import { toFestivalDate, festivalDayFor, fmtTime as fmtTimeUtil } from './festival-utils.js';
+import { groupByTimeSlot } from './schedule-build.js';
 import { lineupTag, eventCardStyle, eventCardBg } from './styles.js';
 import NoteField from './NoteField.jsx';
 
@@ -33,6 +35,11 @@ export default function ScheduleView({
   emptyMessage,
   saveNote,
   canWrite,
+  // Load shedding: the heart goes inert and the note editor stands down, while
+  // the schedule itself (and any saved note) reads exactly as before
+  // (loadshed.js). App passes canWrite already ANDed with the shed level, which
+  // is what stands the editor down; this flag is only about the heart's look.
+  picksPaused,
   onToggleFavorite,
   myFavIds,
   allEvents,
@@ -55,156 +62,143 @@ export default function ScheduleView({
         const daySchedule = buildSchedule(day);
         if (daySchedule.length === 0) return null;
 
+        // The day reads as time slots: the time is printed once on the green as a slot
+        // label and the cards under it carry only what differs between them.
+        const groups = groupByTimeSlot(daySchedule, shiftStartRaw, shiftEndRaw);
+
+        // Gap strips are dormant — every call site passes showGaps false — but they stay
+        // wired to the slot boundaries so the feature can be switched back on.
         const allDayEvents =
           showGaps && allEvents ? allEvents.filter((e) => festivalDayFor(e.start) === day) : [];
-
-        const items = [];
-        for (let i = 0; i < daySchedule.length; i++) {
-          const item = daySchedule[i];
-          const itemStart = item.type === 'shift' ? shiftStartRaw(item.data) : item.data.start;
-          const itemEnd = item.type === 'shift' ? shiftEndRaw(item.data) : item.data.end;
-          const itemStartMs = toFestivalDate(itemStart).getTime();
-          const itemEndMs = toFestivalDate(itemEnd).getTime();
-
-          if (showGaps && allDayEvents.length > 0 && i === 0) {
-            const earliestEvent = allDayEvents.reduce((min, e) => {
-              const t = toFestivalDate(e.start).getTime();
-              return t < min ? t : min;
-            }, Infinity);
-            if (earliestEvent < itemStartMs) {
-              items.push({
-                type: 'gap',
-                startMs: earliestEvent,
-                endMs: itemStartMs,
-                key: `gap-pre-${day}`,
-              });
-            }
-          }
-
-          items.push({ type: 'item', data: item, key: `${item.type}-${item.id}` });
-
-          if (showGaps && allDayEvents.length > 0) {
-            const nextItem = daySchedule[i + 1];
-            const nextStartMs = nextItem
-              ? toFestivalDate(
-                  nextItem.type === 'shift' ? shiftStartRaw(nextItem.data) : nextItem.data.start
-                ).getTime()
-              : null;
-
-            if (nextStartMs && nextStartMs > itemEndMs) {
-              items.push({ type: 'gap', startMs: itemEndMs, endMs: nextStartMs, key: `gap-${i}` });
-            }
-
-            if (!nextItem) {
-              const latestEvent = allDayEvents.reduce((max, e) => {
-                const t = toFestivalDate(e.end).getTime();
-                return t > max ? t : max;
-              }, 0);
-              if (latestEvent > itemEndMs) {
-                items.push({
-                  type: 'gap',
-                  startMs: itemEndMs,
-                  endMs: latestEvent,
-                  key: `gap-post-${day}`,
-                });
-              }
-            }
-          }
-        }
+        const gapBefore = (group, i) => {
+          if (!showGaps || allDayEvents.length === 0) return null;
+          const startMs = toFestivalDate(group.start).getTime();
+          const prev = groups[i - 1];
+          const fromMs = prev
+            ? Math.max(
+                ...prev.items.map((r) =>
+                  toFestivalDate(
+                    r.type === 'shift' ? shiftEndRaw(r.data) : r.data.end
+                  ).getTime()
+                )
+              )
+            : Math.min(...allDayEvents.map((e) => toFestivalDate(e.start).getTime()));
+          return fromMs < startMs ? { startMs: fromMs, endMs: startMs } : null;
+        };
 
         return (
           <div key={day} className={c.schedDay}>
-            <h3 className="text-xl font-black mb-1 text-white">
+            <h3 className="text-xl font-black mb-1 px-[14px] text-white">
               {day} — {getDateForDay(day)}
             </h3>
-            <div className="space-y-0.5">
-              {items.map((entry) => {
-                if (entry.type === 'gap') {
-                  return (
-                    <GapStrip
-                      key={entry.key}
-                      startMs={entry.startMs}
-                      endMs={entry.endMs}
-                      allDayEvents={allDayEvents}
-                      fmtTime={fmtTime}
-                    />
-                  );
-                }
-                const item = entry.data;
-                const itemStart =
-                  item.type === 'shift' ? shiftStartRaw(item.data) : item.data.start;
-                const itemEnd = item.type === 'shift' ? shiftEndRaw(item.data) : item.data.end;
-                const isEvent = item.type === 'event';
-                const tag = isEvent ? lineupTag(item.data) : null;
+            <dl className="space-y-0.5 m-0">
+              {groups.map((group, gi) => {
+                const gap = gapBefore(group, gi);
                 return (
-                  <div
-                    key={entry.key}
-                    className={
-                      item.type === 'shift'
-                        ? c.schedShift
-                        : `rounded-[12px] m-0.5 p-[7px] ${eventCardBg}`
-                    }
-                    style={isEvent ? eventCardStyle(item.data) : undefined}
-                  >
-                    <div className="flex justify-between items-start">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-0.5 flex-wrap mb-[1px]">
-                          <h4 className={`font-black ${c.bodyText}`}>
-                            {item.type === 'shift'
-                              ? item.data.kind || item.data.title || 'Shift'
-                              : item.title}
-                          </h4>
-                          {isEvent && (
-                            <span className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5  uppercase bg-[#BACD32] text-[#4A4A4A]">
-                              {tag.label}
-                            </span>
-                          )}
-                          {isEvent && onToggleFavorite && (
-                            <button
-                              onClick={() => onToggleFavorite(item.data)}
-                              className={`p-[1px] rounded-lg m-0.5  text-xs font-bold px-0.5 ${myFavIds && myFavIds.has(item.data.eventId) ? 'bg-[#CD6C0C] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9]'}`}
-                            >
-                              {myFavIds && myFavIds.has(item.data.eventId) ? '♥' : '♡'}
-                            </button>
-                          )}
-                        </div>
-                        <p className={`text-sm font-bold ${c.bodyText}`}>
-                          {fmtTime(itemStart)} – {fmtTime(itemEnd)}
-                          {isEvent && ` · ${item.venue}`}
-                        </p>
-                        {ViewerTag &&
-                          Array.isArray(item.data.pickedBy) &&
-                          item.data.pickedBy.length > 0 && (
-                            <div className="flex items-center gap-0.5 flex-wrap mt-0.5">
-                              {item.data.pickedBy.map((h) => (
-                                <ViewerTag key={h} userHandle={h} />
-                              ))}
+                  <React.Fragment key={group.key}>
+                    {gap && (
+                      <GapStrip
+                        startMs={gap.startMs}
+                        endMs={gap.endMs}
+                        allDayEvents={allDayEvents}
+                        fmtTime={fmtTime}
+                      />
+                    )}
+                    {/* Text only: at 390px a time range plus any rule would wrap. */}
+                    {/* Slot labels hug the container edge; only the day header keeps the 14px indent. */}
+                    <dt className="px-[5px] pt-0.5 text-base font-black text-white">
+                      {fmtTime(group.start)}
+                      {group.end ? ` – ${fmtTime(group.end)}` : ''}
+                    </dt>
+                    <dd className="m-0 space-y-0.5">
+                      {group.items.map((item) => {
+                        const isEvent = item.type === 'event';
+                        const tag = isEvent ? lineupTag(item.data) : null;
+                        // Only when the slot label can't speak for this card.
+                        const endNote = group.end
+                          ? null
+                          : fmtTime(isEvent ? item.data.end : shiftEndRaw(item.data));
+                        const showNoteField = isEvent && canWrite && saveNote;
+                        return (
+                          <div
+                            key={`${item.type}-${item.id}`}
+                            className={
+                              item.type === 'shift'
+                                ? c.schedShift
+                                : `rounded-[12px] m-0.5 p-[7px] ${eventCardBg}`
+                            }
+                            style={isEvent ? eventCardStyle(item.data) : undefined}
+                          >
+                            <div className="flex justify-between items-start">
+                              <div className="flex-1">
+                                <div className="flex items-center gap-0.5 flex-wrap mb-[1px]">
+                                  <h4 className={`font-black ${c.bodyText}`}>
+                                    {item.type === 'shift'
+                                      ? item.data.kind || item.data.title || 'Shift'
+                                      : item.title}
+                                  </h4>
+                                  {isEvent && (
+                                    <span className="px-0.5 py-[0.5px] rounded-full text-xs font-black m-0.5  uppercase bg-[#BACD32] text-[#4A4A4A]">
+                                      {tag.label}
+                                    </span>
+                                  )}
+                                  {isEvent && onToggleFavorite && (
+                                    <button
+                                      onClick={() => onToggleFavorite(item.data)}
+                                      disabled={picksPaused}
+                                      className={`p-[1px] rounded-lg m-0.5  text-xs font-bold px-0.5 ${picksPaused ? c.shedInert : ''} ${myFavIds && myFavIds.has(item.data.eventId) ? 'bg-[#CD6C0C] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9]'}`}
+                                    >
+                                      <HeartIcon state={myFavIds && myFavIds.has(item.data.eventId) ? 'full' : 'empty'} size={16} />
+                                    </button>
+                                  )}
+                                </div>
+                                {/* Venue line — the time now lives in the slot label above.
+                                    The collapsed note box rides this line (flex-wrap:
+                                    expanded it goes basis-full and wraps below on its own). */}
+                                {(isEvent || endNote || showNoteField) && (
+                                  <div className="flex flex-wrap items-center justify-between gap-0.5">
+                                    <p className={`text-sm font-bold ${c.bodyText}`}>
+                                      {isEvent ? item.venue : ''}
+                                      {endNote ? `${isEvent ? ' · ' : ''}until ${endNote}` : ''}
+                                    </p>
+                                    {showNoteField && (
+                                      <NoteField
+                                        saved={notes && notes[item.data.eventId]}
+                                        onSave={(t) => saveNote(item.data.eventId, t)}
+                                        className={c.noteArea}
+                                        collapsedStyle={{ width: '8em' }}
+                                      />
+                                    )}
+                                  </div>
+                                )}
+                                {ViewerTag &&
+                                  Array.isArray(item.data.pickedBy) &&
+                                  item.data.pickedBy.length > 0 && (
+                                    <div className="flex items-center gap-0.5 flex-wrap mt-0.5">
+                                      {item.data.pickedBy.map((h) => (
+                                        <ViewerTag key={h} userHandle={h} />
+                                      ))}
+                                    </div>
+                                  )}
+                                {isEvent && !showNoteField && notes && notes[item.data.eventId] ? (
+                                  <div
+                                    className={`mt-0.5 p-1.5 bg-[#EEE] dark:bg-[#22252d] rounded-lg m-0.5 `}
+                                  >
+                                    <p className={`text-sm font-bold ${c.bodyText}`}>
+                                      {notes[item.data.eventId]}
+                                    </p>
+                                  </div>
+                                ) : null}
+                              </div>
                             </div>
-                          )}
-                        {isEvent &&
-                          (canWrite && saveNote ? (
-                            <NoteField
-                              saved={notes && notes[item.data.eventId]}
-                              onSave={(t) => saveNote(item.data.eventId, t)}
-                              className={c.noteArea}
-                              collapsedStyle={{ width: '8em' }}
-                              collapsedRight
-                            />
-                          ) : notes && notes[item.data.eventId] ? (
-                            <div
-                              className={`mt-0.5 p-1.5 bg-[#EEE] dark:bg-[#22252d] rounded-lg m-0.5 `}
-                            >
-                              <p className={`text-sm font-bold ${c.bodyText}`}>
-                                {notes[item.data.eventId]}
-                              </p>
-                            </div>
-                          ) : null)}
-                      </div>
-                    </div>
-                  </div>
+                          </div>
+                        );
+                      })}
+                    </dd>
+                  </React.Fragment>
                 );
               })}
-            </div>
+            </dl>
           </div>
         );
       })}

--- a/examples/pickathon-picker/ShiftsView.jsx
+++ b/examples/pickathon-picker/ShiftsView.jsx
@@ -79,7 +79,7 @@ export default function ShiftsView({
           <button
             onClick={handleSubmit}
             disabled={submitting}
-            className={`mt-1 ${submitting ? c.btnCyanWorking : c.btnCyan}`}
+            className={`mt-1 ${submitting ? c.btnWorking : c.btnCyan}`}
           >
             Add Extra
           </button>

--- a/examples/pickathon-picker/access.js
+++ b/examples/pickathon-picker/access.js
@@ -5,12 +5,20 @@ export default function (doc, oldDoc, user, ctx) {
 
   // Owner is authoritative from the existing doc on updates/deletes — we must NOT trust
   // an incoming doc.userId that could target someone else's _id and pass the checks
-  // below. doc.userId is trusted only on true creates (no oldDoc).
-  const ownerId = oldDoc ? oldDoc.userId : doc.userId;
+  // below. doc.userId is trusted on true creates (no oldDoc) AND on re-creates over a
+  // deletion tombstone: a tombstone oldDoc carries no `userId` (fields are stripped on
+  // delete), so `oldDoc ? oldDoc.userId : doc.userId` would yield `undefined` and make
+  // every owner check throw "not owner" — silently refusing every re-favorite of a
+  // previously-removed event (toggleFavorite deletes on un-favorite). Fall back to
+  // doc.userId whenever oldDoc has no userId; a LIVE doc's userId still wins, so the
+  // anti-impersonation guard on genuine updates is unchanged.
+  const ownerId = oldDoc && oldDoc.userId != null ? oldDoc.userId : doc.userId;
 
-  // Every write needs a real account. Logged-out favorites never reach the cloud — they
-  // live in localStorage and migrate in on first sign-in.
-  if (!user) throw { forbidden: 'authentication required' };
+  // Every CLOUD write needs a real account. Logged-out writes are expected and fine —
+  // they stay in the device-local store and migrate in on first sign-in; this refusal
+  // only turns down the (routine) sync attempt. The shell surfaces this exact string
+  // in a toast, so keep it calm and routine, never ominous.
+  if (!user) throw { forbidden: 'Saved on this device — sign in to sync your picks' };
 
   // Favorites live in the owner's *shared* channel and are readable by the
   // owner's PLATFORM FOLLOWERS via the audience label — the follow graph now
@@ -34,6 +42,82 @@ export default function (doc, oldDoc, user, ctx) {
     const ch = `user-${ownerId}`;
     return { channels: [ch], grant: { users: { [ownerId]: [ch] } } };
   }
+
+  // Central festival schedule: server-maintained and WORLD-READABLE. The
+  // `scheduled` tick runs as the vibe OWNER (isOwner:true — backend-db-callback.js)
+  // and mirrors the pickathon.com feed into one `scheduleitem` doc per event.
+  // Listing the channel under `grant.public` makes it readable by anonymous and
+  // every viewer, so the schedule replicates to each client's LOCAL store and
+  // renders OFFLINE with no per-user keying and no network fetch. Owner-only WRITE
+  // so a signed-in stranger can't inject fake schedule docs. This is the opposite
+  // of favorites' `super` channel, which is deliberately NOT world-readable
+  // (RUNBOOK § Channels) to avoid syncing every user's picks to every client.
+  if (type === 'scheduleitem') {
+    if (!user.isOwner) throw { forbidden: 'owner only' };
+    return { channels: ['schedule'], grant: { public: ['schedule'] } };
+  }
+
+  // The schedule mirror's own bookkeeping (`_id: 0-schedule-sync-state`): a
+  // fingerprint per mirrored event, written by the `scheduled` tick so it can
+  // tell "unchanged" without re-reading the schedule docs — which no longer fit
+  // inside the backend query's 2000-doc cap. OWNER-ONLY WRITE is the point: this
+  // doc is what the tick TRUSTS, so a signed-in stranger forging it could
+  // convince the mirror everything is already up to date and freeze the
+  // festival schedule. (Without this branch it would fall through to the
+  // unknown-type branch below, which accepts a write from anybody.) No grant —
+  // nothing here is for clients; the tick reads it unfiltered in admin mode.
+  if (type === 'schedulesync') {
+    if (!user.isOwner) throw { forbidden: 'owner only' };
+    return { channels: ['discard'], grant: {} };
+  }
+
+  // The load-shed switch (`_id: 0-load-shed`, see loadshed.js): one owner-written
+  // doc whose `level` turns viewer-driven work off during the festival rush
+  // without a redeploy. Two halves, both load-bearing:
+  //
+  //   WORLD-READABLE — it rides the same public `schedule` channel as the
+  //   scheduleitem docs, so it replicates to EVERY client's local store,
+  //   anonymous ones included. A switch only signed-in viewers could see would
+  //   shed nothing (anonymous browsing is most of the festival traffic), and
+  //   riding the existing public channel costs no new channel and no per-user
+  //   keying. There is nothing private in it: it says "picks are paused".
+  //
+  //   OWNER-ONLY WRITE — a signed-in stranger who could write it would be able
+  //   to flip everyone's app read-only, or hide the Friends tab for the whole
+  //   festival, from a single `db put`. That is a pure griefing vector, so it
+  //   gets the same treatment as the mirror's state doc and the heartbeat. The
+  //   unknown-type branch at the bottom accepts a write from anybody, which is
+  //   exactly why this branch has to exist. Deletes (a write, tombstoned with no
+  //   `type`) stay in here via the oldDoc fallback at the top of the file.
+  if (type === 'loadshed') {
+    if (!user.isOwner) throw { forbidden: 'owner only' };
+    return { channels: ['schedule'], grant: { public: ['schedule'] } };
+  }
+
+  // The tick's liveness heartbeat (`_id: 0-tick-heartbeat`): one doc, restamped
+  // roughly hourly by the `scheduled` lane, whose timestamp is the only durable
+  // evidence the alarm is still running (a vibe backend's console output goes
+  // nowhere — platform #4305). Read it with
+  //   vibes-diy db get 0-tick-heartbeat --db pickathon --vibe og/pickathon-picker
+  // OWNER-ONLY WRITE, for the same reason as the mirror's state doc above: a
+  // signed-in stranger who could restamp it would forge liveness for a tick
+  // that has been dead for days, which is exactly the alarm this doc is. No
+  // grant — it is ops evidence, never client data.
+  if (type === 'heartbeat') {
+    if (!user.isOwner) throw { forbidden: 'owner only' };
+    return { channels: ['discard'], grant: {} };
+  }
+
+  // RETIRED: `schedulecache` was a per-user write-through copy of the whole feed
+  // (`_id: schedule-cache-{userId}`), from before the server-maintained
+  // `scheduleitem` docs above became the single source. It stored the SAME public
+  // schedule once per user — 10 copies × ~96 KB was 74% of this db, and every
+  // `scheduled` tick (which queries the whole db) paid for it. The app no longer
+  // reads or writes it; legacy docs fall through to the unknown-type branch below
+  // (accepted, routed to `discard`, unreadable) exactly like retired `friend` docs.
+  // Removing the owner check here is also what makes the leftovers DELETABLE: the
+  // old branch threw 'not owner' for every handle but the doc's own, so not even
+  // the vibe owner could sweep them.
 
   // Notes are private to their owner — their own user channel, never shared with friends.
   if (type === 'note') {

--- a/examples/pickathon-picker/access.test.js
+++ b/examples/pickathon-picker/access.test.js
@@ -27,6 +27,135 @@ describe('access.js — channel routing', () => {
     expect(ok.grant).toEqual({ users: { alice: ['user-alice'] } });
   });
 
+  it('retired schedulecache docs are accepted but unreadable, and sweepable by anyone', () => {
+    // The type is retired (the server-maintained `scheduleitem` docs are the single
+    // source now). Legacy docs must still be WRITEABLE — a delete is a write, and the
+    // old owner-check made the leftovers unsweepable — but must land on `discard`
+    // with no grant so they replicate to nobody.
+    const { ok } = run(
+      { type: 'schedulecache', userId: 'alice', events: [], fetchedAt: 1 },
+      null,
+      alice
+    );
+    expect(ok.channels).toEqual(['discard']);
+    expect(ok.grant).toEqual({});
+
+    // A DIFFERENT handle (e.g. the vibe owner sweeping) must not be refused.
+    const bob = { userHandle: 'bob' };
+    const sweep = run({ type: 'schedulecache' }, { type: 'schedulecache', userId: 'alice' }, bob);
+    expect(sweep.ok.channels).toEqual(['discard']);
+  });
+
+  it('schedule items are owner-written and WORLD-READABLE via grant.public', () => {
+    const owner = { userHandle: 'jchris', isOwner: true };
+    const { ok } = run(
+      { _id: 'schedule-event-42', type: 'scheduleitem', eventId: '42', title: 'Band' },
+      null,
+      owner
+    );
+    // A channel listed under grant.public is readable by anonymous + everyone —
+    // this is what makes the schedule replicate to every local store offline.
+    expect(ok.channels).toEqual(['schedule']);
+    expect(ok.grant).toEqual({ public: ['schedule'] });
+  });
+
+  it('only the owner can write the schedule mirror\'s state doc', () => {
+    // The tick TRUSTS this doc to decide the schedule is already up to date, so
+    // a stranger forging it could freeze the festival schedule. Without its own
+    // branch it would fall through to the unknown-type branch, which takes a
+    // write from anybody.
+    expect(
+      run({ type: 'schedulesync', fingerprints: {} }, null, { userHandle: 'mallory', isOwner: false })
+    ).toEqual({ forbidden: 'owner only' });
+    const { ok } = run({ type: 'schedulesync', fingerprints: {} }, null, {
+      userHandle: 'jchris',
+      isOwner: true,
+    });
+    expect(ok.channels).toEqual(['discard']); // bookkeeping, never for clients
+    expect(ok.grant).toEqual({});
+  });
+
+  it('only the owner can write the tick liveness heartbeat', () => {
+    // The heartbeat is how ops tells a dead alarm from a quiet one. A stranger
+    // able to write it could forge liveness for a tick that has been dead for
+    // days — so it is owner-only, exactly like the mirror's state doc.
+    expect(
+      run({ type: 'heartbeat', at: '2026-07-30T00:00:00.000Z' }, null, {
+        userHandle: 'mallory',
+        isOwner: false,
+      })
+    ).toEqual({ forbidden: 'owner only' });
+    const { ok } = run({ type: 'heartbeat', at: '2026-07-30T00:00:00.000Z' }, null, {
+      userHandle: 'jchris',
+      isOwner: true,
+    });
+    expect(ok.channels).toEqual(['discard']); // ops-only, never replicated to clients
+    expect(ok.grant).toEqual({});
+  });
+
+  it('the load-shed switch is owner-written and WORLD-READABLE (same channel as the schedule)', () => {
+    // It has to reach EVERY client — including anonymous ones — or a shed level
+    // would only apply to signed-in viewers, which is the opposite of the point.
+    // Riding the existing public `schedule` channel means no new channel and no
+    // per-user keying.
+    const owner = { userHandle: 'jchris', isOwner: true };
+    const { ok } = run({ _id: '0-load-shed', type: 'loadshed', level: 'read-only' }, null, owner);
+    expect(ok.channels).toEqual(['schedule']);
+    expect(ok.grant).toEqual({ public: ['schedule'] });
+  });
+
+  it('a stranger cannot flip the app read-only (it would be a griefing vector)', () => {
+    // Owner-only WRITE is the security half: a signed-in stranger who could
+    // write this doc could turn off everyone's picks for the whole festival.
+    // Without its own branch it would fall through to the unknown-type branch,
+    // which accepts a write from anybody.
+    expect(
+      run({ _id: '0-load-shed', type: 'loadshed', level: 'schedule-only' }, null, {
+        userHandle: 'mallory',
+        isOwner: false,
+      })
+    ).toEqual({ forbidden: 'owner only' });
+  });
+
+  it('turning the switch back OFF (and deleting it) is owner-only too', () => {
+    // A delete is a write, and the tombstone carries no `type` — so the oldDoc
+    // fallback has to keep it inside this branch rather than dropping it into
+    // the accept-from-anybody one.
+    const owner = { userHandle: 'jchris', isOwner: true };
+    expect(run({}, { _id: '0-load-shed', type: 'loadshed', level: 'off' }, owner).ok.channels).toEqual(
+      ['schedule']
+    );
+    expect(
+      run({}, { _id: '0-load-shed', type: 'loadshed', level: 'read-only' }, {
+        userHandle: 'mallory',
+        isOwner: false,
+      })
+    ).toEqual({ forbidden: 'owner only' });
+  });
+
+  it('a non-owner cannot write a schedule item', () => {
+    expect(
+      run({ type: 'scheduleitem', eventId: '42' }, null, { userHandle: 'mallory', isOwner: false })
+    ).toEqual({ forbidden: 'owner only' });
+  });
+
+  it('an anonymous reader can read a schedule item but NOT another user\'s favorite', () => {
+    // Read visibility is decided by whether the doc's stored channel is public.
+    const sched = run(
+      { type: 'scheduleitem', eventId: '42' },
+      null,
+      { userHandle: 'jchris', isOwner: true }
+    ).ok;
+    const fav = run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, alice).ok;
+    const publicOf = (d) => (d.grant && d.grant.public) || [];
+    // scheduleitem exposes a public channel → anonymous/all can read it.
+    expect(publicOf(sched)).toContain('schedule');
+    // a favorite exposes NO public channel → an anonymous reader cannot read it.
+    expect(publicOf(fav)).toEqual([]);
+    expect(sched.channels.every((ch) => publicOf(sched).includes(ch))).toBe(true);
+    expect(fav.channels.some((ch) => publicOf(fav).includes(ch))).toBe(false);
+  });
+
   it('a shared shift is follower-readable; a private shift stays in the user channel', () => {
     const shared = run({ type: 'shift', userId: 'alice', shareWithFriends: true }, null, alice).ok;
     expect(shared.channels).toEqual(['share-alice']);
@@ -63,9 +192,9 @@ describe('access.js — super grants (owner only)', () => {
 });
 
 describe('access.js — guards', () => {
-  it('requires a signed-in user', () => {
+  it('requires a signed-in user (with a calm, user-facing refusal — the shell toasts it)', () => {
     expect(run({ type: 'favorite', userId: 'alice', eventId: '1' }, null, null)).toEqual({
-      forbidden: 'authentication required',
+      forbidden: 'Saved on this device — sign in to sync your picks',
     });
   });
 

--- a/examples/pickathon-picker/backend.js
+++ b/examples/pickathon-picker/backend.js
@@ -252,11 +252,104 @@ const shiftStartOf = (s) =>
 const shiftEndOf = (s) =>
   s.end ?? (FESTIVAL_DATES[s.day] && s.endTime ? `${FESTIVAL_DATES[s.day]}T${s.endTime}:00` : null);
 
-// 1-minute aggregation tick (tiny db; a short interval keeps the post-deploy/post-eviction cold window — where adding a NEW subscription fails with iOS's "Validation failed" — under a minute). Admin-lane read (unfiltered), so THIS code chooses
+// The host caps `ctx.db.query` at this many docs — sorted by `_id`, then cut,
+// with no error and no cursor (backend-db-callback.ts). This db passed the cap
+// during Pickathon 2026, and everything sorting after the cut went invisible to
+// the tick. Nothing here can raise it; code that must survive a large db has to
+// stop depending on reading all of it. See § the mirror's state doc below.
+const BACKEND_QUERY_MAX_DOCS = 2000;
+
+// ── Load shedding ────────────────────────────────────────────────────────────
+// One owner-written config doc (`_id: 0-load-shed`, `level: off|read-only|
+// schedule-only` — see loadshed.js, which the client imports and this file
+// cannot: the backend isolate resolves no imports, so the id/type are duplicated
+// here on purpose and pinned by loadshed.test.js).
+//
+// What sheds here, and what deliberately does NOT:
+//   · the SUBSCRIPTION lane (GET /faves.ics?t=…) answers 503 + Retry-After.
+//     Calendar clients back off on a 503 and keep the events they already
+//     synced, so this is the one shed with no user-visible damage — an empty
+//     calendar would look like "your picks are gone".
+//   · the aggregate scan in `scheduled` is skipped — nothing reads it while the
+//     GET is 503ing, and while picks are paused it cannot go stale anyway.
+//   · the liveness HEARTBEAT still runs. A shed tick is still a tick that ran,
+//     and it is the only durable evidence of that (#4305) — losing it during the
+//     exact hours we are under load would blind the one alarm we have.
+//   · the 5-minute SCHEDULE MIRROR still runs, in BOTH shed levels. Shedding is
+//     about viewer-driven amplification (per-viewer queries and per-refresh feed
+//     joins), not about a fixed-cost job that runs 12 times an hour regardless of
+//     traffic — and the schedule staying fresh is the whole reason to stay up.
+//
+// The level is remembered in the isolate as well as read from the doc, for the
+// §4a reason: a doc missing from a capped read means "don't know" → keep the
+// level we last saw, never "shedding is off" (that reading would re-open the
+// load spike the switch was flipped for). To turn shedding OFF, put `level:
+// "off"` — do not delete the doc, or a warm isolate keeps shedding.
+// A cold isolate that has never seen the doc fails OPEN: the `fetch` lane cannot
+// read the db at all, so normal service is the only safe default.
+export const LOADSHED_ID = '0-load-shed';
+export const LOADSHED_TYPE = 'loadshed';
+export const SHED_OFF = 'off';
+export const SHED_READ_ONLY = 'read-only';
+export const SHED_SCHEDULE_ONLY = 'schedule-only';
+export const SHED_RETRY_AFTER_SECONDS = 900;
+const SHED_LEVELS = [SHED_OFF, SHED_READ_ONLY, SHED_SCHEDULE_ONLY];
+
+let shedLevel = null; // null = this isolate has never seen the doc
+export const __resetShedForTests = () => {
+  shedLevel = null;
+};
+
+// Fail-open parse, byte-identical in behaviour to loadshed.js's shedLevelOf:
+// only an exactly-recognized level sheds anything, so a fat-fingered `db put`
+// at 11pm on a Saturday cannot brick the app.
+const parseShedLevel = (doc) => {
+  const raw = doc && typeof doc.level === 'string' ? doc.level.trim().toLowerCase() : '';
+  return SHED_LEVELS.includes(raw) ? raw : SHED_OFF;
+};
+
+// Read the level out of the tick's EXISTING whole-db read (the doc's
+// digit-leading `_id` sorts ahead of every id this app mints, so it rides inside
+// the query cap — no extra query), and remember it.
+export const readShedLevel = (docs) => {
+  const doc = (docs || []).find((d) => d && d._id === LOADSHED_ID);
+  if (doc) {
+    shedLevel = parseShedLevel(doc);
+    return shedLevel;
+  }
+  if (shedLevel !== null && shedLevel !== SHED_OFF) {
+    console.warn(
+      `pickathon tick: ${LOADSHED_ID} missing from the db read — keeping the in-isolate level ` +
+        `"${shedLevel}". Put level:"off" to lift shedding; deleting the doc does not.`
+    );
+    return shedLevel;
+  }
+  shedLevel = shedLevel ?? SHED_OFF;
+  return shedLevel;
+};
+
+// Whether a level pauses writes/viewer amplification. `null` (this isolate has
+// never seen the doc) and `off` both read as not shedding.
+const isSheddingLevel = (level) => level === SHED_READ_ONLY || level === SHED_SCHEDULE_ONLY;
+const isShedding = () => isSheddingLevel(shedLevel);
+
+// 1-minute aggregation tick (a short interval keeps the post-deploy/post-eviction cold window — where adding a NEW subscription fails with iOS's "Validation failed" — under a minute). Admin-lane read (unfiltered), so THIS code chooses
 // what becomes link-visible: favorite eventIds always (that's the feature),
 // shifts only when the user marked them shareWithFriends, notes never.
+// The tick is deliberately CHEAP: one read, and — at most every
+// SCHEDULE_SYNC_INTERVAL_MS — one feed fetch. It writes nothing unless the
+// festival schedule actually changed.
 export async function scheduled(event, ctx) {
   const docs = await ctx.db.query({ db: 'pickathon' });
+  // The shed level rides the read we just did (see § Load shedding). When we are
+  // shedding, skip the aggregate scan entirely — the GET lane is 503ing, so
+  // nothing reads it, and with picks paused it cannot drift either — but still
+  // beat the heartbeat and still run the schedule mirror.
+  if (isSheddingLevel(readShedLevel(docs))) {
+    await writeHeartbeat(event, ctx, docs);
+    await syncScheduleDocs(event, ctx, docs);
+    return;
+  }
   const users = new Map();
   const tokens = new Map();
   const entryFor = (handle) => {
@@ -293,13 +386,84 @@ export async function scheduled(event, ctx) {
     entry.eventIds.sort();
     entry.shifts.sort((a, b) => (a[1] < b[1] ? -1 : 1));
   }
+  // A capped read is a SILENT read: the host returns 2000 docs and no signal.
+  // Say so in the log, because the aggregate below is then missing whatever
+  // sorted past the cut (favorites, `_id` "favorite-<handle>-<event>", are the
+  // only growing type and the only ones that can fall off) — those users' .ics
+  // feeds quietly lose picks. Visible in `wrangler tail`.
+  const truncated = docs.length >= BACKEND_QUERY_MAX_DOCS;
+  if (truncated) {
+    console.warn(
+      `pickathon tick: db read hit the ${BACKEND_QUERY_MAX_DOCS}-doc query cap ` +
+        `(last _id "${docs[docs.length - 1]?._id}") — favorites sorting after it are ` +
+        `missing from ics aggregates.`
+    );
+  }
   subCache = {
     at: Date.parse(event?.scheduledTime) || Date.now(),
     users,
     tokens,
-    truncated: docs.length >= 2000,
+    truncated,
   };
+
+  // Liveness first: if this tick is alive, say so before anything that can fail.
+  // Passed the docs we already read — the heartbeat picks its own doc out of them
+  // rather than costing a second query.
+  await writeHeartbeat(event, ctx, docs);
+
+  // Central schedule mirror: refresh pickathon.com on its own (slower) cadence
+  // and upsert only the `scheduleitem` docs whose content changed. Clients read
+  // the schedule from these public docs — nobody fetches the feed per-user
+  // anymore. Passed the `docs` we already read so it can pick its state doc out
+  // of them; it never wipes the schedule on a transient feed failure.
+  await syncScheduleDocs(event, ctx, docs);
 }
+
+// ── Tick liveness heartbeat (scheduled lane) ─────────────────────────────────
+// The `scheduled` alarm has gone silently dead twice on unchanged code, and a
+// vibe backend's console output is forwarded NOWHERE (platform #4305) — so the
+// ONLY durable, queryable evidence that the tick ran is a WRITE. Roughly hourly
+// the tick stamps one doc with the scheduled time it woke at.
+//
+// Ops read path (platform admin):
+//   vibes-diy db get 0-tick-heartbeat --db pickathon --vibe og/pickathon-picker
+// A stamp older than ~2h means the alarm is dead and the app needs a redeploy
+// (nothing else re-arms an app with no other traffic). Treat ~2h of slack as
+// normal: the gate below is in-isolate and best-effort, not a promise.
+//
+// Discipline is the #4293 one. The gate is remembered, never re-derived from a
+// scan: an in-isolate timestamp, backed by the heartbeat doc found in the tick's
+// EXISTING whole-db read (its digit-leading `_id` sorts ahead of every id this
+// app mints, so it rides inside the 2000-doc cap — no extra query). Whichever of
+// the two is newer wins, and a doc missing from a capped read therefore reads as
+// "don't know" rather than "never beat". Only losing BOTH — no doc AND a cold
+// isolate — writes a beat immediately, which is the harmless direction: one
+// extra write per isolate boot, not one per tick.
+//
+// The stamp must CHANGE on every write or the platform dedupes a content-
+// identical re-put invisibly and the doc silently stops tracking liveness —
+// hence `at`, the tick's own scheduled time.
+export const HEARTBEAT_ID = '0-tick-heartbeat';
+export const HEARTBEAT_TYPE = 'heartbeat';
+export const HEARTBEAT_INTERVAL_MS = 55 * 60 * 1000;
+let lastBeatAt = null;
+export const __resetHeartbeatForTests = () => {
+  lastBeatAt = null;
+};
+
+export const writeHeartbeat = async (event, ctx, docs) => {
+  if (!ctx || !ctx.db || typeof ctx.db.put !== 'function') return null;
+  const now = Date.parse(event?.scheduledTime) || Date.now();
+  const doc = (docs || []).find((d) => d && d._id === HEARTBEAT_ID);
+  const docAt = doc ? Date.parse(doc.at) : NaN;
+  const known = [lastBeatAt, Number.isFinite(docAt) ? docAt : null].filter((n) => n !== null);
+  const last = known.length > 0 ? Math.max(...known) : null;
+  if (last !== null && now - last < HEARTBEAT_INTERVAL_MS) return { ok: true, skipped: 'not due' };
+  const at = new Date(now).toISOString();
+  await ctx.db.put({ _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at }, { db: 'pickathon' });
+  lastBeatAt = now;
+  return { ok: true, at };
+};
 
 // Fetch the live schedule feed and project the requested event ids into items.
 // MUST call globalThis.fetch — bare `fetch` here resolves to this module's own
@@ -326,6 +490,230 @@ export const fetchScheduleItems = async (ids) => {
     }
   }
   return items;
+};
+
+// ── Central schedule mirror (scheduled lane) ─────────────────────────────────
+// The schedule is fetched server-side and mirrored into public, world-readable
+// `scheduleitem` docs (one per event, stable _id). The tick upserts ONLY entries
+// whose content changed and deletes events that vanished, so an unchanged
+// schedule mints no writes at all.
+//
+// It used to establish "unchanged" by diffing against the `scheduleitem` docs
+// found in the tick's whole-db read. That silently stopped working once the db
+// passed BACKEND_QUERY_MAX_DOCS: `schedule-event-*` sorts after `caltoken-*`,
+// `favorite-*` and `note-*`, so ALL of the mirror fell outside the capped
+// window, the diff saw zero existing items, and every tick re-put every event —
+// ~330 serialized writes a minute, which pinned this vibe's Durable Object at
+// 97% occupancy and left nothing behind them but queueing (a visitor's first
+// page load included).
+//
+// So the mirror now remembers what it mirrored itself, in ONE state doc: `_id`
+// leads with a DIGIT, which sorts ahead of every letter under both byte and
+// linguistic collation, so it sits in front of every id this app mints
+// (`caltoken-`, `favorite-`, `note-`, `schedule-event-`, and the uuid shifts,
+// whose `019f…` sorts after `0-`) and rides comfortably inside the cap however
+// large the db grows. It carries a content fingerprint per event id — never the
+// schedule itself, which lives in the public docs.
+//
+// That is a guarantee about ids WE mint, not an absolute one: `_id` is a free
+// string, so 2000 docs beginning with punctuation (below `0`) would push even
+// this doc out of the window. Nothing in the app writes such an id, but a
+// signed-in stranger could — the unknown-type branch in access.js accepts a
+// write from anybody, it just routes it to `discard`. So the state doc is
+// backed up by an in-isolate copy (see lastFingerprints), and losing BOTH is
+// handled as "skip this sync", never as "nothing is mirrored" — the one
+// conclusion that reopens the rewrite loop.
+export const SCHEDULE_STATE_ID = '0-schedule-sync-state';
+export const SCHEDULE_STATE_TYPE = 'schedulesync';
+
+// How often the feed is re-fetched. A festival schedule does not change every 60
+// seconds; the 1m value this inherited from the aggregate tick bought nothing and
+// cost an egress round-trip a minute. The gate is in-isolate, so a freshly booted
+// isolate syncs on its first tick (and, thanks to the state doc, writes nothing
+// if the schedule is unchanged).
+export const SCHEDULE_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+let lastScheduleSyncAt = null;
+// Second copy of the state doc's fingerprints, in isolate memory. The durable
+// doc is the one that survives an isolate boot; this one survives the durable
+// doc going missing from a capped read. Between them, "we have no idea what is
+// mirrored" — the belief that re-puts all ~330 events — takes BOTH a lost state
+// doc AND a cold isolate, and even then costs one burst rather than one a
+// minute. Cheap belt-and-braces on the failure mode that started all this.
+let lastFingerprints = null;
+export const __resetScheduleSyncForTests = () => {
+  lastScheduleSyncAt = null;
+  lastFingerprints = null;
+};
+
+export const scheduleItemId = (eventId) => `schedule-event-${eventId}`;
+
+// Normalize the raw pickathon.com feed into the exact fields the client renders
+// (title/venue entity-decoded, times T-normalized). Mirrors App.jsx's old
+// ingestFeed, minus the client-only `day`: the client derives day via
+// festivalDayFor at read time, keeping the 4 AM night-cutoff in one place and
+// the stored content stable (so the diff below doesn't churn on cutoff logic).
+export const ingestScheduleFeed = (data) => {
+  const list = [];
+  if (data === null || typeof data !== 'object') return list;
+  for (const vid in data) {
+    const venue = data[vid];
+    if (!venue || !Array.isArray(venue.events)) continue;
+    for (const ev of venue.events) {
+      if (ev == null || ev.id == null) continue;
+      const item = {
+        eventId: ev.id,
+        title: decodeFeedEntities(String(ev.title ?? '')),
+        start: ensureT(String(ev.start ?? '')),
+        end: ensureT(String(ev.end ?? '')),
+        venueTitle: decodeFeedEntities(String(venue.title ?? '')),
+        lineup: ev.lineup && typeof ev.lineup === 'object' ? ev.lineup : {},
+      };
+      if (typeof ev.url === 'string' && ev.url !== '') item.url = ev.url;
+      if (venue.color != null) item.venueColor = venue.color;
+      list.push(item);
+    }
+  }
+  return list;
+};
+
+// Deterministic serialization for content comparison: object keys sorted so a
+// re-fetch that reorders lineup keys doesn't read as a change (no timestamp-only
+// churn — the doc's content alone decides whether it gets re-put).
+const stableStringify = (v) => {
+  if (v === null || typeof v !== 'object') return JSON.stringify(v) ?? 'null';
+  if (Array.isArray(v)) return '[' + v.map(stableStringify).join(',') + ']';
+  return (
+    '{' +
+    Object.keys(v)
+      .sort()
+      .map((k) => JSON.stringify(k) + ':' + stableStringify(v[k]))
+      .join(',') +
+    '}'
+  );
+};
+const SCHEDULE_CONTENT_KEYS = [
+  'eventId',
+  'title',
+  'start',
+  'end',
+  'url',
+  'venueTitle',
+  'venueColor',
+  'lineup',
+];
+// Compare ONLY the content fields — ignores Fireproof metadata (_rev) so a doc
+// that merely re-synced isn't seen as changed.
+const scheduleContentKey = (d) =>
+  stableStringify(SCHEDULE_CONTENT_KEYS.map((k) => (d[k] === undefined ? null : d[k])));
+
+// A compact fingerprint of a content key, so the state doc can hold one entry
+// per event without holding the schedule twice: ~330 events × 16 hex chars is
+// ~15 KB, where the raw content keys would be ~80 KB and grow with the lineup.
+// Two FNV-1a passes with different offset bases, concatenated — 64 bits of
+// change detection, no security claim (nobody but the owner can write it).
+const fnv1a = (s, seed) => {
+  let h = seed >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+};
+const hex8 = (n) => n.toString(16).padStart(8, '0');
+export const contentFingerprint = (s) => hex8(fnv1a(s, 0x811c9dc5)) + hex8(fnv1a(s, 0x7fffffff));
+
+// The mirror's memory of what it last wrote: { <scheduleitem _id>: <fingerprint> }.
+// Tolerates a missing/legacy/corrupt doc by reading as "nothing mirrored yet",
+// which re-puts everything once — the safe direction (the unsafe one would be
+// believing docs are mirrored when they aren't).
+export const scheduleStateFingerprints = (stateDoc) => {
+  const fps = stateDoc && stateDoc.fingerprints;
+  return fps !== null && typeof fps === 'object' && !Array.isArray(fps) ? fps : {};
+};
+
+// Diff the freshly-fetched feed against the mirror's own state doc — NOT against
+// the tick's db read, which is capped and no longer contains the schedule docs.
+// Returns the docs to put (new or content-changed), the ids to delete (event
+// vanished), and the fingerprint map to persist.
+export const diffScheduleAgainstState = (feedItems, stateDoc) => {
+  const prev = scheduleStateFingerprints(stateDoc);
+  const puts = [];
+  const fingerprints = {};
+  const seen = new Set();
+  for (const it of feedItems) {
+    if (it.eventId == null) continue;
+    const _id = scheduleItemId(it.eventId);
+    if (seen.has(_id)) continue; // a feed that repeats an id → keep the first
+    seen.add(_id);
+    const doc = { _id, type: 'scheduleitem', ...it };
+    const fp = contentFingerprint(scheduleContentKey(doc));
+    fingerprints[_id] = fp;
+    if (prev[_id] !== fp) puts.push(doc);
+  }
+  const deletes = [];
+  for (const _id of Object.keys(prev)) if (!seen.has(_id)) deletes.push(_id);
+  return { puts, deletes, fingerprints };
+};
+
+// The scheduled central fetch. At most once per SCHEDULE_SYNC_INTERVAL_MS:
+// fetch the feed, diff against the state doc, upsert only the changed docs
+// (deleting vanished events), and persist the new state — LAST, so a put that
+// throws mid-run leaves the state honest and the next sync retries. Guards: a
+// failed OR empty feed leaves existing schedule docs untouched and does not
+// advance the cadence gate — never wipe the schedule on a transient upstream
+// hiccup (the same rule the old client-side fetch followed). Runs only when
+// given a write-capable ctx (admin-mode scheduled lane).
+export const syncScheduleDocs = async (event, ctx, docs) => {
+  if (!ctx || !ctx.db || typeof ctx.db.put !== 'function') return null;
+  const now = Date.parse(event?.scheduledTime) || Date.now();
+  if (lastScheduleSyncAt !== null && now - lastScheduleSyncAt < SCHEDULE_SYNC_INTERVAL_MS) {
+    return { ok: true, skipped: 'not due' };
+  }
+  let data;
+  try {
+    const res = await globalThis.fetch(SCHEDULE_URL, { headers: { accept: 'application/json' } });
+    if (!res.ok) throw new Error(`schedule feed ${res.status}`);
+    data = await res.json();
+  } catch (err) {
+    return { ok: false, error: String((err && err.message) || err) };
+  }
+  const feedItems = ingestScheduleFeed(data);
+  if (feedItems.length === 0) return { ok: false, error: 'empty feed' };
+  lastScheduleSyncAt = now;
+  // The durable state doc first; the in-isolate copy is the backstop for the
+  // day it isn't in the read. `_id` is a free string, so enough docs sorting
+  // ahead of `0-` could push it out of the capped window — nothing the app
+  // writes does that, but nothing stops a signed-in stranger either.
+  let stateDoc = (docs || []).find((d) => d && d._id === SCHEDULE_STATE_ID);
+  if (!stateDoc && lastFingerprints !== null) {
+    console.warn(
+      `pickathon tick: ${SCHEDULE_STATE_ID} missing from the db read — using the in-isolate ` +
+        `copy. If this persists, something is sorting ahead of it inside the query cap.`
+    );
+    stateDoc = { fingerprints: lastFingerprints };
+  }
+  const { puts, deletes, fingerprints } = diffScheduleAgainstState(feedItems, stateDoc);
+  lastFingerprints = fingerprints;
+  if (puts.length === 0 && deletes.length === 0) return { ok: true, put: 0, deleted: 0 };
+  if (!stateDoc) {
+    // First sync of a cold isolate with no durable state to read: legitimate on
+    // a brand-new mirror, and the one shape an evicted state doc also takes.
+    // Bounded either way — the line above means it can happen once per isolate,
+    // not once per tick, which is the whole difference between this and #4293.
+    console.warn(`pickathon tick: no mirror state found — writing all ${puts.length} schedule docs.`);
+  }
+  for (const doc of puts) await ctx.db.put(doc, { db: 'pickathon' });
+  for (const _id of deletes) await ctx.db.delete(_id, { db: 'pickathon' });
+  await ctx.db.put(
+    {
+      _id: SCHEDULE_STATE_ID,
+      type: SCHEDULE_STATE_TYPE,
+      fingerprints,
+      syncedAt: new Date(now).toISOString(),
+    },
+    { db: 'pickathon' }
+  );
+  return { ok: true, put: puts.length, deleted: deletes.length };
 };
 
 // Stable UID per item so re-importing an updated export replaces events instead
@@ -422,6 +810,19 @@ const handleSubscription = async (url) => {
     return textResponse(
       400,
       "pass t=<calendar token> — open the app's My Faves tab to get your link"
+    );
+  }
+  // Load shedding (see § Load shedding): 503 + Retry-After, AFTER the token
+  // shape check so a genuinely malformed request still gets its 400. A 503 is
+  // the one honest answer here — calendar clients back off and keep the events
+  // they already synced, where an empty calendar would read as "your picks are
+  // gone". Never cached: the shed can lift at any tick.
+  if (isShedding()) {
+    return textResponse(
+      503,
+      'Festival mode: this calendar feed is paused for a little while. Your picks are safe — ' +
+        'your calendar will fill back in on its own.',
+      { 'retry-after': String(SHED_RETRY_AFTER_SECONDS), 'cache-control': 'no-store' }
     );
   }
   // Display-only label: iOS captures the calendar NAME at subscribe time, and

--- a/examples/pickathon-picker/backend.test.js
+++ b/examples/pickathon-picker/backend.test.js
@@ -8,6 +8,18 @@ import {
   decodeFeedEntities,
   scheduled,
   __resetSubCacheForTests,
+  __resetScheduleSyncForTests,
+  __resetHeartbeatForTests,
+  __resetShedForTests,
+  LOADSHED_ID,
+  LOADSHED_TYPE,
+  SHED_RETRY_AFTER_SECONDS,
+  HEARTBEAT_ID,
+  HEARTBEAT_TYPE,
+  HEARTBEAT_INTERVAL_MS,
+  SCHEDULE_STATE_ID,
+  SCHEDULE_STATE_TYPE,
+  SCHEDULE_SYNC_INTERVAL_MS,
   MAX_ITEMS,
   SCHEDULE_URL,
   fetch as icsFetch,
@@ -332,7 +344,10 @@ const tick = () =>
   scheduled({ scheduledTime: '2026-07-04T12:00:00Z' }, { db: { query: async () => DB_DOCS } });
 
 describe('fetch handler — GET /faves.ics?u=<handle> (subscription lane)', () => {
-  beforeEach(() => __resetSubCacheForTests());
+  beforeEach(() => {
+    __resetSubCacheForTests();
+    __resetShedForTests();
+  });
   afterEach(() => vi.unstubAllGlobals());
   const feedOk = () => {
     const spy = vi.fn(async () => new Response(JSON.stringify(FEED), { status: 200 }));
@@ -468,6 +483,428 @@ describe('fetch handler — POST /faves.ics', () => {
   });
   it('never needs ctx — works with an anonymous, ctx-less call', async () => {
     const res = await icsFetch(post({ items: items() }), undefined);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ── The schedule mirror: what #4293 was actually about ───────────────────────
+// The tick's db read is capped by the host at 2000 docs sorted by _id, and this
+// db passed that. `schedule-event-*` sorts last, so the mirror's own docs became
+// invisible to the tick — it re-put all ~330 of them every 60 seconds and pinned
+// the Durable Object at 97% occupancy. These tests pin the shape that fixed it:
+// the mirror decides "unchanged" from its own state doc, which is reachable at
+// any db size, so a steady schedule costs ZERO writes.
+describe('schedule mirror — unchanged schedule must cost zero writes', () => {
+  beforeEach(() => {
+    __resetSubCacheForTests();
+    __resetScheduleSyncForTests();
+    __resetHeartbeatForTests();
+    __resetShedForTests();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  // A ctx that records every write and replays the docs a capped read returns.
+  const mkCtx = (docs = []) => {
+    const store = new Map(docs.map((d) => [d._id, d]));
+    const puts = [];
+    const deletes = [];
+    return {
+      puts,
+      deletes,
+      docs: () => [...store.values()],
+      db: {
+        query: async () => [...store.values()],
+        put: async (doc) => {
+          puts.push(doc);
+          store.set(doc._id, doc);
+          return doc._id;
+        },
+        delete: async (id) => {
+          deletes.push(id);
+          store.delete(id);
+          return id;
+        },
+      },
+    };
+  };
+  const feedOk = () => {
+    const spy = vi.fn(async () => new Response(JSON.stringify(FEED), { status: 200 }));
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  };
+  // Successive ticks, SCHEDULE_SYNC_INTERVAL_MS apart so each one is due.
+  const at = (n) => ({ scheduledTime: new Date(1e12 + n * SCHEDULE_SYNC_INTERVAL_MS).toISOString() });
+
+  it('mirrors the feed on the first sync and records a fingerprint per event', async () => {
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    const items = ctx.puts.filter((d) => d.type === 'scheduleitem');
+    expect(items.map((d) => d._id).sort()).toEqual([
+      'schedule-event-101',
+      'schedule-event-102',
+      'schedule-event-201',
+    ]);
+    const state = ctx.puts.find((d) => d._id === SCHEDULE_STATE_ID);
+    expect(state.type).toBe(SCHEDULE_STATE_TYPE);
+    expect(Object.keys(state.fingerprints).sort()).toEqual(items.map((d) => d._id).sort());
+  });
+
+  it('writes NOTHING on a later sync of an unchanged schedule (the #4293 regression)', async () => {
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    const afterFirst = ctx.puts.length;
+    await scheduled(at(1), ctx);
+    await scheduled(at(2), ctx);
+    expect(ctx.puts.length).toBe(afterFirst);
+    expect(ctx.deletes).toEqual([]);
+  });
+
+  it('stays quiet even when the capped read cannot see the schedule docs at all', async () => {
+    // Prod's exact shape: the read returns the state doc (its _id leads with a
+    // digit, so it sorts to the front and survives the cap) but NOT one single
+    // `schedule-event-*` doc. This is the case that used to re-put everything.
+    feedOk();
+    const seed = mkCtx(DB_DOCS);
+    await scheduled(at(0), seed);
+    const state = seed.puts.find((d) => d._id === SCHEDULE_STATE_ID);
+    const capped = mkCtx([...DB_DOCS, state]); // no scheduleitem docs survive the cap
+    await scheduled(at(1), capped);
+    expect(capped.puts).toEqual([]);
+    expect(capped.deletes).toEqual([]);
+  });
+
+  it('falls back to the in-isolate copy when the state doc is not in the read', async () => {
+    // The state doc's _id sorts ahead of everything this app mints, but _id is a
+    // free string — enough docs beginning with punctuation would evict it, and a
+    // signed-in stranger can write those (unknown types are accepted, just routed
+    // to `discard`). Losing it must NOT read as "nothing is mirrored".
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    ctx.puts.length = 0;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Same isolate, but the read no longer contains the state doc.
+    const evicted = {
+      db: { ...ctx.db, query: async () => ctx.docs().filter((d) => d._id !== SCHEDULE_STATE_ID) },
+    };
+    await scheduled(at(1), evicted);
+    expect(ctx.puts).toEqual([]); // the isolate remembered — no rewrite storm
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing from the db read'));
+    warn.mockRestore();
+  });
+
+  it('re-puts ONLY the event whose content changed', async () => {
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    ctx.puts.length = 0;
+    const moved = JSON.parse(JSON.stringify(FEED));
+    moved[12].events[0].start = '2026-07-31 15:00:00';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(moved), { status: 200 }))
+    );
+    await scheduled(at(1), ctx);
+    expect(ctx.puts.filter((d) => d.type === 'scheduleitem').map((d) => d._id)).toEqual([
+      'schedule-event-101',
+    ]);
+    expect(ctx.puts.some((d) => d._id === SCHEDULE_STATE_ID)).toBe(true);
+  });
+
+  it('deletes an event that vanished from the feed, from state alone', async () => {
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    ctx.puts.length = 0;
+    const shrunk = JSON.parse(JSON.stringify(FEED));
+    shrunk[13].events = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(shrunk), { status: 200 }))
+    );
+    await scheduled(at(1), ctx);
+    expect(ctx.deletes).toEqual(['schedule-event-201']);
+  });
+
+  it('does not even fetch the feed on a tick inside the sync interval', async () => {
+    const spy = feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    expect(spy).toHaveBeenCalledTimes(1);
+    // A minute later: the aggregate still refreshes, the feed is left alone.
+    await scheduled({ scheduledTime: new Date(1e12 + 60_000).toISOString() }, ctx);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('a failed or empty feed writes nothing and retries on the next tick', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 }))
+    );
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    // The liveness heartbeat is deliberately independent of the feed — a tick
+    // that ran and found the upstream down is still a tick that ran.
+    expect(ctx.puts.filter((d) => d.type !== HEARTBEAT_TYPE)).toEqual([]);
+    expect(ctx.deletes).toEqual([]);
+    // The gate did not advance, so the very next tick tries again.
+    const spy = feedOk();
+    await scheduled({ scheduledTime: new Date(1e12 + 60_000).toISOString() }, ctx);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(ctx.puts.filter((d) => d.type === 'scheduleitem').length).toBe(3);
+  });
+
+  it('treats a corrupt or forged state doc as "nothing mirrored", never as up to date', async () => {
+    feedOk();
+    const ctx = mkCtx([
+      ...DB_DOCS,
+      { _id: SCHEDULE_STATE_ID, type: SCHEDULE_STATE_TYPE, fingerprints: 'not-an-object' },
+    ]);
+    await scheduled(at(0), ctx);
+    expect(ctx.puts.filter((d) => d.type === 'scheduleitem').length).toBe(3);
+  });
+
+  it('warns when the db read comes back capped, because the host says nothing', async () => {
+    feedOk();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const filler = Array.from({ length: 2000 }, (_, i) => ({
+      _id: `favorite-user${String(i).padStart(5, '0')}-1`,
+      type: 'favorite',
+      userId: `user${i}`,
+      eventId: 101,
+    }));
+    await scheduled(at(0), mkCtx(filler));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('2000-doc query cap'));
+    warn.mockRestore();
+  });
+});
+
+describe('tick liveness heartbeat — the only durable proof the alarm ran', () => {
+  beforeEach(() => {
+    __resetSubCacheForTests();
+    __resetScheduleSyncForTests();
+    __resetHeartbeatForTests();
+    __resetShedForTests();
+    // The feed is irrelevant here; a down upstream keeps the mirror out of the puts.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response('nope', { status: 500 }))
+    );
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const mkCtx = (docs = []) => {
+    const puts = [];
+    return {
+      puts,
+      db: { query: async () => docs, put: async (d) => puts.push(d), delete: async () => {} },
+    };
+  };
+  const beats = (ctx) => ctx.puts.filter((d) => d.type === HEARTBEAT_TYPE);
+  const tick = (ms) => ({ scheduledTime: new Date(ms).toISOString() });
+  const T0 = 1e12;
+
+  it('stamps the tick’s scheduled time on a cold isolate with no doc to go by', async () => {
+    const ctx = mkCtx([]);
+    await scheduled(tick(T0), ctx);
+    expect(beats(ctx)).toEqual([
+      { _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at: new Date(T0).toISOString() },
+    ]);
+  });
+
+  it('beats at most once an hour — a 1m tick must not mint a write a minute', async () => {
+    const ctx = mkCtx([]);
+    await scheduled(tick(T0), ctx);
+    await scheduled(tick(T0 + 60_000), ctx);
+    await scheduled(tick(T0 + HEARTBEAT_INTERVAL_MS - 1000), ctx);
+    expect(beats(ctx)).toHaveLength(1);
+  });
+
+  it('re-beats once the interval elapses, with a CHANGED stamp (or the platform dedupes it)', async () => {
+    const ctx = mkCtx([]);
+    await scheduled(tick(T0), ctx);
+    await scheduled(tick(T0 + HEARTBEAT_INTERVAL_MS), ctx);
+    const stamps = beats(ctx).map((d) => d.at);
+    expect(stamps).toHaveLength(2);
+    expect(stamps[0]).not.toBe(stamps[1]);
+  });
+
+  it('honours a recent heartbeat doc from the read after an isolate restart', async () => {
+    // Fresh isolate (no memory), but the doc is right there in the whole-db read
+    // its digit-leading _id guarantees a seat in — so nothing is due.
+    const ctx = mkCtx([
+      { _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at: new Date(T0 - 60_000).toISOString() },
+    ]);
+    await scheduled(tick(T0), ctx);
+    expect(beats(ctx)).toEqual([]);
+  });
+
+  it('beats when the doc in the read is stale — a dead-then-revived alarm says so', async () => {
+    const ctx = mkCtx([
+      { _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at: new Date(T0 - 3 * 60 * 60 * 1000).toISOString() },
+    ]);
+    await scheduled(tick(T0), ctx);
+    expect(beats(ctx)).toHaveLength(1);
+  });
+
+  it('a doc missing from a capped read means "don’t know", never "never beat"', async () => {
+    // The #4293 shape: losing the doc from the read must not restart the writes.
+    const ctx = mkCtx([]);
+    await scheduled(tick(T0), ctx);
+    await scheduled(tick(T0 + 60_000), mkCtx([])); // same isolate, doc absent
+    expect(beats(ctx)).toHaveLength(1);
+  });
+
+  it('treats an unparseable stamp as no evidence and beats now', async () => {
+    const ctx = mkCtx([{ _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at: 'not-a-date' }]);
+    await scheduled(tick(T0), ctx);
+    expect(beats(ctx)).toHaveLength(1);
+  });
+
+  it('writes nothing on a read-only ctx (the ics GET lane shares this isolate)', async () => {
+    await expect(scheduled(tick(T0), { db: { query: async () => [] } })).resolves.not.toThrow();
+  });
+});
+
+describe('load shedding — the owner-flipped config doc', () => {
+  beforeEach(() => {
+    __resetSubCacheForTests();
+    __resetScheduleSyncForTests();
+    __resetHeartbeatForTests();
+    __resetShedForTests();
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  const feedOk = () => {
+    const spy = vi.fn(async () => new Response(JSON.stringify(FEED), { status: 200 }));
+    vi.stubGlobal('fetch', spy);
+    return spy;
+  };
+  const shedDoc = (level) => ({ _id: LOADSHED_ID, type: LOADSHED_TYPE, level });
+  const mkCtx = (docs = []) => {
+    const puts = [];
+    const deletes = [];
+    let rows = docs;
+    return {
+      puts,
+      deletes,
+      setDocs: (d) => {
+        rows = d;
+      },
+      db: {
+        query: async () => rows,
+        put: async (d) => {
+          puts.push(d);
+          return d._id;
+        },
+        delete: async (id) => {
+          deletes.push(id);
+          return id;
+        },
+      },
+    };
+  };
+  const at = (n) => ({ scheduledTime: new Date(1e12 + n * SCHEDULE_SYNC_INTERVAL_MS).toISOString() });
+
+  it('serves the subscription normally when the doc is absent (fail-open)', async () => {
+    feedOk();
+    await scheduled(at(0), mkCtx(DB_DOCS));
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('SUMMARY:Built to Spill');
+  });
+
+  it('serves normally when the level is off or unrecognized (a typo must not shed)', async () => {
+    feedOk();
+    await scheduled(at(0), mkCtx([...DB_DOCS, shedDoc('off')]));
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(200);
+    await scheduled(at(1), mkCtx([...DB_DOCS, shedDoc('readonly')])); // fat-fingered
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(200);
+  });
+
+  it('503s the subscription lane with a retry-after while shedding, in BOTH shed levels', async () => {
+    // Calendar clients retry a 503 gracefully and keep the events they already
+    // synced — which is why this is a 503 and not an empty calendar.
+    for (const level of ['read-only', 'schedule-only']) {
+      __resetShedForTests();
+      __resetSubCacheForTests();
+      feedOk();
+      await scheduled(at(0), mkCtx([...DB_DOCS, shedDoc(level)]));
+      const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+      expect(res.status).toBe(503);
+      expect(res.headers.get('retry-after')).toBe(String(SHED_RETRY_AFTER_SECONDS));
+      expect(res.headers.get('cache-control')).toBe('no-store');
+      const body = await res.text();
+      expect(body).toMatch(/festival/i); // calm, and says it comes back
+      expect(body).not.toMatch(/error|lost|deleted/i);
+    }
+  });
+
+  it('a malformed token still 400s before the shed check (shedding is not a bug bucket)', async () => {
+    feedOk();
+    await scheduled(at(0), mkCtx([...DB_DOCS, shedDoc('read-only')]));
+    expect((await icsFetch(req('/faves.ics?t=short'), {})).status).toBe(400);
+  });
+
+  it('skips the aggregate while shedding but STILL writes the heartbeat', async () => {
+    // Liveness must survive shedding: a shed tick is still a tick that ran, and
+    // the heartbeat is the only durable evidence of that (#4305).
+    feedOk();
+    const ctx = mkCtx([...DB_DOCS, shedDoc('read-only')]);
+    await scheduled(at(0), ctx);
+    expect(ctx.puts.filter((d) => d.type === HEARTBEAT_TYPE)).toHaveLength(1);
+    // No aggregate was built, so the GET has nothing to serve even if it tried.
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(503);
+  });
+
+  it('keeps the 5-minute schedule mirror running in BOTH shed levels', async () => {
+    // Shedding targets viewer-driven amplification, not the fixed-cost mirror —
+    // and the schedule staying fresh is the whole point of staying up.
+    for (const level of ['read-only', 'schedule-only']) {
+      __resetShedForTests();
+      __resetScheduleSyncForTests();
+      feedOk();
+      const ctx = mkCtx([...DB_DOCS, shedDoc(level)]);
+      await scheduled(at(0), ctx);
+      expect(ctx.puts.filter((d) => d.type === 'scheduleitem').length).toBe(3);
+      expect(ctx.puts.some((d) => d._id === SCHEDULE_STATE_ID)).toBe(true);
+    }
+  });
+
+  it('honours the in-isolate copy when the doc falls out of a capped read', async () => {
+    // §4a: a missing doc means "don't know" → use the remembered level. It must
+    // never read as "shedding is off", which would re-open the very load spike
+    // the switch was flipped for.
+    feedOk();
+    const ctx = mkCtx([...DB_DOCS, shedDoc('read-only')]);
+    await scheduled(at(0), ctx);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ctx.setDocs(DB_DOCS); // same isolate, the config doc is no longer in the read
+    await scheduled(at(1), ctx);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(503);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(LOADSHED_ID));
+    warn.mockRestore();
+  });
+
+  it('lifts the shed as soon as the doc says off, and re-fills the aggregate', async () => {
+    feedOk();
+    const ctx = mkCtx([...DB_DOCS, shedDoc('read-only')]);
+    await scheduled(at(0), ctx);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(503);
+    ctx.setDocs([...DB_DOCS, shedDoc('off')]);
+    await scheduled(at(1), ctx);
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('SUMMARY:Built to Spill');
+  });
+
+  it('a cold isolate that has never seen the doc serves normally (fail-open)', async () => {
+    // The GET lane cannot read the db at all, so before the first tick it has no
+    // idea whether we are shedding. Fail-open is the only safe default.
+    feedOk();
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
     expect(res.status).toBe(200);
   });
 });

--- a/examples/pickathon-picker/docs.js
+++ b/examples/pickathon-picker/docs.js
@@ -1,0 +1,69 @@
+// Document identity for the `pickathon` db. The _id shapes are a contract with
+// access.js and backend.js — favorites and notes are keyed by (owner, event) so a
+// re-key on sign-in lands on the same doc instead of duplicating it.
+
+export const favoriteDocId = (userId, eventId) => `favorite-${userId}-${eventId}`;
+export const noteDocId = (userId, eventId) => `note-${userId}-${eventId}`;
+export const calTokenDocId = (userId) => `caltoken-${userId}`;
+
+// Re-stamp a locally-stored doc onto the freshly signed-in handle when useFireproof
+// migrates the local store to the cloud on first login. Owned docs are keyed by user,
+// so favorites/notes re-key deterministically; a shift has no natural key, so it drops
+// its _id and gets a fresh one.
+export const migratePickathonDoc = (doc, handle) => {
+  if (doc.type === 'favorite')
+    return { ...doc, userId: handle, _id: favoriteDocId(handle, doc.eventId) };
+  if (doc.type === 'note') return { ...doc, userId: handle, _id: noteDocId(handle, doc.eventId) };
+  if (doc.type === 'shift') {
+    const { _id, ...rest } = doc;
+    return { ...rest, userId: handle };
+  }
+  return { ...doc, userId: handle };
+};
+
+// The live calendar feed carries the TOKEN, not the handle: unguessable and revocable.
+// `n` is a display hint only. Null unless there is both something to sync and a minted
+// token, so we never advertise a subscription that would sync empty.
+export const icsSubscribePath = (calToken, userId) =>
+  calToken
+    ? `/_api/faves.ics?t=${encodeURIComponent(calToken)}&n=${encodeURIComponent(userId)}`
+    : null;
+
+// URL-safe base64 of 16 random bytes — the calendar capability token, minted locally.
+export const mintCalToken = (getRandomValues) => {
+  const bytes = new Uint8Array(16);
+  getRandomValues(bytes);
+  let bin = '';
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+};
+
+// Mint the user's calendar token if — and only if — they don't already have one.
+// The doc's _id is fixed per user, so a second mint OVERWRITES the first and every
+// calendar already subscribed to the old URL goes dead. The caltoken live query is
+// mounted with the My Faves tab (see App.jsx § lazy-mounted tab-scoped queries), so
+// its first read is empty even for a user who has a token — which is exactly the
+// wrong thing to mint from. This asks the store instead, which is authoritative.
+// A refused write (offline) resolves to null; the subscribe controls simply don't
+// appear until the user is back online.
+export const ensureCalToken = async ({ database, userId, getRandomValues }) => {
+  try {
+    const existing = await database.get(calTokenDocId(userId));
+    if (existing && existing.token) return existing.token;
+  } catch (e) {
+    // Not found — fall through and mint.
+  }
+  const token = mintCalToken(getRandomValues);
+  try {
+    await database.put({
+      _id: calTokenDocId(userId),
+      type: 'caltoken',
+      userId,
+      token,
+      createdAt: Date.now(),
+    });
+  } catch (e) {
+    return null;
+  }
+  return token;
+};

--- a/examples/pickathon-picker/docs.test.js
+++ b/examples/pickathon-picker/docs.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import {
+  favoriteDocId,
+  noteDocId,
+  calTokenDocId,
+  migratePickathonDoc,
+  icsSubscribePath,
+  mintCalToken,
+  ensureCalToken,
+} from './docs.js';
+
+describe('doc ids', () => {
+  it('keys a favorite by (owner, event) so a re-pick is idempotent', () => {
+    expect(favoriteDocId('alice', 'e1')).toBe('favorite-alice-e1');
+    expect(favoriteDocId('alice', 'e1')).toBe(favoriteDocId('alice', 'e1'));
+  });
+
+  it('keys a note by (owner, event) and a token by owner', () => {
+    expect(noteDocId('alice', 'e1')).toBe('note-alice-e1');
+    expect(calTokenDocId('alice')).toBe('caltoken-alice');
+  });
+});
+
+describe('migratePickathonDoc', () => {
+  it('re-keys a favorite onto the signed-in handle', () => {
+    const out = migratePickathonDoc(
+      { _id: 'favorite-anonymous-e1', type: 'favorite', eventId: 'e1', userId: 'anonymous' },
+      'alice'
+    );
+    expect(out).toEqual({
+      _id: 'favorite-alice-e1',
+      type: 'favorite',
+      eventId: 'e1',
+      userId: 'alice',
+    });
+  });
+
+  it('re-keys a note the same way', () => {
+    const out = migratePickathonDoc(
+      { _id: 'note-anonymous-e1', type: 'note', eventId: 'e1', notes: 'hi' },
+      'alice'
+    );
+    expect(out._id).toBe('note-alice-e1');
+    expect(out.notes).toBe('hi');
+  });
+
+  it('drops a shift _id — a shift has no natural key, so it gets a fresh one', () => {
+    const out = migratePickathonDoc({ _id: 'old', type: 'shift', day: 'Friday' }, 'alice');
+    expect(out._id).toBeUndefined();
+    expect(out).toEqual({ type: 'shift', day: 'Friday', userId: 'alice' });
+  });
+
+  it('re-stamps any other doc without touching its id', () => {
+    const out = migratePickathonDoc({ _id: 'x', type: 'caltoken', token: 't' }, 'alice');
+    expect(out).toEqual({ _id: 'x', type: 'caltoken', token: 't', userId: 'alice' });
+  });
+
+  it('is idempotent for an already-migrated favorite', () => {
+    const once = migratePickathonDoc({ type: 'favorite', eventId: 'e1' }, 'alice');
+    expect(migratePickathonDoc(once, 'alice')).toEqual(once);
+  });
+});
+
+describe('icsSubscribePath', () => {
+  it('carries the token, not the handle, as the capability', () => {
+    expect(icsSubscribePath('tok', 'alice')).toBe('/_api/faves.ics?t=tok&n=alice');
+  });
+
+  it('escapes both values', () => {
+    expect(icsSubscribePath('a+b/c', 'a b')).toBe('/_api/faves.ics?t=a%2Bb%2Fc&n=a%20b');
+  });
+
+  it('is null with no token — never advertise a feed that would sync empty', () => {
+    expect(icsSubscribePath(null, 'alice')).toBe(null);
+  });
+});
+
+describe('mintCalToken', () => {
+  it('is url-safe base64 with no padding', () => {
+    const t = mintCalToken((bytes) => bytes.fill(255));
+    expect(t).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(t).not.toContain('=');
+  });
+
+  it('reflects the random bytes it was given', () => {
+    const a = mintCalToken((b) => b.fill(0));
+    const c = mintCalToken((b) => b.fill(1));
+    expect(a).not.toBe(c);
+  });
+});
+
+describe('ensureCalToken — mint exactly once per user, ever', () => {
+  // The caltoken live query is mounted WITH the My Faves tab, so its first read is
+  // [] even for a user who already holds a token. Minting off that empty read would
+  // overwrite the doc (its _id is fixed per user) with a fresh token and silently
+  // break every calendar already subscribed to the old URL — so the mint asks the
+  // store directly instead of trusting the query.
+  const rnd = (bytes) => bytes.fill(7);
+  const mkDb = (existing) => {
+    const puts = [];
+    return {
+      puts,
+      get: async (id) => {
+        if (existing && existing._id === id) return existing;
+        throw new Error('Not found');
+      },
+      put: async (d) => {
+        puts.push(d);
+        return { id: d._id };
+      },
+    };
+  };
+
+  it('mints and stores a token when the user has none', async () => {
+    const db = mkDb(null);
+    const token = await ensureCalToken({ database: db, userId: 'alice', getRandomValues: rnd });
+    expect(db.puts).toHaveLength(1);
+    expect(db.puts[0]).toMatchObject({
+      _id: 'caltoken-alice',
+      type: 'caltoken',
+      userId: 'alice',
+      token,
+    });
+  });
+
+  it('does NOT re-mint over an existing token — that would revoke live subscriptions', async () => {
+    const db = mkDb({ _id: 'caltoken-alice', type: 'caltoken', userId: 'alice', token: 'keepme' });
+    const token = await ensureCalToken({ database: db, userId: 'alice', getRandomValues: rnd });
+    expect(db.puts).toEqual([]);
+    expect(token).toBe('keepme');
+  });
+
+  it('treats a token-less leftover doc as no token and mints', async () => {
+    const db = mkDb({ _id: 'caltoken-alice', type: 'caltoken', userId: 'alice' });
+    await ensureCalToken({ database: db, userId: 'alice', getRandomValues: rnd });
+    expect(db.puts).toHaveLength(1);
+  });
+
+  it('swallows a refused write (offline) rather than throwing into the effect', async () => {
+    const db = { get: async () => { throw new Error('Not found'); }, put: async () => { throw new Error('offline'); } };
+    await expect(
+      ensureCalToken({ database: db, userId: 'alice', getRandomValues: rnd })
+    ).resolves.toBe(null);
+  });
+});

--- a/examples/pickathon-picker/icons.jsx
+++ b/examples/pickathon-picker/icons.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+
+// Inline Feather-style icons so the UI reads as vector marks, not emoji glyphs.
+// Every icon inherits color via `currentColor` and sizes off the `size` prop
+// (default 20), matching the external-link / trash icons already used in the views.
+
+const base = (size) => ({
+  width: size,
+  height: size,
+  viewBox: '0 0 24 24',
+  strokeLinecap: 'round',
+  strokeLinejoin: 'round',
+});
+
+const HEART_PATH =
+  'M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 1 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z';
+
+// state: 'full' (filled), 'half' (left half filled — the "some faved" band state),
+// or 'empty' (outline only).
+export function HeartIcon({ state = 'empty', size = 20, className = '' }) {
+  if (state === 'half') {
+    return (
+      <svg {...base(size)} className={className} aria-hidden="true">
+        <defs>
+          <clipPath id="pk-heart-half">
+            <rect x="0" y="0" width="12" height="24" />
+          </clipPath>
+        </defs>
+        <path d={HEART_PATH} fill="currentColor" clipPath="url(#pk-heart-half)" />
+        <path d={HEART_PATH} fill="none" stroke="currentColor" strokeWidth="2" />
+      </svg>
+    );
+  }
+  const filled = state === 'full';
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path
+        d={HEART_PATH}
+        fill={filled ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+export function LinkIcon({ size = 20, className = '' }) {
+  return (
+    <svg
+      {...base(size)}
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+export function StarIcon({ size = 16, className = '' }) {
+  return (
+    <svg {...base(size)} className={className} aria-hidden="true">
+      <path
+        d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth="1.5"
+      />
+    </svg>
+  );
+}
+
+export function ClipboardIcon({ size = 20, className = '' }) {
+  return (
+    <svg
+      {...base(size)}
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2" />
+      <rect x="8" y="2" width="8" height="4" rx="1" ry="1" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ size = 20, className = '' }) {
+  return (
+    <svg
+      {...base(size)}
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}

--- a/examples/pickathon-picker/loadshed.js
+++ b/examples/pickathon-picker/loadshed.js
@@ -1,0 +1,60 @@
+// Load shedding: ONE owner-written config doc that turns viewer-driven work off
+// during the festival rush, with no redeploy and no code change.
+//
+//   vibes-diy db put --db pickathon '{"_id":"0-load-shed","type":"loadshed","level":"read-only"}'
+//
+// Levels, and exactly what each one costs the viewer:
+//   off            — normal operation. Also what an ABSENT doc and any
+//                    unrecognized level mean: this switch FAILS OPEN, because a
+//                    typo'd `db put` at 11pm on a Saturday must not brick the app.
+//   read-only      — the schedule/browse/now/bands views keep FULL function;
+//                    every write affordance goes inert (favorite toggling, the
+//                    band-level heart, note editing, extras add/edit).
+//   schedule-only  — read-only, PLUS the Friends tab and profile views render a
+//                    one-line paused state INSTEAD of mounting their live
+//                    queries. Those are the per-viewer follower fan-out reads —
+//                    the amplification that actually costs the Sessions DO.
+//
+// Signed-in and anonymous viewers behave identically: shedding is about load,
+// not about who you are.
+//
+// The `_id` leads with a DIGIT on purpose: it sorts ahead of every id this app
+// mints (`caltoken-`, `favorite-`, `note-`, `schedule-event-`, uuid shifts), so
+// the backend's whole-db read sees it inside the host's 2000-doc query cap
+// (§4a). access.js makes it owner-only WRITE but world-READABLE — see the
+// comment there for why both halves matter.
+//
+// backend.js and access.js CANNOT import this file (each runs alone in the
+// backend isolate, no import resolution), so they carry literal copies of the id
+// and type. loadshed.test.js pins the literals as the drift guard.
+
+export const LOADSHED_ID = '0-load-shed';
+export const LOADSHED_TYPE = 'loadshed';
+
+export const SHED_OFF = 'off';
+export const SHED_READ_ONLY = 'read-only';
+export const SHED_SCHEDULE_ONLY = 'schedule-only';
+
+const KNOWN_LEVELS = [SHED_OFF, SHED_READ_ONLY, SHED_SCHEDULE_ONLY];
+
+// Fail-open by construction: only an exactly-recognized level sheds anything.
+// Case/whitespace are forgiven because this doc is written by hand under
+// pressure, but an unknown string is `off`, never "shed harder".
+export const shedLevelOf = (doc) => {
+  const raw = doc && typeof doc.level === 'string' ? doc.level.trim().toLowerCase() : '';
+  return KNOWN_LEVELS.includes(raw) ? raw : SHED_OFF;
+};
+
+// The client reads this through a type-keyed live query, so it gets an array.
+// Key on the id we own rather than "whatever came back".
+export const shedLevelFromDocs = (docs) =>
+  shedLevelOf((docs || []).find((d) => d && d._id === LOADSHED_ID));
+
+export const picksPaused = (level) => level === SHED_READ_ONLY || level === SHED_SCHEDULE_ONLY;
+export const socialPaused = (level) => level === SHED_SCHEDULE_ONLY;
+
+// Copy rules (agents/local-first-copy-rules.md): say what is paused and that
+// nothing is lost. Never imply data loss, never promise a time.
+export const SHED_BANNER =
+  'Festival mode: picks are paused right now — the schedule still works, and your existing picks are safe on this device.';
+export const SHED_SOCIAL_LINE = 'Paused during the festival rush — your picks are safe.';

--- a/examples/pickathon-picker/loadshed.test.js
+++ b/examples/pickathon-picker/loadshed.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  LOADSHED_ID,
+  LOADSHED_TYPE,
+  SHED_OFF,
+  SHED_READ_ONLY,
+  SHED_SCHEDULE_ONLY,
+  shedLevelOf,
+  shedLevelFromDocs,
+  picksPaused,
+  socialPaused,
+} from './loadshed.js';
+
+describe('loadshed — the config doc contract', () => {
+  it('pins the doc identity the client, access.js and backend.js all agree on', () => {
+    // backend.js and access.js cannot import this file (they run alone in the
+    // backend isolate), so they carry literal copies — these two assertions are
+    // the drift guard for that duplication.
+    expect(LOADSHED_ID).toBe('0-load-shed');
+    expect(LOADSHED_TYPE).toBe('loadshed');
+    // Digit-leading `_id`: sorts ahead of every id this app mints, so the doc
+    // rides inside the backend query's 2000-doc cap (§4a).
+    expect(LOADSHED_ID[0] >= '0' && LOADSHED_ID[0] <= '9').toBe(true);
+  });
+});
+
+describe('shedLevelOf — fail-open level parsing', () => {
+  it('reads the three known levels', () => {
+    expect(shedLevelOf({ level: 'off' })).toBe(SHED_OFF);
+    expect(shedLevelOf({ level: 'read-only' })).toBe(SHED_READ_ONLY);
+    expect(shedLevelOf({ level: 'schedule-only' })).toBe(SHED_SCHEDULE_ONLY);
+  });
+
+  it('FAILS OPEN: an absent doc is fully normal operation', () => {
+    // The doc not existing is the normal state of the app — 364 days a year.
+    expect(shedLevelOf(undefined)).toBe(SHED_OFF);
+    expect(shedLevelOf(null)).toBe(SHED_OFF);
+    expect(shedLevelOf({})).toBe(SHED_OFF);
+  });
+
+  it('FAILS OPEN on anything unrecognized — a typo must not brick the app', () => {
+    // A fat-fingered `db put` during the rush is the likeliest way this doc is
+    // ever wrong. Unknown → off, never "shed everything".
+    expect(shedLevelOf({ level: 'readonly' })).toBe(SHED_OFF);
+    expect(shedLevelOf({ level: 'ON' })).toBe(SHED_OFF);
+    expect(shedLevelOf({ level: 42 })).toBe(SHED_OFF);
+    expect(shedLevelOf({ level: null })).toBe(SHED_OFF);
+  });
+
+  it('tolerates case and stray whitespace in a hand-typed level', () => {
+    expect(shedLevelOf({ level: ' Read-Only ' })).toBe(SHED_READ_ONLY);
+    expect(shedLevelOf({ level: 'SCHEDULE-ONLY' })).toBe(SHED_SCHEDULE_ONLY);
+  });
+});
+
+describe('shedLevelFromDocs — the client reads a live query, not one doc', () => {
+  it('picks the config doc out of a type-keyed query result', () => {
+    expect(shedLevelFromDocs([{ _id: LOADSHED_ID, type: LOADSHED_TYPE, level: 'read-only' }])).toBe(
+      SHED_READ_ONLY
+    );
+  });
+
+  it('ignores a stray doc that is not the config id (nobody else may shed us)', () => {
+    // access.js is owner-only-WRITE, so this shouldn't be reachable — but the
+    // client should key on the id it owns rather than "whatever came back".
+    expect(
+      shedLevelFromDocs([{ _id: 'loadshed-forged', type: LOADSHED_TYPE, level: 'schedule-only' }])
+    ).toBe(SHED_OFF);
+  });
+
+  it('an empty or missing read is normal operation', () => {
+    expect(shedLevelFromDocs([])).toBe(SHED_OFF);
+    expect(shedLevelFromDocs(undefined)).toBe(SHED_OFF);
+  });
+});
+
+describe('what each level pauses', () => {
+  it('off pauses nothing', () => {
+    expect(picksPaused(SHED_OFF)).toBe(false);
+    expect(socialPaused(SHED_OFF)).toBe(false);
+  });
+
+  it('read-only pauses writes but keeps the social views', () => {
+    expect(picksPaused(SHED_READ_ONLY)).toBe(true);
+    expect(socialPaused(SHED_READ_ONLY)).toBe(false);
+  });
+
+  it('schedule-only pauses writes AND the follower-fan-out views', () => {
+    expect(picksPaused(SHED_SCHEDULE_ONLY)).toBe(true);
+    expect(socialPaused(SHED_SCHEDULE_ONLY)).toBe(true);
+  });
+});

--- a/examples/pickathon-picker/picks.js
+++ b/examples/pickathon-picker/picks.js
@@ -1,0 +1,75 @@
+// Joining favorite/shift docs to the schedule for a given audience. Pure.
+//
+// Read-visibility is NOT enforced here — the platform already decided which docs this
+// client can read (access.js `audience: { followersOf }`), so a handle whose picks
+// aren't shared simply has no favorite docs in the local store and lands as an empty
+// list. These helpers only ever filter what already arrived.
+import { byStart } from './schedule-build.js';
+
+// Favorites and shifts written while signed out carry no userId.
+export const ownerOf = (doc) => doc.userId || 'anonymous';
+
+export const favoriteEventsFor = (handle, allFavorites, events) => {
+  const ids = new Set(allFavorites.filter((f) => ownerOf(f) === handle).map((f) => f.eventId));
+  return events.filter((e) => ids.has(e.eventId)).sort(byStart);
+};
+
+// Private extras deliberately never leave their owner: only `shareWithFriends` ones.
+export const sharedShiftsFor = (handle, allShifts) =>
+  allShifts.filter((s) => s.shareWithFriends && ownerOf(s) === handle);
+
+// One handle's schedule, or (unified) everyone in `union` merged with each event
+// carrying the `pickedBy` handles so the view can attribute picks.
+export const audienceFavoriteEvents = ({ allFavorites, events, union, only }) => {
+  const pickedBy = new Map();
+  for (const f of allFavorites) {
+    const uid = ownerOf(f);
+    if (union ? union.has(uid) : uid === only) {
+      if (!pickedBy.has(f.eventId)) pickedBy.set(f.eventId, []);
+      pickedBy.get(f.eventId).push(uid);
+    }
+  }
+  return events
+    .filter((e) => pickedBy.has(e.eventId))
+    .map((e) => (union ? { ...e, pickedBy: pickedBy.get(e.eventId).sort() } : e))
+    .sort(byStart);
+};
+
+export const audienceShifts = ({ allShifts, union, only }) =>
+  allShifts
+    .filter((s) => s.shareWithFriends && (union ? union.has(ownerOf(s)) : ownerOf(s) === only))
+    .map((s) => (union ? { ...s, pickedBy: [ownerOf(s)] } : s));
+
+// Per-event: handles you FOLLOW who picked it (never yourself), so the All Events list
+// can show their tags at a glance. Independent of any schedule selection.
+export const picksByEvent = (allFavorites, followedHandles, selfHandle) => {
+  const m = new Map();
+  for (const f of allFavorites) {
+    const uid = ownerOf(f);
+    if (uid !== selfHandle && followedHandles.has(uid)) {
+      const arr = m.get(f.eventId);
+      if (arr) arr.push(uid);
+      else m.set(f.eventId, [uid]);
+    }
+  }
+  for (const arr of m.values()) arr.sort();
+  return m;
+};
+
+// Super-mode aggregates. Both scan every readable favorite, so callers compute them
+// only in super mode.
+export const countsByEvent = (allFavorites) => {
+  const m = {};
+  for (const f of allFavorites) m[f.eventId] = (m[f.eventId] || 0) + 1;
+  return m;
+};
+
+export const pickersByCount = (allFavorites) => {
+  const map = new Map();
+  for (const f of allFavorites) {
+    const uid = ownerOf(f);
+    if (!map.has(uid)) map.set(uid, { userId: uid, count: 0 });
+    map.get(uid).count++;
+  }
+  return [...map.values()].sort((a, b) => b.count - a.count);
+};

--- a/examples/pickathon-picker/picks.test.js
+++ b/examples/pickathon-picker/picks.test.js
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ownerOf,
+  favoriteEventsFor,
+  sharedShiftsFor,
+  audienceFavoriteEvents,
+  audienceShifts,
+  picksByEvent,
+  countsByEvent,
+  pickersByCount,
+} from './picks.js';
+import { eventsFromScheduleDocs } from './schedule-build.js';
+
+const events = eventsFromScheduleDocs([
+  { eventId: 'a', title: 'A', start: '2026-07-31T18:00:00', end: '2026-07-31T19:00:00' },
+  { eventId: 'b', title: 'B', start: '2026-07-31T20:00:00', end: '2026-07-31T21:00:00' },
+  { eventId: 'c', title: 'C', start: '2026-08-01T18:00:00', end: '2026-08-01T19:00:00' },
+]);
+
+const fav = (userId, eventId) => ({
+  _id: `favorite-${userId}-${eventId}`,
+  type: 'favorite',
+  userId,
+  eventId,
+});
+
+describe('ownerOf', () => {
+  it('treats a doc with no userId as anonymous (signed-out writes)', () => {
+    expect(ownerOf({})).toBe('anonymous');
+    expect(ownerOf({ userId: 'alice' })).toBe('alice');
+  });
+});
+
+describe('favoriteEventsFor', () => {
+  it('returns that handle picks only, in start order', () => {
+    const all = [fav('alice', 'b'), fav('alice', 'a'), fav('bob', 'c')];
+    expect(favoriteEventsFor('alice', all, events).map((e) => e.eventId)).toEqual(['a', 'b']);
+  });
+
+  it('is empty for a handle with nothing readable', () => {
+    expect(favoriteEventsFor('nobody', [fav('alice', 'a')], events)).toEqual([]);
+  });
+
+  it('ignores a favorite whose event is not in the schedule', () => {
+    expect(favoriteEventsFor('alice', [fav('alice', 'gone')], events)).toEqual([]);
+  });
+
+  it('deduplicates repeated favorites of the same event', () => {
+    const all = [fav('alice', 'a'), { ...fav('alice', 'a'), _id: 'dupe' }];
+    expect(favoriteEventsFor('alice', all, events)).toHaveLength(1);
+  });
+});
+
+describe('sharedShiftsFor', () => {
+  const shifts = [
+    { _id: 's1', userId: 'alice', shareWithFriends: true },
+    { _id: 's2', userId: 'alice', shareWithFriends: false },
+    { _id: 's3', userId: 'bob', shareWithFriends: true },
+  ];
+
+  it('never leaks a private extra', () => {
+    expect(sharedShiftsFor('alice', shifts).map((s) => s._id)).toEqual(['s1']);
+  });
+});
+
+describe('audienceFavoriteEvents', () => {
+  const all = [fav('alice', 'a'), fav('bob', 'a'), fav('bob', 'c')];
+
+  it('filters to one handle without a pickedBy tag', () => {
+    const out = audienceFavoriteEvents({ allFavorites: all, events, only: 'bob' });
+    expect(out.map((e) => e.eventId)).toEqual(['a', 'c']);
+    expect(out[0].pickedBy).toBeUndefined();
+  });
+
+  it('unifies a set of handles and attributes each pick, sorted', () => {
+    const out = audienceFavoriteEvents({
+      allFavorites: all,
+      events,
+      union: new Set(['bob', 'alice']),
+    });
+    expect(out.map((e) => e.eventId)).toEqual(['a', 'c']);
+    expect(out[0].pickedBy).toEqual(['alice', 'bob']);
+  });
+
+  it('keeps start order across days', () => {
+    const out = audienceFavoriteEvents({
+      allFavorites: [fav('bob', 'c'), fav('bob', 'a')],
+      events,
+      only: 'bob',
+    });
+    expect(out.map((e) => e.eventId)).toEqual(['a', 'c']);
+  });
+});
+
+describe('audienceShifts', () => {
+  const shifts = [
+    { _id: 's1', userId: 'alice', shareWithFriends: true },
+    { _id: 's2', userId: 'bob', shareWithFriends: true },
+    { _id: 's3', userId: 'bob', shareWithFriends: false },
+  ];
+
+  it('tags each unified extra with its owner', () => {
+    const out = audienceShifts({ allShifts: shifts, union: new Set(['alice', 'bob']) });
+    expect(out.map((s) => s._id)).toEqual(['s1', 's2']);
+    expect(out[1].pickedBy).toEqual(['bob']);
+  });
+
+  it('leaves a single-handle extra untagged', () => {
+    const [only] = audienceShifts({ allShifts: shifts, only: 'alice' });
+    expect(only.pickedBy).toBeUndefined();
+  });
+});
+
+describe('picksByEvent', () => {
+  it('maps events to the followed handles who picked them, excluding me', () => {
+    const all = [fav('me', 'a'), fav('alice', 'a'), fav('bob', 'a'), fav('stranger', 'b')];
+    const m = picksByEvent(all, new Set(['alice', 'bob']), 'me');
+    expect(m.get('a')).toEqual(['alice', 'bob']);
+    expect(m.has('b')).toBe(false);
+  });
+});
+
+describe('super-mode aggregates', () => {
+  const all = [fav('alice', 'a'), fav('bob', 'a'), fav('bob', 'c')];
+
+  it('counts picks per event', () => {
+    expect(countsByEvent(all)).toEqual({ a: 2, c: 1 });
+  });
+
+  it('ranks pickers by pick count', () => {
+    expect(pickersByCount(all)).toEqual([
+      { userId: 'bob', count: 2 },
+      { userId: 'alice', count: 1 },
+    ]);
+  });
+});

--- a/examples/pickathon-picker/schedule-build.js
+++ b/examples/pickathon-picker/schedule-build.js
@@ -1,0 +1,147 @@
+// Turning docs into the day-by-day schedule the views render. Pure — no React, no db.
+import { FESTIVAL_2026, toFestivalDate, festivalDayFor } from './festival-utils.js';
+
+// The stored `scheduleitem` doc deliberately omits `day` (kept out so the server's
+// content diff doesn't churn). Derive it at READ time: Pickathon runs late, so a set
+// belongs to the festival NIGHT it started in — anything before 4 AM counts as the
+// prior day, which is what festivalDayFor applies.
+export const eventsFromScheduleDocs = (docs) =>
+  docs.map((d) => ({
+    eventId: d.eventId,
+    title: d.title,
+    start: d.start,
+    end: d.end,
+    url: d.url,
+    venueTitle: d.venueTitle,
+    venueColor: d.venueColor,
+    lineup: d.lineup || {},
+    day: festivalDayFor(d.start),
+  }));
+
+export const byStart = (a, b) => toFestivalDate(a.start) - toFestivalDate(b.start);
+
+// Prefer the festival day's canonical calendar date. Since a day groups after-midnight
+// sets from the *next* calendar date (4 AM cutoff), we must not derive the header date
+// from a stray early-morning event's start — hence the canonical table first, an event
+// only as a second guess, and the fallbackStart + day index as a last resort.
+export const getDateForDay = (day, events = []) => {
+  if (FESTIVAL_2026.dates[day]) return FESTIVAL_2026.dates[day];
+  const evt = events.find((e) => e.day === day);
+  if (evt) return evt.start.split('T')[0];
+  const base = new Date(FESTIVAL_2026.fallbackStart);
+  const idx = FESTIVAL_2026.dayOrder.indexOf(day);
+  const d = new Date(base);
+  d.setDate(base.getDate() + Math.max(0, idx));
+  return d.toISOString().split('T')[0];
+};
+
+// Only days that actually have events or shifts, in festival order. We deliberately do
+// NOT seed with the full dayOrder — a festival day with nothing on it (e.g. Monday)
+// shouldn't show up in the picker or as an empty section. Unknown days sort last.
+export const displayDaysFor = (events, shifts) => {
+  const present = new Set([...events.map((e) => e.day), ...shifts.map((s) => s.day)].filter(Boolean));
+  const o = FESTIVAL_2026.dayOrder;
+  return [...present].sort((a, b) => {
+    const ai = o.indexOf(a),
+      bi = o.indexOf(b);
+    if (ai === -1 && bi === -1) return a.localeCompare(b);
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+};
+
+// One day's rows: picked events + extras, time-ordered. A shift sorts BEFORE an event
+// starting at the same minute — you leave for the shift, then catch what's left of the
+// set. Callers supply which events/shifts (mine, a followed handle's, a profile's);
+// the merge and the ordering are identical for all of them.
+export const buildDaySchedule = (day, events, shifts, shiftStartRaw) =>
+  [
+    ...events
+      .filter((e) => festivalDayFor(e.start) === day)
+      .map((e) => ({
+        type: 'event',
+        id: e.eventId,
+        title: e.title,
+        sort: toFestivalDate(e.start),
+        venue: e.venueTitle,
+        data: e,
+      })),
+    ...shifts
+      .filter((s) => festivalDayFor(shiftStartRaw(s)) === day)
+      .map((s) => ({
+        type: 'shift',
+        id: s._id,
+        sort: toFestivalDate(shiftStartRaw(s)),
+        data: s,
+      })),
+  ].sort((a, b) => a.sort - b.sort || (a.type === 'shift' ? -1 : 1));
+
+// A shift stores its own start/end; the legacy shapes (startISO, or day + startTime)
+// are still readable, so resolve in that order.
+export const makeShiftBounds = (events) => ({
+  shiftStartRaw: (s) => s.start ?? s.startISO ?? `${getDateForDay(s.day, events)}T${s.startTime}:00`,
+  shiftEndRaw: (s) => s.end ?? s.endISO ?? `${getDateForDay(s.day, events)}T${s.endTime}:00`,
+});
+
+// The day listing reads as time slots, not as a list of timestamps: consecutive rows
+// that start at the same minute are one group, and the time is printed ONCE as a label
+// above them. That is what makes an overlap legible — two acts at 4 PM are two bubbles
+// under one label rather than two cards repeating the same range.
+//
+// `end` is the group's shared end, and is null when the members disagree — the label
+// then shows only the start and each card carries its own "until …" note, because
+// printing one range over rows that don't share it would be a lie. Grouping is by
+// CONSECUTIVE equal starts on the already-sorted day, so ordering is never disturbed;
+// shifts group by exactly the same rule as events.
+export const groupByTimeSlot = (items, shiftStartRaw, shiftEndRaw) =>
+  groupBySlot(
+    items,
+    (row) => (row.type === 'shift' ? shiftStartRaw(row.data) : row.data.start),
+    (row) => (row.type === 'shift' ? shiftEndRaw(row.data) : row.data.end)
+  );
+
+// Same slot rule for a plain event list (the All Events browse day, which has no
+// shifts and holds events directly rather than schedule rows).
+export const groupEventsByTimeSlot = (events) =>
+  groupBySlot(
+    events,
+    (e) => e.start,
+    (e) => e.end
+  );
+
+const groupBySlot = (items, startOf, endOf) => {
+  const at = (s) => toFestivalDate(s).getTime();
+  const groups = [];
+  for (const row of items) {
+    const start = startOf(row);
+    const prev = groups[groups.length - 1];
+    if (prev && at(prev.start) === at(start)) prev.rows.push(row);
+    else groups.push({ start, rows: [row] });
+  }
+  return groups.map((g, i) => {
+    const ends = g.rows.map(endOf);
+    const uniform = ends.every((e) => at(e) === at(ends[0]));
+    return { key: `${g.start}-${i}`, start: g.start, end: uniform ? ends[0] : null, items: g.rows };
+  });
+};
+
+// Parse a QA test-clock string in FESTIVAL time (the same frame every event start is
+// parsed in), so `#now=2026-07-31T20:00` means 8 PM on site regardless of the device's
+// timezone. Returns null for anything unparseable — a typo must fall back to the real
+// clock, never to NaN.
+export const parseTestClock = (raw) => {
+  if (!raw) return null;
+  const ms = toFestivalDate(String(raw).trim()).getTime();
+  return Number.isNaN(ms) ? null : ms;
+};
+
+// A cold local replica can read EMPTY for a moment even though the server seeded the
+// schedule into first paint: the empty first snapshot is treated as authoritative and
+// reaps the seeded rows, and the initial pull then puts them back. Anonymous first-timers
+// saw the real schedule, then a full-width "downloading" takeover, then the schedule
+// again. So a transient empty read is NOT news: keep showing the last non-empty set we
+// held this session. Only a session that never had ANY events reads as empty — which is
+// what the takeover is actually for. (The platform-side hold on seeded rows is a separate
+// fix in flight; this makes the app immune either way.)
+export const retainEvents = (current, held) => (current.length > 0 ? current : held);

--- a/examples/pickathon-picker/schedule-build.test.js
+++ b/examples/pickathon-picker/schedule-build.test.js
@@ -1,0 +1,389 @@
+import { describe, it, expect } from 'vitest';
+import { toFestivalDate, setsOnNow, upNextSets } from './festival-utils.js';
+import {
+  eventsFromScheduleDocs,
+  getDateForDay,
+  displayDaysFor,
+  buildDaySchedule,
+  makeShiftBounds,
+  byStart,
+  groupByTimeSlot,
+  groupEventsByTimeSlot,
+  parseTestClock,
+  retainEvents,
+} from './schedule-build.js';
+
+const doc = (over = {}) => ({
+  _id: `schedule-event-${over.eventId || 'e1'}`,
+  type: 'scheduleitem',
+  eventId: 'e1',
+  title: 'Band One',
+  start: '2026-07-31T20:00:00',
+  end: '2026-07-31T21:00:00',
+  url: 'https://pickathon.com/e1',
+  venueTitle: 'Woods',
+  venueColor: '#0f0',
+  ...over,
+});
+
+const shift = (over = {}) => ({
+  _id: 'shift-1',
+  type: 'shift',
+  day: 'Friday',
+  startTime: '09:00',
+  endTime: '17:00',
+  start: '2026-07-31T09:00:00',
+  end: '2026-07-31T17:00:00',
+  kind: 'Shift',
+  ...over,
+});
+
+describe('eventsFromScheduleDocs', () => {
+  it('derives `day` at read time (the stored doc omits it)', () => {
+    const [e] = eventsFromScheduleDocs([doc()]);
+    expect(e.day).toBe('Friday');
+    expect(e.eventId).toBe('e1');
+    expect(e.lineup).toEqual({});
+  });
+
+  it('groups an after-midnight set onto the festival NIGHT it started in', () => {
+    const [e] = eventsFromScheduleDocs([doc({ start: '2026-08-01T01:30:00' })]);
+    expect(e.day).toBe('Friday');
+  });
+
+  it('keeps 4 AM and later on the new day', () => {
+    const [e] = eventsFromScheduleDocs([doc({ start: '2026-08-01T04:30:00' })]);
+    expect(e.day).toBe('Saturday');
+  });
+
+  it('carries the lineup through when present', () => {
+    const [e] = eventsFromScheduleDocs([doc({ lineup: { id: 'workshop', color: '#abc' } })]);
+    expect(e.lineup).toEqual({ id: 'workshop', color: '#abc' });
+  });
+});
+
+describe('getDateForDay', () => {
+  it('prefers the canonical festival date over any event start', () => {
+    const events = eventsFromScheduleDocs([doc({ start: '2026-08-01T01:00:00' })]);
+    expect(getDateForDay('Friday', events)).toBe('2026-07-31');
+  });
+
+  it('falls back to an event start for a day outside the table', () => {
+    const events = [{ day: 'Wednesday', start: '2026-07-29T18:00:00' }];
+    expect(getDateForDay('Wednesday', events)).toBe('2026-07-29');
+  });
+
+  it('falls back to fallbackStart + day index when nothing else knows', () => {
+    expect(getDateForDay('Wednesday', [])).toBe('2026-07-30');
+  });
+});
+
+describe('displayDaysFor', () => {
+  it('lists only days with content, in festival order', () => {
+    const events = eventsFromScheduleDocs([
+      doc({ eventId: 'a', start: '2026-08-02T12:00:00' }),
+      doc({ eventId: 'b', start: '2026-07-30T12:00:00' }),
+    ]);
+    expect(displayDaysFor(events, [])).toEqual(['Thursday', 'Sunday']);
+  });
+
+  it('includes days that only a shift occupies', () => {
+    expect(displayDaysFor([], [shift({ day: 'Monday' })])).toEqual(['Monday']);
+  });
+
+  it('sorts unknown days last, alphabetically among themselves', () => {
+    const events = [{ day: 'Zebra' }, { day: 'Friday' }, { day: 'Aardvark' }];
+    expect(displayDaysFor(events, [])).toEqual(['Friday', 'Aardvark', 'Zebra']);
+  });
+
+  it('drops days that are absent/undefined', () => {
+    expect(displayDaysFor([{ day: undefined }], [])).toEqual([]);
+  });
+});
+
+describe('buildDaySchedule', () => {
+  const { shiftStartRaw } = makeShiftBounds([]);
+
+  it('merges picked events and extras for one day only', () => {
+    const events = eventsFromScheduleDocs([
+      doc({ eventId: 'fri', start: '2026-07-31T20:00:00' }),
+      doc({ eventId: 'sat', start: '2026-08-01T20:00:00' }),
+    ]);
+    const rows = buildDaySchedule('Friday', events, [shift()], shiftStartRaw);
+    expect(rows.map((r) => r.id)).toEqual(['shift-1', 'fri']);
+  });
+
+  it('orders by start time', () => {
+    const events = eventsFromScheduleDocs([
+      doc({ eventId: 'late', start: '2026-07-31T22:00:00' }),
+      doc({ eventId: 'early', start: '2026-07-31T18:00:00' }),
+    ]);
+    expect(buildDaySchedule('Friday', events, [], shiftStartRaw).map((r) => r.id)).toEqual([
+      'early',
+      'late',
+    ]);
+  });
+
+  it('puts a shift BEFORE an event starting the same minute', () => {
+    const events = eventsFromScheduleDocs([doc({ eventId: 'e', start: '2026-07-31T09:00:00' })]);
+    const rows = buildDaySchedule('Friday', events, [shift()], shiftStartRaw);
+    expect(rows.map((r) => r.type)).toEqual(['shift', 'event']);
+  });
+
+  it('shapes event rows with the fields the view reads', () => {
+    const events = eventsFromScheduleDocs([doc()]);
+    const [row] = buildDaySchedule('Friday', events, [], shiftStartRaw);
+    expect(row).toMatchObject({ type: 'event', id: 'e1', title: 'Band One', venue: 'Woods' });
+    expect(row.data.eventId).toBe('e1');
+  });
+
+  it('is empty for a day with nothing on it', () => {
+    expect(buildDaySchedule('Monday', eventsFromScheduleDocs([doc()]), [], shiftStartRaw)).toEqual(
+      []
+    );
+  });
+
+  it('groups an after-midnight pick onto the prior festival night', () => {
+    const events = eventsFromScheduleDocs([doc({ eventId: 'late', start: '2026-08-01T01:00:00' })]);
+    expect(buildDaySchedule('Friday', events, [], shiftStartRaw).map((r) => r.id)).toEqual(['late']);
+  });
+});
+
+describe('makeShiftBounds', () => {
+  it('prefers the stored start/end', () => {
+    const { shiftStartRaw, shiftEndRaw } = makeShiftBounds([]);
+    expect(shiftStartRaw(shift())).toBe('2026-07-31T09:00:00');
+    expect(shiftEndRaw(shift())).toBe('2026-07-31T17:00:00');
+  });
+
+  it('reads the legacy startISO/endISO shape', () => {
+    const { shiftStartRaw, shiftEndRaw } = makeShiftBounds([]);
+    const legacy = { day: 'Friday', startISO: '2026-07-31T08:00:00', endISO: 'x' };
+    expect(shiftStartRaw(legacy)).toBe('2026-07-31T08:00:00');
+    expect(shiftEndRaw(legacy)).toBe('x');
+  });
+
+  it('composes day + time when neither is stored', () => {
+    const { shiftStartRaw } = makeShiftBounds([]);
+    expect(shiftStartRaw({ day: 'Saturday', startTime: '10:30' })).toBe('2026-08-01T10:30:00');
+  });
+});
+
+describe('byStart', () => {
+  it('orders two events by festival-local start', () => {
+    expect(byStart({ start: '2026-07-31T09:00:00' }, { start: '2026-07-31T10:00:00' })).toBeLessThan(
+      0
+    );
+  });
+});
+
+describe('groupByTimeSlot', () => {
+  const { shiftStartRaw, shiftEndRaw } = makeShiftBounds([]);
+  const group = (rows) => groupByTimeSlot(rows, shiftStartRaw, shiftEndRaw);
+  const ev = (id, start, end) => ({
+    type: 'event',
+    id,
+    title: id,
+    venue: 'Woods',
+    data: { eventId: id, start, end },
+  });
+  const sh = (id, start, end) => ({ type: 'shift', id, data: { _id: id, start, end } });
+
+  it('is empty for a day with nothing on it', () => {
+    expect(group([])).toEqual([]);
+  });
+
+  it('makes a singleton group carry its own full range', () => {
+    const [g] = group([ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00')]);
+    expect(g.start).toBe('2026-07-31T16:00:00');
+    expect(g.end).toBe('2026-07-31T17:00:00');
+    expect(g.items).toHaveLength(1);
+  });
+
+  it('folds two acts sharing a range into ONE labelled slot', () => {
+    const groups = group([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].items.map((r) => r.id)).toEqual(['a', 'b']);
+    expect(groups[0].end).toBe('2026-07-31T17:00:00');
+  });
+
+  it('drops the shared end when members disagree, so cards can say their own', () => {
+    const [g] = group([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T16:00:00', '2026-07-31T17:30:00'),
+    ]);
+    expect(g.end).toBe(null);
+    expect(g.items).toHaveLength(2);
+  });
+
+  it('starts a new group at every new start time', () => {
+    const groups = group([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T18:00:00', '2026-07-31T19:00:00'),
+    ]);
+    expect(groups.map((g) => g.start)).toEqual([
+      '2026-07-31T16:00:00',
+      '2026-07-31T18:00:00',
+    ]);
+  });
+
+  it('groups a shift and an event that start together, by the same rule', () => {
+    const [g] = group([
+      sh('s1', '2026-07-31T09:00:00', '2026-07-31T17:00:00'),
+      ev('a', '2026-07-31T09:00:00', '2026-07-31T17:00:00'),
+    ]);
+    expect(g.items.map((r) => r.type)).toEqual(['shift', 'event']);
+    expect(g.end).toBe('2026-07-31T17:00:00');
+  });
+
+  it('reads a shift through the bounds accessors, not its raw fields', () => {
+    const legacy = { type: 'shift', id: 's', data: { _id: 's', day: 'Friday', startTime: '09:00', endTime: '17:00' } };
+    const [g] = group([legacy]);
+    expect(g.start).toBe('2026-07-31T09:00:00');
+    expect(g.end).toBe('2026-07-31T17:00:00');
+  });
+
+  it('treats equal instants written differently as the same slot', () => {
+    const groups = group([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T16:00', '2026-07-31T17:00'),
+    ]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].end).toBe('2026-07-31T17:00:00');
+  });
+
+  it('keeps same-start rows in separate groups when they are not consecutive', () => {
+    const groups = group([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T18:00:00', '2026-07-31T19:00:00'),
+      ev('c', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+    ]);
+    expect(groups.map((g) => g.items.length)).toEqual([1, 1, 1]);
+  });
+
+  it('gives every group a distinct key', () => {
+    const groups = group([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T18:00:00', '2026-07-31T19:00:00'),
+      ev('c', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+    ]);
+    expect(new Set(groups.map((g) => g.key)).size).toBe(3);
+  });
+});
+
+describe('parseTestClock', () => {
+  it('parses a minute-precision stamp in FESTIVAL time, not device time', () => {
+    expect(parseTestClock('2026-07-31T20:00')).toBe(toFestivalDate('2026-07-31T20:00').getTime());
+  });
+
+  it('accepts seconds and surrounding whitespace', () => {
+    expect(parseTestClock(' 2026-07-31T20:00:00 ')).toBe(parseTestClock('2026-07-31T20:00'));
+  });
+
+  it('falls back to the real clock (null) on junk or absence', () => {
+    expect(parseTestClock('not-a-time')).toBe(null);
+    expect(parseTestClock('')).toBe(null);
+    expect(parseTestClock(null)).toBe(null);
+  });
+});
+
+// The Now tab's selection under a fixed clock — the states a QA screenshot needs to
+// distinguish, including the end-of-set boundary and the 4 AM night roll.
+describe('now/next selection at a fixed test clock', () => {
+  const ev = (venueTitle, start, end) => ({ eventId: `${venueTitle}-${start}`, venueTitle, start, end });
+  const events = [
+    ev('Woods', '2026-07-31T19:00:00', '2026-07-31T20:00:00'),
+    ev('Mtn', '2026-07-31T19:30:00', '2026-07-31T20:30:00'),
+    ev('Barn', '2026-07-31T20:15:00', '2026-07-31T21:15:00'),
+  ];
+  const clock = (s) => parseTestClock(s);
+
+  it('shows both overlapping sets as playing now', () => {
+    expect(setsOnNow(events, clock('2026-07-31T19:45')).map((e) => e.venueTitle)).toEqual([
+      'Woods',
+      'Mtn',
+    ]);
+  });
+
+  it('drops a set the instant it ends (end is exclusive)', () => {
+    expect(setsOnNow(events, clock('2026-07-31T20:00')).map((e) => e.venueTitle)).toEqual(['Mtn']);
+  });
+
+  it('counts a set as playing from its exact start', () => {
+    expect(setsOnNow(events, clock('2026-07-31T19:00')).map((e) => e.venueTitle)).toEqual(['Woods']);
+  });
+
+  it('offers the not-yet-started set as up next', () => {
+    expect(upNextSets(events, clock('2026-07-31T19:45')).map((e) => e.venueTitle)).toEqual(['Barn']);
+  });
+
+  it('has nothing on stage and nothing next once the night is over', () => {
+    expect(setsOnNow(events, clock('2026-08-01T02:00'))).toEqual([]);
+    expect(upNextSets(events, clock('2026-08-01T02:00'))).toEqual([]);
+  });
+
+  it('still finds the late set from an after-midnight clock (same festival night)', () => {
+    const late = [ev('Galaxy', '2026-08-01T01:00:00', '2026-08-01T02:30:00')];
+    expect(setsOnNow(late, clock('2026-08-01T01:30')).map((e) => e.venueTitle)).toEqual(['Galaxy']);
+  });
+});
+
+describe('groupEventsByTimeSlot (All Events browse)', () => {
+  const ev = (id, start, end) => ({ eventId: id, title: id, venueTitle: 'V', start, end });
+
+  it('folds a plain event list into slots by the same rule', () => {
+    const groups = groupEventsByTimeSlot([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('c', '2026-07-31T18:00:00', '2026-07-31T19:00:00'),
+    ]);
+    expect(groups.map((g) => g.items.length)).toEqual([2, 1]);
+    expect(groups[0].end).toBe('2026-07-31T17:00:00');
+  });
+
+  it('drops the shared end when a slot member runs longer', () => {
+    const [g] = groupEventsByTimeSlot([
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T16:00:00', '2026-07-31T17:30:00'),
+    ]);
+    expect(g.end).toBe(null);
+  });
+
+  it('regroups a filtered list without touching order', () => {
+    const all = [
+      ev('a', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('b', '2026-07-31T16:00:00', '2026-07-31T17:00:00'),
+      ev('c', '2026-07-31T18:00:00', '2026-07-31T19:00:00'),
+    ];
+    const filtered = all.filter((e) => e.eventId !== 'b');
+    expect(groupEventsByTimeSlot(filtered).map((g) => g.items.length)).toEqual([1, 1]);
+  });
+
+  it('is empty for no events', () => {
+    expect(groupEventsByTimeSlot([])).toEqual([]);
+  });
+});
+
+describe('retainEvents — a transient empty read must not blank the screen', () => {
+  const some = [{ eventId: 'a' }];
+  const more = [{ eventId: 'a' }, { eventId: 'b' }];
+
+  it('shows the live rows whenever there are any', () => {
+    expect(retainEvents(some, [])).toBe(some);
+  });
+
+  it('keeps the last non-empty set through a zero-row blip', () => {
+    expect(retainEvents([], some)).toBe(some);
+  });
+
+  it('prefers fresher live rows over the held ones', () => {
+    expect(retainEvents(more, some)).toBe(more);
+  });
+
+  it('is empty only when the session never held any events — the honest empty first visit', () => {
+    expect(retainEvents([], [])).toEqual([]);
+  });
+});

--- a/examples/pickathon-picker/social-logic.js
+++ b/examples/pickathon-picker/social-logic.js
@@ -1,0 +1,56 @@
+// The decisions behind the social surfaces — who can see what, which follow control to
+// render, which copy to show. Pure so the matrix can be pinned by tests instead of by
+// clicking through six states in a browser.
+
+// Whose picks I can see = handles I follow with an ACTIVE edge. A follow into a private
+// account sits at "requested" until they approve — it grants no reads, so including it
+// would only render empty schedule sections.
+export const activeFollowHandles = (following) =>
+  new Set(following.filter((f) => f.state === 'active').map((f) => f.handle));
+
+export const followStateMap = (following) => new Map(following.map((f) => [f.handle, f.state]));
+
+// Your OWN profile deliberately reads through the follower-visible path, not your local
+// favorites: the point of previewing it is to see what OTHERS get, and an un-armed
+// account (#3484) shows its followers nothing.
+export const profilePicksVisible = ({ isSelf, followersEnabled, followedHandles, handle }) => {
+  if (!handle) return false;
+  return isSelf ? Boolean(followersEnabled) : followedHandles.has(handle);
+};
+
+// The follow control is state selection, not a boolean: 'none' on your own profile,
+// 'signin' for a visitor with no identity, 'loading' until the graph snapshot lands.
+// The button can't offer "Request to follow" up front — a target handle's account
+// privacy isn't in the protocol, so the private case can only surface AFTER the tap,
+// as 'requested' (platform #4319).
+export const followButtonState = ({ isSelf, signedIn, socialReady, followState }) => {
+  if (isSelf) return 'none';
+  if (!signedIn) return 'signin';
+  if (!socialReady) return 'loading';
+  if (followState === 'active') return 'following';
+  if (followState === 'requested') return 'requested';
+  return 'follow';
+};
+
+// Follower-facing copy deliberately never names pick-sharing: that's a control the
+// VIEWER can't reach, so naming it only tells them to go badger someone. The self arms
+// do name it, because there it's actionable.
+export const profileEmptyMessage = ({ isSelf, sharingOff, followState, signedIn }) => {
+  if (isSelf)
+    return sharingOff
+      ? "Your followers see nothing here — you haven't turned on pick-sharing yet."
+      : "You haven't picked any events yet — your followers see an empty schedule.";
+  if (followState === 'active') return "No picks to show — they haven't shared any yet.";
+  if (followState === 'requested')
+    return 'Their account is private — once they approve your request, their picks show up here.';
+  return signedIn
+    ? 'Follow to see the events they picked and the extras they share with followers.'
+    : 'Sign in and follow to see the events they picked and the extras they share.';
+};
+
+// Turning pick-sharing back ON has two paths and the social snapshot can't tell them
+// apart. Someone who disarmed in this session has already consented, so re-arming is a
+// plain level flip — routing them back through the consent matrix would let a prior
+// standing deny no-op confusingly. A first-ever arm is the invite the platform owns.
+export const armPath = ({ disarmed, canSetVisibility }) =>
+  disarmed && canSetVisibility ? 'level' : 'consent';

--- a/examples/pickathon-picker/social-logic.test.js
+++ b/examples/pickathon-picker/social-logic.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import {
+  activeFollowHandles,
+  followStateMap,
+  profilePicksVisible,
+  followButtonState,
+  profileEmptyMessage,
+  armPath,
+} from './social-logic.js';
+
+describe('activeFollowHandles', () => {
+  it('counts only ACTIVE edges — a requested follow grants no reads', () => {
+    const s = activeFollowHandles([
+      { handle: 'alice', state: 'active' },
+      { handle: 'bob', state: 'requested' },
+    ]);
+    expect([...s]).toEqual(['alice']);
+  });
+});
+
+describe('followStateMap', () => {
+  it('keeps the state of every edge, requested included', () => {
+    const m = followStateMap([
+      { handle: 'alice', state: 'active' },
+      { handle: 'bob', state: 'requested' },
+    ]);
+    expect(m.get('alice')).toBe('active');
+    expect(m.get('bob')).toBe('requested');
+    expect(m.get('carol')).toBeUndefined();
+  });
+});
+
+describe('profilePicksVisible', () => {
+  const followed = new Set(['alice']);
+
+  it('shows a followed handle picks', () => {
+    expect(
+      profilePicksVisible({ handle: 'alice', isSelf: false, followedHandles: followed })
+    ).toBe(true);
+  });
+
+  it('shows nothing for someone you do not follow', () => {
+    expect(profilePicksVisible({ handle: 'bob', isSelf: false, followedHandles: followed })).toBe(
+      false
+    );
+  });
+
+  it('gates your OWN profile on the arm, not on owning the docs', () => {
+    expect(
+      profilePicksVisible({
+        handle: 'me',
+        isSelf: true,
+        followersEnabled: false,
+        followedHandles: followed,
+      })
+    ).toBe(false);
+    expect(
+      profilePicksVisible({
+        handle: 'me',
+        isSelf: true,
+        followersEnabled: true,
+        followedHandles: followed,
+      })
+    ).toBe(true);
+  });
+
+  it('is false with no profile open', () => {
+    expect(profilePicksVisible({ handle: null, followedHandles: followed })).toBe(false);
+  });
+});
+
+describe('followButtonState', () => {
+  it('offers nothing on your own profile', () => {
+    expect(followButtonState({ isSelf: true, signedIn: true, socialReady: true })).toBe('none');
+  });
+
+  it('asks a signed-out visitor to sign in', () => {
+    expect(followButtonState({ isSelf: false, signedIn: false })).toBe('signin');
+  });
+
+  it('waits for the graph snapshot before offering an action', () => {
+    expect(followButtonState({ isSelf: false, signedIn: true, socialReady: false })).toBe('loading');
+  });
+
+  it('reflects the edge state once known', () => {
+    const base = { isSelf: false, signedIn: true, socialReady: true };
+    expect(followButtonState({ ...base, followState: 'active' })).toBe('following');
+    expect(followButtonState({ ...base, followState: 'requested' })).toBe('requested');
+    expect(followButtonState({ ...base, followState: null })).toBe('follow');
+  });
+});
+
+describe('profileEmptyMessage', () => {
+  it('names pick-sharing on your own un-armed profile (there it is actionable)', () => {
+    expect(profileEmptyMessage({ isSelf: true, sharingOff: true })).toBe(
+      "Your followers see nothing here — you haven't turned on pick-sharing yet."
+    );
+  });
+
+  it('says your armed-but-empty profile shows followers an empty schedule', () => {
+    expect(profileEmptyMessage({ isSelf: true, sharingOff: false })).toBe(
+      "You haven't picked any events yet — your followers see an empty schedule."
+    );
+  });
+
+  it('never names pick-sharing to a follower — the viewer cannot act on it', () => {
+    const msg = profileEmptyMessage({ isSelf: false, followState: 'active', signedIn: true });
+    expect(msg).toBe("No picks to show — they haven't shared any yet.");
+    expect(msg).not.toMatch(/sharing/i);
+  });
+
+  it('explains a pending request', () => {
+    expect(profileEmptyMessage({ isSelf: false, followState: 'requested', signedIn: true })).toBe(
+      'Their account is private — once they approve your request, their picks show up here.'
+    );
+  });
+
+  it('tells a signed-in non-follower what following unlocks', () => {
+    expect(profileEmptyMessage({ isSelf: false, followState: null, signedIn: true })).toBe(
+      'Follow to see the events they picked and the extras they share with followers.'
+    );
+  });
+
+  it('tells a signed-out visitor to sign in first', () => {
+    expect(profileEmptyMessage({ isSelf: false, followState: null, signedIn: false })).toBe(
+      'Sign in and follow to see the events they picked and the extras they share.'
+    );
+  });
+});
+
+describe('armPath', () => {
+  it('routes a first-ever arm through the platform consent matrix', () => {
+    expect(armPath({ disarmed: false, canSetVisibility: true })).toBe('consent');
+  });
+
+  it('re-arms a session-disarmed viewer with a plain level flip (already consented)', () => {
+    expect(armPath({ disarmed: true, canSetVisibility: true })).toBe('level');
+  });
+
+  it('falls back to consent when the runtime has no visibility setter', () => {
+    expect(armPath({ disarmed: true, canSetVisibility: false })).toBe('consent');
+  });
+});

--- a/examples/pickathon-picker/styles.js
+++ b/examples/pickathon-picker/styles.js
@@ -9,13 +9,9 @@ export const c = {
   navBg: 'bg-[#71AD44] dark:bg-[#1d3015]',
   bodyText: 'text-[#4A4A4A] dark:text-[#e9e9e9]',
   border: '',
-  pinkBg: 'bg-[#CD6C0C]',
-  eventCard: 'bg-[#BACD32] dark:bg-[#2c3510] rounded-[16px] m-0.5 p-2 shadow-lg',
-  favCard: 'bg-[#71AD44] dark:bg-[#1d3015] rounded-[16px] m-0.5 p-2 shadow-lg',
   shiftCard: 'bg-[#71AD44] dark:bg-[#1d3015] rounded-[16px] m-0.5 p-2',
   schedDay: 'mb-1.5 bg-[#71AD44] dark:bg-[#1d3015] rounded-2xl m-0.5 p-2',
   schedShift: 'rounded-[12px] m-0.5 p-[7px] bg-[#BACD32] dark:bg-[#2c3510]',
-  schedEvent: 'rounded-[12px] m-0.5 p-[7px] bg-white dark:bg-[#22252d]',
   input:
     'p-[7px] m-0.5 rounded-xl font-bold text-[#4A4A4A] dark:text-[#e9e9e9] bg-white dark:bg-[#22252d]',
   navBtn: (active) =>
@@ -24,16 +20,31 @@ export const c = {
     'bg-[#CD6C0C] text-white font-bold py-[7px] px-2.5 rounded-2xl m-0.5 hover:opacity-90 transition-all',
   btnCyan:
     'bg-[#71AD44] dark:bg-[#1d3015] text-white font-bold py-[7px] px-2.5 rounded-2xl m-0.5 hover:opacity-90 transition-all',
-  // Same button, in-flight: color-only cue (orange) while the write lands. Copy is unchanged.
-  btnCyanWorking:
-    'bg-[#CD6C0C] text-white font-bold py-[7px] px-2.5 rounded-2xl m-0.5 opacity-90 transition-all cursor-wait',
+  // Understated reverser (turn pick-sharing back off). Deliberately not a button
+  // shape: undoing a share you chose should be findable, never a competing CTA.
+  quietLink: (busy) =>
+    `text-sm font-bold underline underline-offset-2 opacity-70 hover:opacity-100 transition-all text-[#4A4A4A] dark:text-[#e9e9e9] ${busy ? 'opacity-40 cursor-wait' : ''}`,
+  // In-flight state for any action button: grey + desaturated + wait cursor, so it
+  // reads as "working" rather than a hover effect (hover is opacity-only).
+  btnWorking:
+    'bg-[#8b9083] text-white/85 font-bold py-[7px] px-2.5 rounded-2xl m-0.5 saturate-50 transition-all cursor-wait',
   badge: 'bg-[#CD6C0C] text-white px-[3px] py-[1px] rounded-full text-sm font-bold m-0.5',
+  // Load shedding (loadshed.js): appended to a write control that is temporarily
+  // INERT rather than hidden — your pick state must stay legible even while you
+  // can't change it. Same vocabulary as btnWorking (desaturate + a cursor that
+  // says "not now"), so it reads as a state of the app, not a broken button.
+  shedInert: 'opacity-60 saturate-50 cursor-not-allowed',
   favToggleOn:
     'p-[7px] rounded-2xl m-0.5 font-bold transition-all bg-[#CD6C0C] text-white hover:opacity-90',
   favToggleOff:
     'p-[7px] rounded-2xl m-0.5 font-bold transition-all bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#BACD32] dark:hover:bg-[#2c3510]',
   linkBtn:
     'p-[7px] bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] rounded-2xl m-0.5 hover:bg-[#BACD32] dark:hover:bg-[#2c3510] transition-all',
+  // Same mark as linkBtn, but no pill: on a card that already carries a round
+  // heart button, a second circle reads as a second toggle. Plain text color on
+  // transparent so the artist link reads as a link, not a control.
+  linkPlain:
+    'p-[7px] bg-transparent text-[#4A4A4A] dark:text-[#e9e9e9] m-0.5 hover:opacity-70 transition-all',
   noteArea:
     'w-full p-1.5 m-0.5 rounded-[4px] resize-none text-[16px] text-[#4A4A4A] dark:text-[#e9e9e9] bg-transparent border border-[#4A4A4A]/40 dark:border-[#e9e9e9]/30',
   deleteBtn: 'p-[7px] bg-[#B22222] text-white rounded-2xl m-0.5 hover:opacity-80 transition-all',
@@ -41,7 +52,6 @@ export const c = {
     `px-0.5 py-[1px] rounded-full m-0.5 text-xs font-bold transition-all ${pending ? 'bg-[#B22222] text-white' : 'bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] hover:bg-[#B22222] hover:text-white'}`,
   noteBox: 'mt-0.5 p-1.5 bg-white dark:bg-[#22252d] rounded-lg m-0.5',
   shiftForm: 'bg-[#BACD32] dark:bg-[#2c3510] rounded-2xl m-0.5 p-2.5 mb-1.5',
-  spinner: 'w-4 h-4 m-0.5 rounded-full animate-spin',
   readOnlyBanner:
     'mt-0.5 bg-white dark:bg-[#22252d] text-[#4A4A4A] dark:text-[#e9e9e9] px-[7px] py-1.5 rounded-lg text-sm font-bold m-0.5',
   // Callout at the bottom-left, locked to the Vibes switch height (60px, 28px up
@@ -64,14 +74,3 @@ export const lineupTag = (event) => {
 export const eventCardStyle = (event) => ({ '--lineup': event.lineup?.color || '#d7c57d' });
 export const eventCardBg =
   'bg-[var(--lineup)] dark:bg-[color-mix(in_oklab,var(--lineup)_36%,#14161b)]';
-
-export const viewerTagStyle = {
-  '--accent': '#CD6C0C',
-  '--accent-text': '#fff',
-  '--card-bg': 'rgba(255,255,255,0.85)',
-  '--border': '#4A4A4A',
-  '--text': '#4A4A4A',
-  borderRadius: 999,
-  fontWeight: 700,
-  fontSize: 16,
-};

--- a/examples/pickathon-picker/url-state.js
+++ b/examples/pickathon-picker/url-state.js
@@ -1,0 +1,94 @@
+// Deep-link / address-bar state. Extracted from App.jsx so it can be tested without a
+// browser: every function takes the window to act on, defaulting to the real one.
+//
+// A profile link arrives as `#friend=<handle>` on the vibes.diy URL (hash keeps the
+// platform HTML cache warm — query params bypass it and pay full SSR every visit).
+// The platform forwards the host hash into the iframe and mirrors our replaceState
+// back to the address bar, which makes the fragment ordinary shareable navigation
+// state, not a one-time secret: it names whose PROFILE is open, so it stays in the
+// URL while the profile is up and is removed when it closes. Copying the address bar
+// re-shares a profile view, which is exactly what the QR does. `?friend=` is kept as
+// a fallback for QR codes printed before the hash migration.
+const defaultWindow = () => (typeof window === 'undefined' ? undefined : window);
+
+// Hash first, then this frame's query, then the host frame (cross-origin in
+// production, so that last read usually throws and is deliberately swallowed).
+export const readFriendParam = (win = defaultWindow()) => {
+  if (!win) return null;
+  try {
+    const fromHash = new URLSearchParams((win.location.hash || '').slice(1)).get('friend');
+    if (fromHash) return fromHash;
+    const own = new URLSearchParams(win.location.search).get('friend');
+    if (own) return own;
+  } catch (e) {}
+  try {
+    if (win.top && win.top !== win) {
+      const t = win.top.location;
+      return (
+        new URLSearchParams((t.hash || '').slice(1)).get('friend') ||
+        new URLSearchParams(t.search).get('friend')
+      );
+    }
+  } catch (e) {}
+  return null;
+};
+
+// Mirror the open profile into the URL (`handle`), or clear it (`null`). Always drops
+// the legacy `?friend=` query so a QR printed before the hash migration lands the
+// visitor on the canonical hash form — what they copy is what we want re-shared.
+// Other hash params (e.g. `super=1`) are preserved.
+export const writeFriendParamToUrl = (handle, win = defaultWindow()) => {
+  if (!win) return;
+  const apply = (loc, hist) => {
+    try {
+      const u = new URL(loc.href);
+      const h = new URLSearchParams((u.hash || '').slice(1));
+      if (handle) h.set('friend', handle);
+      else h.delete('friend');
+      u.searchParams.delete('friend');
+      const hs = h.toString();
+      hist.replaceState(null, '', u.pathname + u.search + (hs ? '#' + hs : ''));
+    } catch (e) {}
+  };
+  // The platform mirrors this replaceState up to the vibes.diy address bar.
+  apply(win.location, win.history);
+  // The parent vibes.diy URL is cross-origin, so this usually no-ops — best effort.
+  try {
+    if (win.top && win.top !== win) apply(win.top.location, win.top.history);
+  } catch (e) {}
+};
+
+// QA scaffolding that ships harmlessly: `#now=2026-07-31T20:00` (or `?now=`) makes the
+// Now tab reason from that instant instead of the wall clock, so the on-site view can be
+// checked (and screenshotted) before the festival starts. Nothing is written, and an end
+// user who sets it only time-travels their own Now tab.
+export const readNowParam = (win = defaultWindow()) => {
+  if (!win) return null;
+  try {
+    const fromHash = new URLSearchParams((win.location.hash || '').slice(1)).get('now');
+    if (fromHash) return fromHash;
+    const own = new URLSearchParams(win.location.search).get('now');
+    if (own) return own;
+  } catch (e) {}
+  return null;
+};
+
+// Super mode is an easter egg, so it reads the HOST url when reachable and falls back
+// to this frame's — the opposite preference order from the friend param, which the
+// platform forwards inward.
+export const readSuperParam = (win = defaultWindow()) => {
+  const on = (loc) =>
+    new URLSearchParams(loc.search).get('super') === '1' ||
+    new URLSearchParams((loc.hash || '').slice(1)).get('super') === '1';
+  if (!win) return false;
+  try {
+    const w = win.top && win.top !== win ? win.top : win;
+    return on(w.location);
+  } catch (e) {
+    try {
+      return on(win.location);
+    } catch (e2) {
+      return false;
+    }
+  }
+};

--- a/examples/pickathon-picker/url-state.test.js
+++ b/examples/pickathon-picker/url-state.test.js
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { readFriendParam, writeFriendParamToUrl, readSuperParam, readNowParam } from './url-state.js';
+
+// A stand-in for window/window.top: enough Location + History surface for the helpers,
+// with replaceState actually rewriting the location so a set→clear round trip is
+// observable. `throws` models the cross-origin frame, where reading .location throws.
+const frame = (href) => {
+  const f = { calls: [] };
+  const set = (h) => {
+    const u = new URL(h, 'https://vibes.diy');
+    f.location = { href: u.href, hash: u.hash, search: u.search, pathname: u.pathname };
+  };
+  set(href);
+  f.history = {
+    replaceState: (_s, _t, url) => {
+      f.calls.push(url);
+      set(new URL(url, f.location.href).href);
+    },
+  };
+  return f;
+};
+
+const win = (href, topHref) => {
+  const w = frame(href);
+  w.top = topHref === undefined ? w : topHref === 'cross-origin' ? crossOrigin() : frame(topHref);
+  return w;
+};
+
+const crossOrigin = () => ({
+  get location() {
+    throw new Error('cross-origin');
+  },
+  get history() {
+    throw new Error('cross-origin');
+  },
+});
+
+describe('readFriendParam', () => {
+  it('reads the hash form', () => {
+    expect(readFriendParam(win('https://vibes.diy/vibe/qa/p#friend=alice'))).toBe('alice');
+  });
+
+  it('falls back to the legacy query form', () => {
+    expect(readFriendParam(win('https://vibes.diy/vibe/qa/p?friend=bob'))).toBe('bob');
+  });
+
+  it('prefers the hash when both are present', () => {
+    expect(readFriendParam(win('https://vibes.diy/p?friend=bob#friend=alice'))).toBe('alice');
+  });
+
+  it('ignores unrelated params', () => {
+    expect(readFriendParam(win('https://vibes.diy/p#super=1'))).toBe(null);
+  });
+
+  it('decodes a percent-encoded handle', () => {
+    expect(readFriendParam(win('https://vibes.diy/p#friend=a%20b'))).toBe('a b');
+  });
+
+  it('falls through to the host frame when this frame has nothing', () => {
+    expect(readFriendParam(win('https://sandbox/app', 'https://vibes.diy/v#friend=carol'))).toBe(
+      'carol'
+    );
+  });
+
+  it('swallows a cross-origin host frame and reports nothing', () => {
+    expect(readFriendParam(win('https://sandbox/app', 'cross-origin'))).toBe(null);
+  });
+
+  it('returns null with no window at all', () => {
+    expect(readFriendParam(undefined)).toBe(null);
+  });
+});
+
+describe('writeFriendParamToUrl', () => {
+  it('sets the hash form', () => {
+    const w = win('https://vibes.diy/vibe/qa/p');
+    writeFriendParamToUrl('alice', w);
+    expect(w.calls.at(-1)).toBe('/vibe/qa/p#friend=alice');
+  });
+
+  it('switches an already-open profile in place', () => {
+    const w = win('https://vibes.diy/vibe/qa/p#friend=alice');
+    writeFriendParamToUrl('bob', w);
+    expect(w.calls.at(-1)).toBe('/vibe/qa/p#friend=bob');
+  });
+
+  it('clears the fragment on close', () => {
+    const w = win('https://vibes.diy/vibe/qa/p#friend=alice');
+    writeFriendParamToUrl(null, w);
+    expect(w.calls.at(-1)).toBe('/vibe/qa/p');
+  });
+
+  it('normalizes the legacy query form to the hash form', () => {
+    const w = win('https://vibes.diy/vibe/qa/p?friend=bob');
+    writeFriendParamToUrl('bob', w);
+    expect(w.calls.at(-1)).toBe('/vibe/qa/p#friend=bob');
+  });
+
+  it('preserves other hash params', () => {
+    const w = win('https://vibes.diy/p#super=1');
+    writeFriendParamToUrl('alice', w);
+    expect(w.calls.at(-1)).toBe('/p#super=1&friend=alice');
+    writeFriendParamToUrl(null, w);
+    expect(w.calls.at(-1)).toBe('/p#super=1');
+  });
+
+  it('preserves other query params', () => {
+    const w = win('https://vibes.diy/p?utm=x');
+    writeFriendParamToUrl('alice', w);
+    expect(w.calls.at(-1)).toBe('/p?utm=x#friend=alice');
+  });
+
+  it('best-efforts the host frame and never throws on a cross-origin one', () => {
+    const w = win('https://sandbox/app', 'cross-origin');
+    expect(() => writeFriendParamToUrl('alice', w)).not.toThrow();
+    expect(w.calls.at(-1)).toBe('/app#friend=alice');
+  });
+
+  it('mirrors into a same-origin host frame too', () => {
+    const w = win('https://vibes.diy/app', 'https://vibes.diy/vibe/qa/p');
+    writeFriendParamToUrl('alice', w);
+    expect(w.top.calls.at(-1)).toBe('/vibe/qa/p#friend=alice');
+  });
+});
+
+// The hash IS the open-profile state, so what the sync callback reads back is what the
+// app shows: present → open/switch, absent → closed.
+describe('hash sync semantics', () => {
+  it('round-trips open → switch → close', () => {
+    const w = win('https://vibes.diy/vibe/qa/p');
+    writeFriendParamToUrl('alice', w);
+    expect(readFriendParam(w)).toBe('alice');
+    writeFriendParamToUrl('bob', w);
+    expect(readFriendParam(w)).toBe('bob');
+    writeFriendParamToUrl(null, w);
+    expect(readFriendParam(w)).toBe(null);
+  });
+});
+
+describe('readSuperParam', () => {
+  it('reads ?super=1 and #super=1', () => {
+    expect(readSuperParam(win('https://vibes.diy/p?super=1'))).toBe(true);
+    expect(readSuperParam(win('https://vibes.diy/p#super=1'))).toBe(true);
+  });
+
+  it('is off for any other value', () => {
+    expect(readSuperParam(win('https://vibes.diy/p?super=true'))).toBe(false);
+    expect(readSuperParam(win('https://vibes.diy/p'))).toBe(false);
+  });
+
+  it('prefers the host frame, and falls back to this one when it is cross-origin', () => {
+    expect(readSuperParam(win('https://sandbox/app', 'https://vibes.diy/v?super=1'))).toBe(true);
+    expect(readSuperParam(win('https://sandbox/app?super=1', 'cross-origin'))).toBe(true);
+  });
+});
+
+describe('readNowParam (QA test clock)', () => {
+  it('reads the hash form', () => {
+    expect(readNowParam(win('https://vibes.diy/p#now=2026-07-31T20:00'))).toBe('2026-07-31T20:00');
+  });
+
+  it('reads the query form', () => {
+    expect(readNowParam(win('https://vibes.diy/p?now=2026-07-31T20:00'))).toBe('2026-07-31T20:00');
+  });
+
+  it('prefers the hash when both are set', () => {
+    expect(readNowParam(win('https://vibes.diy/p?now=2026-07-30T12:00#now=2026-07-31T20:00'))).toBe(
+      '2026-07-31T20:00'
+    );
+  });
+
+  it('is absent by default — no override means the real clock', () => {
+    expect(readNowParam(win('https://vibes.diy/p#friend=alice'))).toBe(null);
+  });
+});


### PR DESCRIPTION
## Why

On the Pickathon picker, the link out to an artist's page on pickathon.com sat inside a white circular button — right next to the round heart button — so on the bands list it read as a second toggle rather than a link. Now is the moment to fix it because the festival opens today and the bands list is the page people scroll most. The fix keeps the same external-link mark but drops the pill: plain body text on a transparent background, which reads as a link and leaves exactly one circular control (the heart) per card.

Two things came along with it, both about the same feeds:

- **All Events** drops the artist link from its list items entirely — one row of chrome per card is enough at that density.
- **Right Now / Up Next** now render the *same* card as All Events. They were a near-copy that had already drifted (no followed-pick chips, no saved notes, no pick counts). The shared shape is extracted into `EventListItem.jsx` so the two feeds can't drift again; `NowView` gets the same feeders the browse list gets.

## Reconciliation with the deployed app

This also brings `examples/pickathon-picker/` back in line with what's actually deployed at `og/pickathon-picker`. The repo copy had drifted well behind prod — several modules the live app ships (`icons.jsx`, `picks.js`, `loadshed.js`, `schedule-build.js`, `social-logic.js`, `url-state.js`, `docs.js`, `ProfileView.jsx`, and their tests) were missing from it entirely. Per the picker runbook, live is the base of truth: the change was made against a `pull --published og/pickathon-picker`, not against this directory, and the diff here is that live source plus the three UI changes above.

## Shipped

The vibe deploy is the ship, and it's already done — staged on `qa/pickathon-picker`, verified in a browser (bands link, All Events, Now), then pushed to `og/pickathon-picker`. This PR is the repo catching up, not the deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALj4cKXreXgoQigDXY7LwR)_