### PR TITLE
Pickathon picker: only prompt to sign in once identity is settled

### DIFF
--- a/examples/pickathon-picker/App.jsx
+++ b/examples/pickathon-picker/App.jsx
@@ -82,7 +82,7 @@ function Logo() {
 }
 
 export default function PickathonPicker() {
-  const { viewer, ViewerTag } = useViewer();
+  const { viewer, ViewerTag, isViewerPending } = useViewer();
   // Optimistic writes + anonymous local writes (with sign-in migration) now come from
   // useFireproof itself: local-first writes with cloud+overlay reads are the default
   // for every vibe (the old `anonymousLocal` flag is deprecated and ignored), and the
@@ -114,6 +114,15 @@ export default function PickathonPicker() {
   const myHandle = viewer?.userHandle || 'anonymous';
   const userId = myHandle;
   const signedIn = Boolean(viewer?.userHandle);
+  // Sign-in prompts are only honest once identity has SETTLED, and "settled" has a
+  // real signal — useViewer().isViewerPending. A published vibe's server render
+  // can't see the Clerk session, so its seed is always anonymous (#3639); the true
+  // identity arrives on the first vibe.evt.viewerChanged, which fires for genuinely
+  // anonymous viewers too and is what clears this flag. Until then we do not know,
+  // and "don't know" must render as silence, never as "logged out" — a viewer who
+  // is signed in (or was, and is being restored) would otherwise be told to sign in.
+  // Unknown may persist for a whole visit; that is a prompt we correctly never show.
+  const settledSignedOut = !isViewerPending && !signedIn;
 
   // Logged-out visitors favorite anonymously (local, migrated on sign-in). Notes/
   // shifts/friends stay signed-in. Gate signed-in writes on the app's own access.js
@@ -945,7 +954,7 @@ export default function PickathonPicker() {
         </div>
       )}
 
-      {!signedIn && (
+      {settledSignedOut && (
         // Full-width bar on mobile that cradles the Vibes switch; on desktop it shrinks
         // and right-justifies next to the logo. The invisible spacer reserves the
         // switch/logo footprint (bottom-right platform chrome) so the text sits to its left.


### PR DESCRIPTION
## Why

The callout at the bottom of the picker — "Sign in via the Vibes DIY logo — followers can see your picks" — was showing to people who are already signed in. It rendered whenever the app had no viewer handle, and "no viewer handle yet" is also what the first second of every page load looks like. Now is the moment because the festival is running and that bar is on screen for everyone. The fix is to say nothing until we actually know: an invitation to sign in is only honest once identity has settled and there is genuinely nobody signed in.

The signal is `useViewer().isViewerPending`. A published vibe's server render can't see the Clerk session, so its seed is always anonymous (#3639); the true identity arrives on the first `vibe.evt.viewerChanged`, which is what clears that flag. Until then the answer is *unknown*, and unknown renders as silence — not as "logged out".

No timer, deliberately: identity can stay unknown for a whole visit, and a stopwatch that eventually decides "must be logged out" would be guessing. A prompt we never show in that case is the correct outcome.

The prompt is still reachable for real anonymous visitors, because the `viewerChanged` event fires for them too. Measured on a deployed build: `isViewerPending` flips false shortly after first paint and the callout follows a moment later (signed out, `og/pickathon-picker`: paints at ~5s, prompt at ~6-7s).

## Not verified here

The signed-in path was not confirmed in a browser — a headless session's cookies don't propagate into the vibe's cross-origin iframe, so the app sees that browser as anonymous regardless. The reasoning above is from the platform's own pending semantics plus the anonymous-side measurement; the "a logged-in visitor is never flashed" check wants a real device.

## Shipped

The vibe deploy is the ship and it's already done — staged on `qa/pickathon-picker`, then pushed to `og/pickathon-picker`. This PR is the repo copy catching up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALj4cKXreXgoQigDXY7LwR)_