### PR TITLE
pickathon-picker: serve the .ics calendar feed from request-time keyed reads

### DIFF
--- a/examples/pickathon-picker/App.jsx
+++ b/examples/pickathon-picker/App.jsx
@@ -43,6 +43,9 @@ import {
   SHED_SOCIAL_LINE,
 } from './loadshed.js';
 import { c } from './styles.js';
+// Side-effectful import: starts the responsiveness sampler at module eval, so the
+// boot window the freeze reports point at is inside its coverage. See perf-probe.js.
+import { markPerf, schedulePerfReports } from './perf-probe.js';
 import ScheduleView from './ScheduleView.jsx';
 import BandsView from './BandsView.jsx';
 import BrowseView from './BrowseView.jsx';
@@ -124,6 +127,19 @@ export default function PickathonPicker() {
   // Unknown may persist for a whole visit; that is a prompt we correctly never show.
   const settledSignedOut = !isViewerPending && !signedIn;
 
+  // Perf probe milestones (temporary diagnostic — perf-probe.js): when identity
+  // settled and when the schedule first had content. Idempotent, write nothing.
+  // `viewerSoft` vs `viewerSettle` is the load-bearing pair: soft = the first
+  // moment ANY handle reached this app (the remembered-identity paint, if it
+  // fired), settle = the authoritative confirmation. soft≈settle means the
+  // remembered-identity cache never painted early for this session.
+  useEffect(() => {
+    if (!isViewerPending) markPerf('viewerSettle');
+  }, [isViewerPending]);
+  useEffect(() => {
+    if (viewer?.userHandle) markPerf('viewerSoft');
+  }, [viewer?.userHandle]);
+
   // Logged-out visitors favorite anonymously (local, migrated on sign-in). Notes/
   // shifts/friends stay signed-in. Gate signed-in writes on the app's own access.js
   // via useVibe().can — the same fn the server runs.
@@ -158,7 +174,7 @@ export default function PickathonPicker() {
   const picksHeld = picksPausedAt(shedLevel);
   const socialHeld = socialPausedAt(shedLevel);
 
-  // Docs-first schedule: the festival schedule is server-maintained. A 1-minute
+  // Docs-first schedule: the festival schedule is server-maintained. A 5-minute
   // `scheduled` tick in backend.js mirrors the pickathon.com feed into public,
   // world-readable `scheduleitem` docs in this same `pickathon` db (access.js).
   // Every client — including anonymous/signed-out — pulls those docs into its
@@ -250,6 +266,23 @@ export default function PickathonPicker() {
   const lastEventsRef = useRef(liveEvents);
   if (liveEvents.length > 0) lastEventsRef.current = liveEvents;
   const events = retainEvents(liveEvents, lastEventsRef.current);
+  useEffect(() => {
+    if (events.length > 0) markPerf('firstEvents');
+  }, [events.length > 0]);
+
+  // Perf probe reports (temporary diagnostic — perf-probe.js): two bounded LWW
+  // writes per signed-in session, skipped while shedding. Shed level rides a ref
+  // so a mid-session flip is honored without rescheduling.
+  const shedLevelRef = useRef(shedLevel);
+  shedLevelRef.current = shedLevel;
+  useEffect(() => {
+    if (!signedIn) return;
+    return schedulePerfReports({
+      database,
+      userId,
+      isHeld: () => shedLevelRef.current !== 'off',
+    });
+  }, [signedIn, userId, database]);
 
   // Writes are refused in the offline cached view — surface a notice instead of
   // crashing or silently eating the tap. Success returns the put/del result, so
@@ -567,9 +600,9 @@ export default function PickathonPicker() {
 
   // The persistent-subscription URL (webcal:// opens the iPhone/macOS Calendar
   // subscribe flow; Google Calendar takes the https form via copy). It carries
-  // ONLY the handle, so it's a LIVE feed: backend.js re-aggregates favorites
-  // from the db every few minutes and re-joins set times against the schedule
-  // feed on each refresh — new picks reach subscribers automatically, and
+  // ONLY the token, so it's a LIVE feed: backend.js reads the token owner's
+  // favorites from the db on every refresh and re-joins set times against the
+  // schedule feed — new picks reach subscribers automatically, and
   // sharing the link lets a friend follow your faves. Signed-in only:
   // anonymous faves live in this browser and never reach the cloud.
   // Offer it only when the feed would actually carry something: favorites, or
@@ -643,7 +676,9 @@ export default function PickathonPicker() {
 
   return (
     <div className={`min-h-screen ${c.pageBg}`} style={{ touchAction: 'manipulation' }}>
-      <div className={`max-w-6xl mx-auto ${c.cardBg} shadow-2xl ${c.border} overflow-hidden`}>
+      {/* No `overflow-hidden` here: any clipping ancestor silently turns the sticky
+          nav below into a normal static bar. */}
+      <div className={`max-w-6xl mx-auto ${c.cardBg} shadow-2xl ${c.border}`}>
         <div className={`${c.headerBg} ${c.border} p-2.5`}>
           <div className="flex items-start justify-between gap-1 flex-wrap">
             <div className="flex items-center gap-1">
@@ -667,7 +702,10 @@ export default function PickathonPicker() {
           </div>
         </div>
 
-        <div className={`${c.navBg} ${c.border} p-2`}>
+        {/* Sticky: the header (logo + dates) scrolls away, the tab bar pins to the top
+            of the viewport so switching views never needs a scroll back up. Opaque
+            background is load-bearing — content scrolls underneath it. */}
+        <div className={`sticky top-0 z-30 ${c.navBg} ${c.border} p-2 shadow-md`}>
           <div className="flex flex-wrap gap-[3px]">
             {['browse', 'bands', 'favorites', 'friends', 'shifts', 'schedule', 'now']
               .filter((v) => {
@@ -819,7 +857,6 @@ export default function PickathonPicker() {
                   favCounts={favCounts}
                   friendPicksByEvent={friendPicksByEvent}
                   ViewerTag={ProfileTag}
-                  nowTick={nowTick}
                   c={c}
                 />
               )}
@@ -1056,8 +1093,16 @@ function ProfileTab({
   );
   const build = (day) =>
     buildDaySchedule(day, profileFavoriteEvents, profileShifts, shiftStartRaw);
+  // Either kind of follower-visible content counts as "arrived" — a profile that
+  // shares only extras is not still-loading.
+  const hasPicks = profileFavoriteEvents.length > 0 || profileShifts.length > 0;
   return (
-    <ProfileView handle={handle} schedule={{ ...schedule, build, shiftStartRaw }} {...rest} />
+    <ProfileView
+      handle={handle}
+      hasPicks={hasPicks}
+      schedule={{ ...schedule, build, shiftStartRaw }}
+      {...rest}
+    />
   );
 }
 
@@ -1088,10 +1133,10 @@ function MyFavesTab({
   const [icsCopied, setIcsCopied] = useState(false);
   // LOCAL MINTING of the calendar capability token: generated client-side the
   // moment the schedule tab opens with subscribable content. The optimistic
-  // write makes it visible to the live query (and the button URL) instantly;
-  // until the backend's ≤1m tick learns it, the endpoint serves the valid
-  // anchor-only calendar, so even an immediate subscribe tap can't fail.
-  // Opt-in: users who never open this tab get no token and no ics aggregate.
+  // write makes it visible to the live query (and the button URL) instantly,
+  // and the endpoint resolves a freshly-minted token on the very next request
+  // (it reads the db per request), so even an immediate subscribe tap works.
+  // Opt-in: users who never open this tab get no token and no feed at all.
   // The token (not the handle) rides the URL — unguessable, revocable.
   const { docs: calTokens } = useLiveQuery(byTypeUser, { key: ['caltoken', userId] });
   const calToken = calTokens[0]?.token || null;

--- a/examples/pickathon-picker/RUNBOOK.md
+++ b/examples/pickathon-picker/RUNBOOK.md
@@ -130,19 +130,22 @@ Notes that cost time if you don't know them:
   same world-readable `schedule` channel as the schedule itself, so every client
   (including anonymous, including offline replicas) sees the level. Write is
   **owner-only** — a stranger able to flip the app read-only would be a griefing vector.
-- **Turn it off with `level:"off"`, not `db del`.** `backend.js` keeps an in-isolate copy
-  so a doc missing from a capped read means "don't know, keep shedding" (§ the 2000-doc
-  cap) rather than "shedding is off". A deleted doc therefore keeps a warm isolate
-  shedding until it is evicted.
-- **The tick keeps its heartbeat and keeps mirroring the schedule** in both shed levels —
-  liveness evidence must survive exactly the hours we are under load, and the 5-minute
-  mirror is a fixed cost, not viewer amplification. Only the ics aggregate is skipped.
+- **`level:"off"` and `db del` both lift it.** The feed reads the doc **by id** on each
+  request, so an absent doc is an authoritative "no shedding". (It was not always: the old
+  capped whole-db read could not tell "deleted" from "sorted off the end", so deletion used
+  to keep a warm isolate shedding. `level:"off"` is still the clearer flip.) A read that
+  *fails* is still "don't know" → the isolate keeps the level it last saw.
+- **The tick does not shed at all.** It no longer touches user data or scales with traffic
+  (two keyed reads and, at most every 5 minutes, one feed fetch), so both its heartbeat and
+  its schedule mirror keep running: liveness evidence must survive exactly the hours we are
+  under load, and the schedule staying fresh is the reason to stay up.
 - **The feed answers 503, not an empty calendar.** Calendar clients back off on a 503 and
   keep the events they already synced; an empty calendar would read as "your picks are
   gone".
-- Client-side effect is immediate (it's a replicated doc); the backend follows within one
-  tick (≤1m). Measured on a probe deploy 2026-07-29: `read-only` produced the 503 within
-  25s, and `level:"off"` restored 200 within 50s.
+- Client-side effect is immediate (it's a replicated doc); the backend follows on the very
+  next feed request, since the switch is read per request rather than cached from a tick.
+  (Measured on the pre-rewrite probe deploy 2026-07-29, when the backend followed a tick
+  behind: `read-only` produced the 503 within 25s, `level:"off"` restored 200 within 50s.)
 - **Run the `db put` as the handle that OWNS the app** (`og` for the live app). Measured:
   a CLI signed in under a different handle gets `Error: owner only` for this doc — and for
   the pre-existing `grant` doc too — and `--admin` does NOT bypass the access function
@@ -159,47 +162,61 @@ The "My Faves" schedule tab offers two things, both served by `backend.js`:
 - **🔁 Subscribe on iPhone** — persistent: a `webcal://…/_api/faves.ics?t=<token>&n=<handle>`
   link (Copy link gives the https form for Google Calendar). The token is a
   per-user random **capability**, auto-minted client-side when the My Faves tab
-  opens (opt-in: no visit → no token → no ics aggregate; `n` is a display-only
-  label because iOS captures the calendar name at subscribe time). Unguessable —
+  opens (opt-in: no visit → no token → no feed; `n` is a display-only label
+  because iOS captures the calendar name at subscribe time — it also lets the
+  backend resolve the token with one keyed read instead of a scan, but it is a
+  hint only: the token in the doc must match the one presented). Unguessable —
   the earlier `?u=<handle>` form invited swapping in someone else's handle — and
   revocable: delete the user's `caltoken` doc and the feed drains. Still a
   **live feed**: new picks flow to subscribers automatically, sharing the link
   lets a friend follow your faves, and set times are re-joined against the live
   pickathon.com schedule feed (platform egress) on every refresh.
 
-Architecture constraint that shapes all of this: calendar clients refresh with
-**anonymous GETs**, and `ctx.db.query` denies anonymous callers outright — and
-denies access-fn-bound dbs on the `fetch` lane regardless (#3085). Only the
-`scheduled` lane (owner, admin mode) can read the `pickathon` db. So `backend.js`
-runs a **1-minute aggregation tick**: handle → {favorite eventIds, shareWithFriends
-shifts} into module-level isolate state, and the GET serves from that cache. All
-three handlers share one isolate per vibe. After an isolate eviction the cache is
-empty until the next tick (≤1m); the GET then serves the **anchor-only calendar**
-(a hard-coded "Gates Open" event rides in every response, so the feed is never
-empty and adding a subscription always validates). A transient schedule-feed
-failure still 502s so established subscribers keep previously-synced events.
+Architecture that shapes all of this: calendar clients refresh with **anonymous
+GETs**, which the read gate denies by default — anonymous outright, and
+access-fn-bound dbs on the `fetch` lane regardless (#3085). `backend.js` opts in
+with `config.fetch.unfilteredReads = { dbs: ["pickathon"], why: … }` (#3650),
+which lifts both denials **for this lane** and hands the authorization job to the
+handler: the `t=` capability token is how it does it. The GET then does its own
+**request-time keyed reads** — `ctx.db.get("caltoken-<n>")` (or a paged
+`field:"token"` lookup when the `n=` hint is absent or wrong) → the owner's
+favorites and shared shifts via one paged `field:"userId"` read → a live join
+against the pickathon.com schedule. A hard-coded "Gates Open" anchor event rides
+in every response, so the feed is never empty and adding a subscription always
+validates; a transient schedule-feed failure still 502s so established
+subscribers keep previously-synced events.
+
+**Superseded (and why):** the GET used to serve from an in-isolate cache built by
+a 1-minute `scheduled` tick that read the whole db, because that lane was the only
+one allowed to read it. Two costs, both real in production: the host caps a scan
+at **2000 docs sorted by `_id`**, silently, so once favorites pushed this db past
+2000 every user sorting after the cut lost picks from their feed (~43% of them);
+and a token minted seconds ago resolved to nothing until the next tick, which iOS
+shows as "Validation failed" at subscribe time. Both are gone — the reads are
+keyed, so they are correct at any db size and current to the second.
 
 Consequences to keep in mind:
 
-- **Freshness:** a new favorite reaches subscription refreshes within ~5 minutes
-  (plus the client's own refresh cadence and the 5-minute shared cache).
-- **Cold-window tradeoff (owner call)**: iOS validates the URL at add time, and a
-  cold-cache 503 there read as "Validation failed" — so cold now serves the valid
-  anchor-only calendar instead. The flip side: an existing subscriber whose
-  refresh lands in the ≤1m post-deploy/post-eviction window sees anchor-only
-  until their next refresh. Rare, self-healing, and subscribe-always-works wins.
+- **Freshness:** a new favorite reaches the next subscription refresh (plus the
+  client's own refresh cadence and the 5-minute shared cache). No tick latency.
+- **Every paged read loops on `next`, never on emptiness.** The host filters
+  *after* cutting the page, so a full page can filter down to zero docs and still
+  carry a cursor — stopping there would silently drop every doc behind it. Pinned
+  by tests in `backend.test.js`.
 - **Privacy:** a feed is reachable only through its random token — nothing is
-  exposed to handle-guessing, and users without a token have no aggregate at
-  all. Notes never leave the db; shifts are included only when
-  `shareWithFriends`.
-- **Scale:** `ctx.db.query` caps at 2000 docs per read. The live db is ~105 docs
-  today; if it ever approaches 2000, the aggregate silently truncates (the cache
-  records `truncated: true`) and this design needs revisiting.
+  exposed to handle-guessing, and a user without a token has no feed at all.
+  Notes are never read into a response; shifts are included only when
+  `shareWithFriends`. Note that `unfilteredReads` is scoped per **lane**, not per
+  route: everything inside `fetch` *could* read this db, so what leaves is
+  decided by `backend.js` alone.
+- **Cost:** one anonymous request costs a shed-switch get, a token lookup and a
+  paged picks read, bounded by `MAX_PAGES`. The `n=` hint keeps the token lookup
+  at one get for every URL the app itself generates.
 
 Remember `backend.js` runs **alone** in its isolate — no relative imports — so its
 timezone helpers are deliberately duplicated from `festival-utils.js`. Its own
 `fetch()` egress calls must use `globalThis.fetch` (bare `fetch` resolves to the
-exported handler). Tests: `backend.test.js` (formatter, aggregation, both lanes)
+exported handler). Tests: `backend.test.js` (formatter, both lanes, the keyed reads)
 and `schedule.test.js` (item flattening).
 
 ## Schedule data (docs-first, offline-ready)
@@ -222,27 +239,25 @@ docs: the diff read "nothing is mirrored" and re-put all ~330 events **every 60
 seconds**, holding the vibe's Durable Object at 97% occupancy so every visitor's
 first page load queued behind it. The fix is that the mirror no longer asks the
 db what it mirrored — it remembers, in `_id: 0-schedule-sync-state` (`type:
-schedulesync`, one content fingerprint per event). That `_id` leads with a
-**digit**, which sorts ahead of every id this app mints (`caltoken-`, `favorite-`,
-`note-`, `schedule-event-`, and the `019f…` uuid shifts), so it rides inside the
-cap at any db size. Owner-only write in `access.js`: the tick trusts it, so a
-forged one could freeze the schedule. An unchanged schedule now costs **zero
-writes**.
+schedulesync`, one content fingerprint per event), which it reads **by id**
+(`ctx.db.get`): one keyed read, the same cost and the same correctness on a
+20-doc db and a 200,000-doc one. Owner-only write in `access.js`: the tick trusts
+it, so a forged one could freeze the schedule. An unchanged schedule costs **zero
+writes**. (The digit-leading `_id` is a fossil of the era before keyed reads,
+when it had to sort ahead of every id the app mints. It is harmless and renaming
+it would strand the live doc, so it stays — but nothing reasons about sort order
+any more.)
 
-That last guarantee covers ids *we* mint, not all possible ids — `_id` is a free
-string, and 2000 docs starting with punctuation (below `0`) would evict even this
-one. Nothing in the app writes such an id; a signed-in stranger could, since the
-unknown-type branch in `access.js` accepts a write from anybody and merely routes
-it to `discard`. So the fingerprints are also held **in isolate memory**
-(`lastFingerprints`), and the tick treats a missing state doc as "use the copy",
-never as "nothing is mirrored". Concluding the latter takes a lost state doc *and*
-a cold isolate, and costs one burst rather than one a minute.
+The fingerprints are ALSO held **in isolate memory** (`lastFingerprints`), because
+"I could not read my state" must never be handled as "nothing is mirrored" — that
+is the reading that reopens the rewrite loop, whatever the read mechanism. Losing
+both the doc and the isolate's memory costs one burst, not one a minute.
 
-> **Watch for:** `pickathon tick: db read hit the 2000-doc query cap` in
-> `wrangler tail`. It is expected today and means the aggregate below is missing
-> the favorites that sort after the cut — those users' `.ics` feeds lose picks.
-> Fixing that needs a filtered or paginated backend read, which the platform
-> does not offer yet.
+> **Closed:** the `pickathon tick: db read hit the 2000-doc query cap` warning is
+> gone with the whole-db read that produced it. The platform's keyed/paginated
+> backend reads (`ctx.db.get`, `ctx.db.query` with `field`+`key`/`keys` and
+> `limit`/`after`) landed, and both the tick and the `.ics` feed now use them —
+> so no read in this app depends on the db being small.
 
 > **Retired:** the per-user `schedulecache` write-through doc
 > (`_id: schedule-cache-{userId}`) and the client-side background feed fetch. It

--- a/examples/pickathon-picker/backend.js
+++ b/examples/pickathon-picker/backend.js
@@ -7,34 +7,70 @@
 //   → 200 text/calendar — the SUBSCRIPTION lane (webcal://). The token is a
 //   per-user RANDOM CAPABILITY (a `caltoken` doc, auto-minted client-side the
 //   first time the user opens their schedule tab — opt-in: no visit, no token,
-//   no ics aggregate). Unlike the earlier handle-keyed URL it is unguessable
+//   no feed at all). Unlike the earlier handle-keyed URL it is unguessable
 //   (a handle in the URL invited swapping in someone else's), shareable on
 //   purpose, and revocable (delete the doc; the feed drains). It is still a
 //   live feed: new picks flow to every subscriber without re-subscribing, and
 //   set times come from a fresh join against the live pickathon.com schedule
 //   feed (platform egress) on every refresh.
 //
-// How the anonymous GET learns a user's favorites: it can't read the db —
-// ctx.db.query denies anonymous callers outright, and denies access-fn-bound
-// dbs on the user-triggerable `fetch` lane regardless (backend-db-callback.ts,
-// #3085). The one lane that CAN read the "pickathon" db is `scheduled` (runs
-// as the owner in admin mode), so a 1-minute tick aggregates
-// handle → {favorite eventIds, friend-shared shifts} into module state, and
-// the GET serves from that in-isolate cache. All three handlers share one
-// isolate per vibe, so the cache is visible across lanes; after an isolate
-// eviction the next tick (≤1m) repopulates it. Until then the GET serves the
-// never-empty anchor-only calendar (see ANCHOR_ITEMS) so ADDING a subscription
-// always validates; a transient feed failure still 502s so established
-// subscribers keep previously-synced events.
+// How the anonymous GET learns a user's favorites: it READS THEM, at request
+// time, with keyed reads. `config.fetch.unfilteredReads` (#3650) declares the
+// one db this feed needs, which lifts both the anonymous deny and the
+// access-fn-bound deny on this lane — so authorization becomes THIS file's job,
+// and the `t=` capability token is how it does it. The reads are keyed and
+// paged (`ctx.db.get` by id; `ctx.db.query` with `field`+`key`/`keys`, `limit`
+// and the `after` cursor — #4398), never a whole-db scan:
 //
-// Privacy: a feed is reachable only through its random token, so nothing is
-// exposed to handle-guessing. Notes never leave the db; shifts are included
-// only with shareWithFriends; users without a token have no aggregate at all.
+//   1. `t=` → the caltoken doc. `n=` (the display hint the client already puts
+//      in the URL) makes that one `ctx.db.get("caltoken-<n>")`; the token in
+//      the doc must equal the token presented, so a wrong or hostile `n` buys
+//      nothing and falls back to a paged `field: "token"` lookup.
+//   2. handle → that user's favorites and shared shifts, one paged
+//      `field: "userId"` read.
+//   3. favorite eventIds → the live pickathon.com schedule, joined per request.
+//
+// This replaced a 1-minute `scheduled` tick that read the WHOLE db, aggregated
+// handle → picks into module state, and had the GET serve from that in-isolate
+// cache. The host caps a scan at 2000 docs sorted by `_id` and says nothing
+// (backend-db-callback.ts); this db passed 2000 during Pickathon 2026 and every
+// favorite sorting after the cut went silently missing from its owner's feed —
+// ~43% of users. The cache also meant a just-minted token served nothing until
+// the next tick, which iOS shows as "Validation failed" at subscribe time.
+// Request-time reads fix both: correct at any db size, and current to the
+// second. The GET is now the only reader of user data.
+//
+// What the `scheduled` tick is still for (and only this): the central schedule
+// MIRROR — one public `scheduleitem` doc per festival event, which is what
+// every client renders from, offline — plus a roughly-hourly liveness
+// heartbeat. Both remember their own state in docs read BY ID, backed by an
+// in-isolate copy; neither reads more than a handful of docs, whatever the db
+// grows to. No user data passes through the tick at all any more, so its
+// cadence dropped from 1m to 5m (the mirror's own interval — a festival
+// schedule does not change every 60 seconds, and a cadence is a standing bill).
+//
+// Privacy is unchanged, and now enforced per request: a feed is reachable only
+// through its random token, so nothing is exposed to handle-guessing. Notes are
+// never read into a response; shifts are included only with shareWithFriends;
+// a user with no token has no feed. The unfilteredReads declaration is scoped
+// per LANE, not per route — every path inside `fetch` can read this db — so the
+// only reads in here are the three above, and the only thing that decides what
+// leaves is this file.
 //
 // This file runs ALONE in the backend isolate — no import resolution — so the
 // few festival-utils timezone helpers it needs are duplicated here on purpose.
 
-export const config = { scheduled: { interval: '1m' } };
+export const PICKATHON_DB = 'pickathon';
+
+export const config = {
+  scheduled: { interval: '5m' },
+  fetch: {
+    unfilteredReads: {
+      dbs: ['pickathon'],
+      why: 'GET /faves.ics?t=<token> is an anonymous calendar-subscription feed: calendar clients present an unguessable per-user capability token, never a session. The handler resolves that token to the handle that owns it and then reads only that handle docs — favorites and shareWithFriends shifts, keyed and paged. Notes and other people docs are never read into a response.',
+    },
+  },
+};
 
 const FESTIVAL_TZ = 'America/Los_Angeles';
 
@@ -238,26 +274,51 @@ const FESTIVAL_DATES = {
   Monday: '2026-08-03',
 };
 
-// The cross-lane cache: written by `scheduled` (the only lane that may read
-// the access-fn-bound db), read by anonymous GETs. Null until the first tick
-// after isolate boot — the GET answers 503 then, never a bogus empty calendar.
-let subCache = null;
-export const __resetSubCacheForTests = () => {
-  subCache = null;
-};
-
 const shiftStartOf = (s) =>
   s.start ??
   (FESTIVAL_DATES[s.day] && s.startTime ? `${FESTIVAL_DATES[s.day]}T${s.startTime}:00` : null);
 const shiftEndOf = (s) =>
   s.end ?? (FESTIVAL_DATES[s.day] && s.endTime ? `${FESTIVAL_DATES[s.day]}T${s.endTime}:00` : null);
 
-// The host caps `ctx.db.query` at this many docs — sorted by `_id`, then cut,
-// with no error and no cursor (backend-db-callback.ts). This db passed the cap
-// during Pickathon 2026, and everything sorting after the cut went invisible to
-// the tick. Nothing here can raise it; code that must survive a large db has to
-// stop depending on reading all of it. See § the mirror's state doc below.
-const BACKEND_QUERY_MAX_DOCS = 2000;
+// ── Reading the db ───────────────────────────────────────────────────────────
+// One page is one round trip to the host, and the host caps a page at 2000 docs
+// however large a `limit` asks for. PAGE_LIMIT trades round trips against the
+// size of the JSON body crossing the isolate boundary; MAX_PAGES bounds the
+// work ONE anonymous request can ask for, because this lane is reachable by
+// anybody with a URL.
+export const PAGE_LIMIT = 500;
+const MAX_PAGES = 40;
+
+// Read every doc matching a keyed query, page by page.
+//
+// The trap this exists to hold: the host filters AFTER cutting the page, so a
+// full page can filter down to ZERO docs and still carry a `next` cursor. A
+// loop that stops when a page comes back empty silently loses every doc behind
+// it — which for this feed means "your picks are gone". Loop on `next`, never
+// on emptiness. `next` is undefined exactly when the page was not full, i.e.
+// when the read is genuinely finished.
+const STOP = Symbol('stop');
+const readAllPages = async (ctx, options, onDocs) => {
+  let after;
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const rows = await ctx.db.query({
+      db: PICKATHON_DB,
+      limit: PAGE_LIMIT,
+      ...options,
+      ...(after === undefined ? {} : { after }),
+    });
+    const docs = Array.isArray(rows) ? rows : (rows && rows.docs) || [];
+    if (onDocs(docs) === STOP) return true;
+    after = rows && rows.next;
+    if (!after) return true;
+  }
+  // Bounded, and loud about it: better a short answer than an unbounded scan
+  // paid for by whoever loads the page behind this one on the same DO.
+  console.warn(
+    `pickathon feed: stopped a paged read after ${MAX_PAGES} pages (${JSON.stringify(options)}).`
+  );
+  return false;
+};
 
 // ── Load shedding ────────────────────────────────────────────────────────────
 // One owner-written config doc (`_id: 0-load-shed`, `level: off|read-only|
@@ -266,27 +327,31 @@ const BACKEND_QUERY_MAX_DOCS = 2000;
 // here on purpose and pinned by loadshed.test.js).
 //
 // What sheds here, and what deliberately does NOT:
-//   · the SUBSCRIPTION lane (GET /faves.ics?t=…) answers 503 + Retry-After.
-//     Calendar clients back off on a 503 and keep the events they already
-//     synced, so this is the one shed with no user-visible damage — an empty
-//     calendar would look like "your picks are gone".
-//   · the aggregate scan in `scheduled` is skipped — nothing reads it while the
-//     GET is 503ing, and while picks are paused it cannot go stale anyway.
-//   · the liveness HEARTBEAT still runs. A shed tick is still a tick that ran,
-//     and it is the only durable evidence of that (#4305) — losing it during the
-//     exact hours we are under load would blind the one alarm we have.
-//   · the 5-minute SCHEDULE MIRROR still runs, in BOTH shed levels. Shedding is
-//     about viewer-driven amplification (per-viewer queries and per-refresh feed
-//     joins), not about a fixed-cost job that runs 12 times an hour regardless of
-//     traffic — and the schedule staying fresh is the whole reason to stay up.
+//   · the SUBSCRIPTION lane (GET /faves.ics?t=…) answers 503 + Retry-After,
+//     BEFORE the token lookup, the picks read and the feed join — shedding the
+//     viewer work is the entire point. Calendar clients back off on a 503 and
+//     keep the events they already synced, so this is the one shed with no
+//     user-visible damage — an empty calendar would look like "your picks are
+//     gone".
+//   · the `scheduled` tick does not shed at all any more. It no longer touches
+//     user data or scales with traffic: it is one keyed read plus, at most every
+//     5 minutes, one feed fetch. The liveness HEARTBEAT keeps beating (a shed
+//     tick is still a tick that ran, and that doc is the only durable evidence
+//     of it — #4305), and the SCHEDULE MIRROR keeps running, because the
+//     schedule staying fresh is the whole reason to stay up.
 //
-// The level is remembered in the isolate as well as read from the doc, for the
-// §4a reason: a doc missing from a capped read means "don't know" → keep the
-// level we last saw, never "shedding is off" (that reading would re-open the
-// load spike the switch was flipped for). To turn shedding OFF, put `level:
-// "off"` — do not delete the doc, or a warm isolate keeps shedding.
-// A cold isolate that has never seen the doc fails OPEN: the `fetch` lane cannot
-// read the db at all, so normal service is the only safe default.
+// The GET reads the switch itself, by id, on each request — so flipping it takes
+// effect on the next request rather than after the next tick. Two readings of
+// "no level", and they are NOT the same:
+//   · the read came back EMPTY — a keyed get is authoritative about absence, so
+//     a deleted doc means shedding is off. (The old capped-scan design could not
+//     tell "deleted" from "sorted off the end", which is why it had to keep
+//     shedding and why the runbook said never to delete the doc.)
+//   · the read FAILED — that is "don't know", so keep the level this isolate
+//     last saw. Never "shedding is off": that reading would re-open the very
+//     load spike the switch was flipped for (§4a).
+// An isolate that has never seen the doc and cannot read it fails OPEN — normal
+// service is the only safe default for a switch we cannot see.
 export const LOADSHED_ID = '0-load-shed';
 export const LOADSHED_TYPE = 'loadshed';
 export const SHED_OFF = 'off';
@@ -308,116 +373,58 @@ const parseShedLevel = (doc) => {
   return SHED_LEVELS.includes(raw) ? raw : SHED_OFF;
 };
 
-// Read the level out of the tick's EXISTING whole-db read (the doc's
-// digit-leading `_id` sorts ahead of every id this app mints, so it rides inside
-// the query cap — no extra query), and remember it.
-export const readShedLevel = (docs) => {
-  const doc = (docs || []).find((d) => d && d._id === LOADSHED_ID);
-  if (doc) {
-    shedLevel = parseShedLevel(doc);
+// Read the switch by id — one `ctx.db.get`, no scan, current as of this request
+// — and remember it. See § Load shedding for why an empty read and a failed read
+// give different answers.
+export const readShedLevel = async (ctx) => {
+  if (!ctx || !ctx.db || typeof ctx.db.get !== 'function') return shedLevel ?? SHED_OFF;
+  try {
+    const doc = await ctx.db.get(LOADSHED_ID, { db: PICKATHON_DB });
+    shedLevel = doc ? parseShedLevel(doc) : SHED_OFF;
     return shedLevel;
-  }
-  if (shedLevel !== null && shedLevel !== SHED_OFF) {
+  } catch (err) {
     console.warn(
-      `pickathon tick: ${LOADSHED_ID} missing from the db read — keeping the in-isolate level ` +
-        `"${shedLevel}". Put level:"off" to lift shedding; deleting the doc does not.`
+      `pickathon feed: could not read ${LOADSHED_ID} (${String((err && err.message) || err)}) — ` +
+        `keeping the in-isolate level "${shedLevel ?? SHED_OFF}".`
     );
-    return shedLevel;
+    return shedLevel ?? SHED_OFF;
   }
-  shedLevel = shedLevel ?? SHED_OFF;
-  return shedLevel;
 };
 
-// Whether a level pauses writes/viewer amplification. `null` (this isolate has
-// never seen the doc) and `off` both read as not shedding.
+// Whether a level pauses viewer amplification. `null` (this isolate has never
+// seen the doc) and `off` both read as not shedding.
 const isSheddingLevel = (level) => level === SHED_READ_ONLY || level === SHED_SCHEDULE_ONLY;
-const isShedding = () => isSheddingLevel(shedLevel);
 
-// 1-minute aggregation tick (a short interval keeps the post-deploy/post-eviction cold window — where adding a NEW subscription fails with iOS's "Validation failed" — under a minute). Admin-lane read (unfiltered), so THIS code chooses
-// what becomes link-visible: favorite eventIds always (that's the feature),
-// shifts only when the user marked them shareWithFriends, notes never.
-// The tick is deliberately CHEAP: one read, and — at most every
-// SCHEDULE_SYNC_INTERVAL_MS — one feed fetch. It writes nothing unless the
+// The 5-minute tick. It exists for exactly two jobs, and NEITHER of them
+// touches user data: stamp the liveness heartbeat, and keep the central
+// schedule mirror in step with pickathon.com. There is no aggregate here any
+// more — the `.ics` GET reads what it needs when it is asked (see the header) —
+// so nothing about this tick's cost or correctness depends on how big the db
+// has grown. Both jobs remember their own state in a doc read BY ID, plus an
+// in-isolate copy; the tick reads two docs and, at most every
+// SCHEDULE_SYNC_INTERVAL_MS, fetches the feed. It writes nothing unless the
 // festival schedule actually changed.
 export async function scheduled(event, ctx) {
-  const docs = await ctx.db.query({ db: 'pickathon' });
-  // The shed level rides the read we just did (see § Load shedding). When we are
-  // shedding, skip the aggregate scan entirely — the GET lane is 503ing, so
-  // nothing reads it, and with picks paused it cannot drift either — but still
-  // beat the heartbeat and still run the schedule mirror.
-  if (isSheddingLevel(readShedLevel(docs))) {
-    await writeHeartbeat(event, ctx, docs);
-    await syncScheduleDocs(event, ctx, docs);
-    return;
-  }
-  const users = new Map();
-  const tokens = new Map();
-  const entryFor = (handle) => {
-    const key = String(handle).toLowerCase();
-    if (!users.has(key)) users.set(key, { eventIds: [], shifts: [] });
-    return users.get(key);
-  };
-  for (const d of docs) {
-    if (!d || !d.userId) continue;
-    if (d.type === 'caltoken') {
-      if (typeof d.token === 'string' && /^[A-Za-z0-9_-]{16,64}$/.test(d.token)) {
-        tokens.set(d.token, String(d.userId).toLowerCase());
-      }
-    } else if (d.type === 'favorite' && d.eventId != null) {
-      entryFor(d.userId).eventIds.push(String(d.eventId));
-    } else if (d.type === 'shift' && d.shareWithFriends) {
-      const start = shiftStartOf(d);
-      const end = shiftEndOf(d);
-      if (start && end)
-        entryFor(d.userId).shifts.push([
-          typeof d.kind === 'string' && d.kind.trim() !== '' ? d.kind.trim() : 'Shift',
-          start,
-          end,
-        ]);
-    }
-  }
-  // Opt-in means opt-in: keep aggregates ONLY for handles holding a token —
-  // no ics data is built for users who never opened the calendar surface.
-  const optedIn = new Set(tokens.values());
-  for (const handle of [...users.keys()]) {
-    if (!optedIn.has(handle)) users.delete(handle);
-  }
-  for (const entry of users.values()) {
-    entry.eventIds.sort();
-    entry.shifts.sort((a, b) => (a[1] < b[1] ? -1 : 1));
-  }
-  // A capped read is a SILENT read: the host returns 2000 docs and no signal.
-  // Say so in the log, because the aggregate below is then missing whatever
-  // sorted past the cut (favorites, `_id` "favorite-<handle>-<event>", are the
-  // only growing type and the only ones that can fall off) — those users' .ics
-  // feeds quietly lose picks. Visible in `wrangler tail`.
-  const truncated = docs.length >= BACKEND_QUERY_MAX_DOCS;
-  if (truncated) {
-    console.warn(
-      `pickathon tick: db read hit the ${BACKEND_QUERY_MAX_DOCS}-doc query cap ` +
-        `(last _id "${docs[docs.length - 1]?._id}") — favorites sorting after it are ` +
-        `missing from ics aggregates.`
-    );
-  }
-  subCache = {
-    at: Date.parse(event?.scheduledTime) || Date.now(),
-    users,
-    tokens,
-    truncated,
-  };
-
   // Liveness first: if this tick is alive, say so before anything that can fail.
-  // Passed the docs we already read — the heartbeat picks its own doc out of them
-  // rather than costing a second query.
-  await writeHeartbeat(event, ctx, docs);
-
-  // Central schedule mirror: refresh pickathon.com on its own (slower) cadence
-  // and upsert only the `scheduleitem` docs whose content changed. Clients read
-  // the schedule from these public docs — nobody fetches the feed per-user
-  // anymore. Passed the `docs` we already read so it can pick its state doc out
-  // of them; it never wipes the schedule on a transient feed failure.
-  await syncScheduleDocs(event, ctx, docs);
+  await writeHeartbeat(event, ctx);
+  // Central schedule mirror: refresh pickathon.com on its own cadence and upsert
+  // only the `scheduleitem` docs whose content changed. Clients read the
+  // schedule from these public docs — nobody fetches the feed per-user anymore.
+  // It never wipes the schedule on a transient feed failure.
+  await syncScheduleDocs(event, ctx);
 }
+
+// One doc, by id, tolerating a lane that cannot read (the POST download lane
+// passes no ctx at all) and a read that fails. `null` means "no doc"; `undefined`
+// means "could not tell" — a distinction both callers care about (§4a).
+const getDoc = async (ctx, id) => {
+  if (!ctx || !ctx.db || typeof ctx.db.get !== 'function') return undefined;
+  try {
+    return (await ctx.db.get(id, { db: PICKATHON_DB })) ?? null;
+  } catch (err) {
+    return undefined;
+  }
+};
 
 // ── Tick liveness heartbeat (scheduled lane) ─────────────────────────────────
 // The `scheduled` alarm has gone silently dead twice on unchanged code, and a
@@ -432,13 +439,12 @@ export async function scheduled(event, ctx) {
 // normal: the gate below is in-isolate and best-effort, not a promise.
 //
 // Discipline is the #4293 one. The gate is remembered, never re-derived from a
-// scan: an in-isolate timestamp, backed by the heartbeat doc found in the tick's
-// EXISTING whole-db read (its digit-leading `_id` sorts ahead of every id this
-// app mints, so it rides inside the 2000-doc cap — no extra query). Whichever of
-// the two is newer wins, and a doc missing from a capped read therefore reads as
-// "don't know" rather than "never beat". Only losing BOTH — no doc AND a cold
-// isolate — writes a beat immediately, which is the harmless direction: one
-// extra write per isolate boot, not one per tick.
+// scan: an in-isolate timestamp, backed by the heartbeat doc read BY ID — one
+// keyed `ctx.db.get`, reachable at any db size, with no sort window to fall out
+// of. Whichever of the two is newer wins, and a doc that is missing or
+// unreadable reads as "don't know" rather than "never beat". Only losing BOTH —
+// no doc AND a cold isolate — writes a beat immediately, which is the harmless
+// direction: one extra write per isolate boot, not one per tick.
 //
 // The stamp must CHANGE on every write or the platform dedupes a content-
 // identical re-put invisibly and the doc silently stops tracking liveness —
@@ -451,10 +457,13 @@ export const __resetHeartbeatForTests = () => {
   lastBeatAt = null;
 };
 
-export const writeHeartbeat = async (event, ctx, docs) => {
+export const writeHeartbeat = async (event, ctx) => {
   if (!ctx || !ctx.db || typeof ctx.db.put !== 'function') return null;
   const now = Date.parse(event?.scheduledTime) || Date.now();
-  const doc = (docs || []).find((d) => d && d._id === HEARTBEAT_ID);
+  const doc = await getDoc(ctx, HEARTBEAT_ID);
+  // A missing doc, an unreadable read, and an unparseable stamp all land on NaN,
+  // which the filter below drops — leaving the in-isolate copy to answer, and a
+  // cold isolate with no evidence at all to beat once.
   const docAt = doc ? Date.parse(doc.at) : NaN;
   const known = [lastBeatAt, Number.isFinite(docAt) ? docAt : null].filter((n) => n !== null);
   const last = known.length > 0 ? Math.max(...known) : null;
@@ -500,29 +509,25 @@ export const fetchScheduleItems = async (ids) => {
 //
 // It used to establish "unchanged" by diffing against the `scheduleitem` docs
 // found in the tick's whole-db read. That silently stopped working once the db
-// passed BACKEND_QUERY_MAX_DOCS: `schedule-event-*` sorts after `caltoken-*`,
-// `favorite-*` and `note-*`, so ALL of the mirror fell outside the capped
-// window, the diff saw zero existing items, and every tick re-put every event —
-// ~330 serialized writes a minute, which pinned this vibe's Durable Object at
-// 97% occupancy and left nothing behind them but queueing (a visitor's first
-// page load included).
+// passed the host's 2000-doc query cap: `schedule-event-*` sorts after
+// `caltoken-*`, `favorite-*` and `note-*`, so ALL of the mirror fell outside the
+// capped window, the diff saw zero existing items, and every tick re-put every
+// event — ~330 serialized writes a minute, which pinned this vibe's Durable
+// Object at 97% occupancy and left nothing behind them but queueing (a visitor's
+// first page load included).
 //
-// So the mirror now remembers what it mirrored itself, in ONE state doc: `_id`
-// leads with a DIGIT, which sorts ahead of every letter under both byte and
-// linguistic collation, so it sits in front of every id this app mints
-// (`caltoken-`, `favorite-`, `note-`, `schedule-event-`, and the uuid shifts,
-// whose `019f…` sorts after `0-`) and rides comfortably inside the cap however
-// large the db grows. It carries a content fingerprint per event id — never the
-// schedule itself, which lives in the public docs.
+// So the mirror remembers what it mirrored itself, in ONE state doc, read BY ID
+// (`ctx.db.get`) — no scan, no sort window to fall out of, the same cost on a
+// 20-doc db and a 200,000-doc one. It carries a content fingerprint per event id
+// — never the schedule itself, which lives in the public docs. (The `_id` leads
+// with a digit for historical reasons: that was the old workaround for having no
+// keyed read. It is harmless, and renaming it would strand the live doc, so it
+// stays — but nothing here reasons about sort order any more.)
 //
-// That is a guarantee about ids WE mint, not an absolute one: `_id` is a free
-// string, so 2000 docs beginning with punctuation (below `0`) would push even
-// this doc out of the window. Nothing in the app writes such an id, but a
-// signed-in stranger could — the unknown-type branch in access.js accepts a
-// write from anybody, it just routes it to `discard`. So the state doc is
-// backed up by an in-isolate copy (see lastFingerprints), and losing BOTH is
-// handled as "skip this sync", never as "nothing is mirrored" — the one
-// conclusion that reopens the rewrite loop.
+// The state doc is still backed by an in-isolate copy (see lastFingerprints),
+// because "I could not read my state" must never be handled as "nothing is
+// mirrored" — the one conclusion that reopens the rewrite loop. Losing both is
+// handled as "sync from scratch once per isolate", which is bounded.
 export const SCHEDULE_STATE_ID = '0-schedule-sync-state';
 export const SCHEDULE_STATE_TYPE = 'schedulesync';
 
@@ -663,7 +668,7 @@ export const diffScheduleAgainstState = (feedItems, stateDoc) => {
 // advance the cadence gate — never wipe the schedule on a transient upstream
 // hiccup (the same rule the old client-side fetch followed). Runs only when
 // given a write-capable ctx (admin-mode scheduled lane).
-export const syncScheduleDocs = async (event, ctx, docs) => {
+export const syncScheduleDocs = async (event, ctx) => {
   if (!ctx || !ctx.db || typeof ctx.db.put !== 'function') return null;
   const now = Date.parse(event?.scheduledTime) || Date.now();
   if (lastScheduleSyncAt !== null && now - lastScheduleSyncAt < SCHEDULE_SYNC_INTERVAL_MS) {
@@ -680,15 +685,14 @@ export const syncScheduleDocs = async (event, ctx, docs) => {
   const feedItems = ingestScheduleFeed(data);
   if (feedItems.length === 0) return { ok: false, error: 'empty feed' };
   lastScheduleSyncAt = now;
-  // The durable state doc first; the in-isolate copy is the backstop for the
-  // day it isn't in the read. `_id` is a free string, so enough docs sorting
-  // ahead of `0-` could push it out of the capped window — nothing the app
-  // writes does that, but nothing stops a signed-in stranger either.
-  let stateDoc = (docs || []).find((d) => d && d._id === SCHEDULE_STATE_ID);
+  // The durable state doc first (one keyed read); the in-isolate copy is the
+  // backstop for the day it is gone or unreadable. Either way the fallback is
+  // "use what this isolate remembers", never "nothing is mirrored".
+  let stateDoc = await getDoc(ctx, SCHEDULE_STATE_ID);
   if (!stateDoc && lastFingerprints !== null) {
     console.warn(
-      `pickathon tick: ${SCHEDULE_STATE_ID} missing from the db read — using the in-isolate ` +
-        `copy. If this persists, something is sorting ahead of it inside the query cap.`
+      `pickathon tick: ${SCHEDULE_STATE_ID} came back ${stateDoc === undefined ? 'unreadable' : 'empty'} — ` +
+        `using the in-isolate copy rather than re-mirroring the whole schedule.`
     );
     stateDoc = { fingerprints: lastFingerprints };
   }
@@ -700,7 +704,9 @@ export const syncScheduleDocs = async (event, ctx, docs) => {
     // a brand-new mirror, and the one shape an evicted state doc also takes.
     // Bounded either way — the line above means it can happen once per isolate,
     // not once per tick, which is the whole difference between this and #4293.
-    console.warn(`pickathon tick: no mirror state found — writing all ${puts.length} schedule docs.`);
+    console.warn(
+      `pickathon tick: no mirror state found — writing all ${puts.length} schedule docs.`
+    );
   }
   for (const doc of puts) await ctx.db.put(doc, { db: 'pickathon' });
   for (const _id of deletes) await ctx.db.delete(_id, { db: 'pickathon' });
@@ -801,12 +807,93 @@ const ANCHOR_ITEMS = [
   },
 ];
 
-// Subscription refresh: anonymous GET keyed by user handle. Served inline (no
-// attachment) so calendar clients treat it as a feed; short shared cache so a
-// popular handle doesn't hammer the feed join.
-const handleSubscription = async (url) => {
+// ── Resolving one subscriber, at request time ────────────────────────────────
+
+const TOKEN_RE = /^[A-Za-z0-9_-]{16,64}$/;
+const HANDLE_RE = /^[a-z0-9][a-z0-9_-]{0,39}$/;
+const calTokenDocId = (userId) => `caltoken-${userId}`;
+
+// token → the handle it belongs to, or null.
+//
+// The token is the ONLY capability. `hint` is the `n=` display parameter the
+// client already puts in the subscribe URL; it turns the common case into a
+// single `ctx.db.get` instead of a paged scan, but it is never trusted: the
+// resolved doc's own token has to equal the one presented, so pointing `n=` at
+// somebody else's caltoken resolves nothing. A missing, stale or hostile hint
+// just falls through to the keyed lookup by `token`.
+export const resolveCalToken = async (ctx, token, hint) => {
+  if (!ctx || !ctx.db) return null;
+  const ok = (doc) =>
+    doc && doc.type === 'caltoken' && doc.token === token && doc.userId ? String(doc.userId) : null;
+  if (hint) {
+    const byId = ok(await getDoc(ctx, calTokenDocId(hint)));
+    if (byId !== null) return byId;
+  }
+  if (typeof ctx.db.query !== 'function') return null;
+  let found = null;
+  try {
+    await readAllPages(ctx, { field: 'token', key: token }, (docs) => {
+      for (const d of docs) {
+        found = ok(d);
+        if (found !== null) return STOP;
+      }
+    });
+  } catch (err) {
+    return null;
+  }
+  return found;
+};
+
+// Everything of one user's that may leave the db: favorite event ids, and shifts
+// they explicitly marked shareWithFriends. One paged keyed read on `userId`.
+//
+// Notes come back in this read (they carry a userId too) and are dropped right
+// here — the type check below is the privacy boundary, and it is deliberately a
+// whitelist: an unknown doc type contributes nothing to a feed.
+//
+// The handle is matched case-insensitively the way the old aggregate did, by
+// asking for both spellings: docs written before handles were normalized carry
+// mixed case, and a user whose caltoken says "Alice" still owns "favorite-alice-*".
+export const readUserPicks = async (ctx, handle) => {
+  const entry = { eventIds: [], shifts: [] };
+  if (!ctx || !ctx.db || typeof ctx.db.query !== 'function') return entry;
+  const keys = [...new Set([handle, handle.toLowerCase()])];
+  try {
+    await readAllPages(ctx, { field: 'userId', keys }, (docs) => {
+      for (const d of docs) {
+        if (!d) continue;
+        if (d.type === 'favorite' && d.eventId != null) {
+          entry.eventIds.push(String(d.eventId));
+        } else if (d.type === 'shift' && d.shareWithFriends) {
+          const start = shiftStartOf(d);
+          const end = shiftEndOf(d);
+          if (start && end)
+            entry.shifts.push([
+              typeof d.kind === 'string' && d.kind.trim() !== '' ? d.kind.trim() : 'Shift',
+              start,
+              end,
+            ]);
+        }
+      }
+    });
+  } catch (err) {
+    // A read that fails mid-way leaves a PARTIAL entry, which would silently
+    // drop picks. Answer with nothing instead: the response then degrades to the
+    // anchor calendar, and the next refresh (minutes away) tries again.
+    console.warn(`pickathon feed: picks read failed — ${String((err && err.message) || err)}`);
+    return { eventIds: [], shifts: [] };
+  }
+  entry.eventIds.sort();
+  entry.shifts.sort((a, b) => (a[1] < b[1] ? -1 : 1));
+  return entry;
+};
+
+// Subscription refresh: anonymous GET, authorized by the capability token in the
+// URL. Served inline (no attachment) so calendar clients treat it as a feed;
+// short shared cache so a popular feed doesn't hammer the schedule join.
+const handleSubscription = async (url, ctx) => {
   const t = url.searchParams.get('t') ?? '';
-  if (!/^[A-Za-z0-9_-]{16,64}$/.test(t)) {
+  if (!TOKEN_RE.test(t)) {
     return textResponse(
       400,
       "pass t=<calendar token> — open the app's My Faves tab to get your link"
@@ -817,7 +904,7 @@ const handleSubscription = async (url) => {
   // the one honest answer here — calendar clients back off and keep the events
   // they already synced, where an empty calendar would read as "your picks are
   // gone". Never cached: the shed can lift at any tick.
-  if (isShedding()) {
+  if (isSheddingLevel(await readShedLevel(ctx))) {
     return textResponse(
       503,
       'Festival mode: this calendar feed is paused for a little while. Your picks are safe — ' +
@@ -825,21 +912,21 @@ const handleSubscription = async (url) => {
       { 'retry-after': String(SHED_RETRY_AFTER_SECONDS), 'cache-control': 'no-store' }
     );
   }
-  // Display-only label: iOS captures the calendar NAME at subscribe time, and
-  // a just-minted token often beats the tick — without this the calendar is
-  // permanently named "@my". The token alone gates data; `n` labels it.
+  // Display-only label AND the lookup hint: iOS captures the calendar NAME at
+  // subscribe time, so a feed that cannot name itself is permanently "@my". The
+  // token alone gates data; `n` only labels it (and saves a scan — see
+  // resolveCalToken).
   const nRaw = (url.searchParams.get('n') ?? '').toLowerCase();
-  const displayName = /^[a-z0-9][a-z0-9_-]{0,39}$/.test(nRaw) ? nRaw : null;
-  // Cold cache (freshly booted isolate) AND unknown tokens serve the
-  // anchor-only calendar rather than an error, so ADDING a subscription always
-  // works — a just-minted token can beat the next tick, and iOS renders any
-  // add-time failure as "Validation failed". A revoked token converges to the
-  // same anchor-only feed. Tradeoff (owner call): a subscriber whose refresh
-  // lands in the ≤1m cold window sees anchor-only until their next refresh —
-  // rare and self-healing, vs. a guaranteed add-time failure after deploys.
-  const cold = subCache === null;
-  const handle = cold ? undefined : subCache.tokens.get(t);
-  const entry = (handle && subCache.users.get(handle)) || { eventIds: [], shifts: [] };
+  const displayName = HANDLE_RE.test(nRaw) ? nRaw : null;
+  // A token that resolves to nobody — never minted, revoked, or simply
+  // unreadable because this lane could not reach the db — serves the anchor-only
+  // calendar rather than an error, so ADDING a subscription always works: iOS
+  // renders any add-time failure as "Validation failed". A revoked token
+  // converges to the same anchor-only feed as its owner's picks drain away.
+  const resolved = await resolveCalToken(ctx, t, displayName);
+  const handle = resolved === null ? undefined : resolved.toLowerCase();
+  const entry =
+    resolved === null ? { eventIds: [], shifts: [] } : await readUserPicks(ctx, resolved);
   let eventItems = [];
   if (entry.eventIds.length > 0) {
     try {
@@ -854,10 +941,10 @@ const handleSubscription = async (url) => {
     start: r[1],
     end: r[2],
   }));
-  // LENIENT per-item validation: these rows come from the db aggregate and the
-  // schedule feed — sources the subscriber doesn't control — so a malformed
-  // legacy row drops out instead of 400ing the whole feed. A user with no
-  // (valid) faves gets an EMPTY calendar, not an error.
+  // LENIENT per-item validation: these rows come from the db and the schedule
+  // feed — sources the subscriber doesn't control — so a malformed legacy row
+  // drops out instead of 400ing the whole feed. A user with no (valid) faves
+  // gets the anchor calendar, not an error.
   const items = sanitizeFavesItems([...ANCHOR_ITEMS, ...eventItems, ...shiftRows]).slice(
     0,
     MAX_ITEMS
@@ -868,9 +955,10 @@ const handleSubscription = async (url) => {
       status: 200,
       headers: {
         'content-type': 'text/calendar; charset=utf-8',
-        // A cold/unresolved (anchor-only) response must not linger in any shared
-        // cache past the tick that fills the real data.
-        'cache-control': cold || !handle ? 'no-store' : 'public, max-age=300',
+        // An unresolved (anchor-only) response must not linger in any shared
+        // cache: the token may be seconds old, or the db momentarily unreadable,
+        // and the next request would otherwise be served the placeholder.
+        'cache-control': handle ? 'public, max-age=300' : 'no-store',
       },
     }
   );
@@ -886,7 +974,7 @@ export async function fetch(request, ctx) {
     );
   }
   if (request.method === 'GET' || request.method === 'HEAD') {
-    return handleSubscription(url);
+    return handleSubscription(url, ctx);
   }
   if (request.method !== 'POST') {
     return textResponse(405, 'method not allowed — GET a subscription or POST schedule items', {

--- a/examples/pickathon-picker/backend.test.js
+++ b/examples/pickathon-picker/backend.test.js
@@ -7,7 +7,9 @@ import {
   buildFavesCalendar,
   decodeFeedEntities,
   scheduled,
-  __resetSubCacheForTests,
+  config,
+  PICKATHON_DB,
+  PAGE_LIMIT,
   __resetScheduleSyncForTests,
   __resetHeartbeatForTests,
   __resetShedForTests,
@@ -288,8 +290,9 @@ describe('decodeFeedEntities', () => {
   });
 });
 
-// The db docs the scheduled aggregation tick sees (admin-lane read of the
-// access-fn-bound db — the one lane allowed to read it).
+// The docs in the `pickathon` db. Both lanes read them now: the `fetch` lane by
+// keyed request-time reads (config.fetch.unfilteredReads), the `scheduled` lane
+// by id for its own state docs.
 const DB_DOCS = [
   { _id: 'favorite-Alice-101', type: 'favorite', userId: 'Alice', eventId: 101 },
   { _id: 'favorite-alice-201', type: 'favorite', userId: 'alice', eventId: '201' },
@@ -340,12 +343,93 @@ const DB_DOCS = [
 ];
 const T_ALICE = 'alice-token-1234567890A';
 const T_BOB = 'bob-token-1234567890BBB';
-const tick = () =>
-  scheduled({ scheduledTime: '2026-07-04T12:00:00Z' }, { db: { query: async () => DB_DOCS } });
 
-describe('fetch handler — GET /faves.ics?u=<handle> (subscription lane)', () => {
+// A faithful stand-in for the host's `ctx.db` (#4398): `get` by id, and `query`
+// that pages by `_id` with `limit`/`after` and applies `field`+`key`/`keys`
+// AFTER the page is cut — which is what makes an empty page with a live `next`
+// possible, the trap the read loops have to survive. The result is an Array with
+// non-enumerable `next`/`docs` riding along, exactly like the isolate shim.
+const mkStore = (docs = []) => {
+  const store = new Map(docs.map((d) => [d._id, d]));
+  const puts = [];
+  const deletes = [];
+  const queries = [];
+  const gets = [];
+  let getFails = null;
+  const enc = (v) => JSON.stringify(v ?? null);
+  return {
+    puts,
+    deletes,
+    queries,
+    gets,
+    store,
+    setDocs: (list) => {
+      store.clear();
+      for (const d of list) store.set(d._id, d);
+    },
+    failGets: (err) => {
+      getFails = err;
+    },
+    db: {
+      get: async (id, options) => {
+        gets.push({ id, options });
+        if (getFails) throw getFails;
+        const d = store.get(id);
+        return d ? { ...d } : null;
+      },
+      query: async (options = {}) => {
+        queries.push(options);
+        const all = [...store.values()].sort((a, b) =>
+          a._id < b._id ? -1 : a._id > b._id ? 1 : 0
+        );
+        const limit = Math.max(1, Math.min(options.limit ?? 2000, 2000));
+        const start =
+          typeof options.after === 'string' ? all.findIndex((d) => d._id > options.after) : 0;
+        const page = start === -1 ? [] : all.slice(start, start + limit);
+        const next = page.length === limit ? page[page.length - 1]._id : undefined;
+        let out = page;
+        if (options.field !== undefined) {
+          out = out.filter((d) => d[options.field] !== undefined);
+          if (options.key !== undefined)
+            out = out.filter((d) => enc(d[options.field]) === enc(options.key));
+          if (options.keys !== undefined)
+            out = out.filter((d) => options.keys.some((k) => enc(d[options.field]) === enc(k)));
+        }
+        const res = out.map((d) => ({ ...d }));
+        Object.defineProperty(res, 'next', { value: next, enumerable: false });
+        Object.defineProperty(res, 'docs', { value: res, enumerable: false });
+        return res;
+      },
+      put: async (doc) => {
+        puts.push(doc);
+        store.set(doc._id, doc);
+        return doc._id;
+      },
+      delete: async (id) => {
+        deletes.push(id);
+        store.delete(id);
+        return id;
+      },
+    },
+  };
+};
+const ctxOf = (docs = []) => {
+  const s = mkStore(docs);
+  return { ...s, ctx: { db: s.db } };
+};
+
+describe('config — the fetch lane declares its unfiltered reads', () => {
+  it('names the db the feed needs, with an honest why', () => {
+    // Without this declaration the anonymous GET cannot read the db at all, and
+    // the feed is back to being served from a tick-populated cache.
+    expect(config.fetch.unfilteredReads.dbs).toEqual([PICKATHON_DB]);
+    expect(typeof config.fetch.unfilteredReads.why).toBe('string');
+    expect(config.fetch.unfilteredReads.why.length).toBeGreaterThan(20);
+  });
+});
+
+describe('fetch handler — GET /faves.ics?t=<token> (subscription lane)', () => {
   beforeEach(() => {
-    __resetSubCacheForTests();
     __resetShedForTests();
   });
   afterEach(() => vi.unstubAllGlobals());
@@ -355,26 +439,14 @@ describe('fetch handler — GET /faves.ics?u=<handle> (subscription lane)', () =
     return spy;
   };
 
-  it('serves the never-empty anchor-only calendar before the first aggregation tick', async () => {
-    // iOS validates a NEW subscription by fetching at add time — a cold-cache
-    // error there reads as "Validation failed", so cold must serve a valid,
-    // non-empty calendar (owner call; anchor-only until the ≤1m tick).
-    feedOk();
-    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
-    expect(res.status).toBe(200);
-    expect(res.headers.get('cache-control')).toBe('no-store'); // don't pin the skeleton
-    const body = await res.text();
-    expect(body).toContain('SUMMARY:Gates Open');
-    expect(body).not.toContain('Built to Spill'); // faves arrive with the tick
-  });
-
-  it("serves a user's CURRENT faves: db-aggregated ids joined live against the feed", async () => {
+  it("serves a user's CURRENT faves: keyed request-time reads joined live against the feed", async () => {
     const fetchSpy = feedOk();
-    await tick();
-    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    const { ctx } = ctxOf(DB_DOCS);
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), ctx);
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toBe('text/calendar; charset=utf-8');
     expect(res.headers.get('content-disposition')).toBe(null); // a feed, not a download
+    expect(res.headers.get('cache-control')).toBe('public, max-age=300');
     const body = await res.text();
     expect(fetchSpy).toHaveBeenCalledWith(SCHEDULE_URL, expect.anything());
     expect(body).toContain('SUMMARY:Built to Spill'); // alice faved 101 (case-folded handle)
@@ -391,60 +463,192 @@ describe('fetch handler — GET /faves.ics?u=<handle> (subscription lane)', () =
     expect(body).toContain('REFRESH-INTERVAL;VALUE=DURATION:PT6H');
   });
 
-  it('serves fave-less holders and pre-tick tokens alike: valid anchor-only, never an error', async () => {
+  it('serves a just-minted token immediately — no tick to wait for', async () => {
+    // The whole point of the rewrite: a token written a second ago resolves on
+    // the very next request, where the cached design served anchor-only until
+    // the next tick (and iOS renders an add-time miss as "Validation failed").
     feedOk();
-    await tick();
-    const res = await icsFetch(req('/faves.ics?t=freshly-minted-token-000&n=jchris'), {});
+    const fresh = {
+      _id: 'caltoken-carol',
+      type: 'caltoken',
+      userId: 'carol',
+      token: 'carol-token-1234567890CC',
+    };
+    const { ctx } = ctxOf([
+      ...DB_DOCS,
+      fresh,
+      { _id: 'favorite-carol-102', type: 'favorite', userId: 'carol', eventId: 102 },
+    ]);
+    const body = await (await icsFetch(req(`/faves.ics?t=${fresh.token}`), ctx)).text();
+    expect(body).toContain('SUMMARY:Skills & Games');
+    expect(body).toContain('X-WR-CALNAME:@carol — Pickathon Picks');
+  });
+
+  it('serves fave-less holders and unknown tokens alike: valid anchor-only, never an error', async () => {
+    feedOk();
+    const { ctx } = ctxOf(DB_DOCS);
+    const res = await icsFetch(req('/faves.ics?t=freshly-minted-token-000&n=jchris'), ctx);
     expect(res.status).toBe(200);
     expect(res.headers.get('cache-control')).toBe('no-store'); // don't pin the placeholder
     const body = await res.text();
     expect(body).toContain('SUMMARY:Gates Open');
     // iOS captures the calendar name at subscribe time; the display-only n=
-    // param names it correctly even before the tick resolves the token.
+    // param names it even when the token resolves to nobody.
     expect(body).toContain('X-WR-CALNAME:@jchris — Pickathon Picks');
     expect((body.match(/BEGIN:VEVENT/g) || []).length).toBe(1);
   });
 
+  it('serves the never-empty anchor calendar when it cannot read the db at all', async () => {
+    // A ctx-less/db-less call (and any read failure) must still validate as a
+    // subscription rather than 500 — iOS reads an add-time error as "Validation
+    // failed" and the user never gets a working calendar.
+    feedOk();
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    const body = await res.text();
+    expect(body).toContain('SUMMARY:Gates Open');
+    expect(body).not.toContain('Built to Spill');
+  });
+
   it('derives legacy shift times from day + startTime/endTime', async () => {
     feedOk();
-    await tick();
-    const body = await (await icsFetch(req(`/faves.ics?t=${T_BOB}`), {})).text();
+    const { ctx } = ctxOf(DB_DOCS);
+    const body = await (await icsFetch(req(`/faves.ics?t=${T_BOB}`), ctx)).text();
     expect(body).toContain('SUMMARY:Gate');
     expect(body).toContain('DTSTART:20260731T170000Z'); // Friday 10:00 PDT
   });
 
-  it('does not aggregate users who never opted in (no token → no ics data at all)', async () => {
-    // The tick fixture has no caltoken for a "nobody" user, and the opt-in
-    // filter also drops fave-holders without tokens from the users map.
-    feedOk();
-    await tick();
-    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
-    expect(res.status).toBe(200); // alice opted in and serves normally
-  });
-
   it('400s a missing or malformed token and 502s a broken feed', async () => {
     feedOk();
-    await tick();
-    expect((await icsFetch(req('/faves.ics'), {})).status).toBe(400);
-    expect((await icsFetch(req('/faves.ics?t=short'), {})).status).toBe(400);
-    expect((await icsFetch(req('/faves.ics?t=bad$token!!!!!!!!!!!'), {})).status).toBe(400);
+    const { ctx } = ctxOf(DB_DOCS);
+    expect((await icsFetch(req('/faves.ics'), ctx)).status).toBe(400);
+    expect((await icsFetch(req('/faves.ics?t=short'), ctx)).status).toBe(400);
+    expect((await icsFetch(req('/faves.ics?t=bad$token!!!!!!!!!!!'), ctx)).status).toBe(400);
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => new Response('nope', { status: 500 }))
     );
-    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(502);
+    // 502, never an empty 200: established subscribers keep the events they
+    // already synced instead of watching their calendar empty out.
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), ctx)).status).toBe(502);
   });
 
   it("shifts don't touch the feed: a shifts-only user serves without egress", async () => {
     const fetchSpy = feedOk();
-    await scheduled(
-      { scheduledTime: '2026-07-04T12:00:00Z' },
-      { db: { query: async () => [DB_DOCS[3], DB_DOCS[7]] } }
-    );
-    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    const { ctx } = ctxOf([DB_DOCS[3], DB_DOCS[7]]);
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), ctx);
     expect(res.status).toBe(200);
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(await res.text()).toContain('SUMMARY:Volunteer');
+  });
+});
+
+// ── The rewrite: the GET reads the db itself, keyed ──────────────────────────
+// The cache is gone. These pin the read discipline that replaced it: every read
+// is keyed (never a whole-db scan), the token is still the only capability, and
+// every paged loop follows `next` rather than stopping on an empty page.
+describe('subscription lane — request-time keyed reads', () => {
+  beforeEach(() => __resetShedForTests());
+  afterEach(() => vi.unstubAllGlobals());
+  const feedOk = () =>
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(JSON.stringify(FEED), { status: 200 }))
+    );
+
+  it('never issues an unkeyed whole-db query', async () => {
+    feedOk();
+    const s = ctxOf(DB_DOCS);
+    await icsFetch(req(`/faves.ics?t=${T_ALICE}&n=alice`), s.ctx);
+    expect(s.queries.length).toBeGreaterThan(0);
+    for (const q of s.queries) {
+      expect(q.field).toBeDefined(); // keyed, always
+      expect(q.limit).toBeLessThanOrEqual(2000); // and paged
+      expect(q.db).toBe(PICKATHON_DB);
+    }
+  });
+
+  it('resolves the token by id when n= names the right handle — one get, no scan', async () => {
+    feedOk();
+    const s = ctxOf(DB_DOCS);
+    await icsFetch(req(`/faves.ics?t=${T_ALICE}&n=alice`), s.ctx);
+    expect(s.gets.map((g) => g.id)).toContain('caltoken-alice');
+    // The hint short-circuits the scan: no query by `token` was needed.
+    expect(s.queries.filter((q) => q.field === 'token')).toEqual([]);
+  });
+
+  it('n= is a HINT, never the capability: a wrong hint still serves the token owner', async () => {
+    feedOk();
+    const s = ctxOf(DB_DOCS);
+    const body = await (await icsFetch(req(`/faves.ics?t=${T_ALICE}&n=bob`), s.ctx)).text();
+    expect(body).toContain('SUMMARY:Built to Spill'); // alice's pick
+    expect(body).not.toContain('Skills'); // never bob's
+    expect(body).toContain('X-WR-CALNAME:@alice — Pickathon Picks');
+  });
+
+  it("a hint pointing at someone else's caltoken doc serves nothing of theirs", async () => {
+    // get('caltoken-bob') resolves a real doc — but its token is not the one
+    // presented, so it must be rejected, not trusted.
+    feedOk();
+    const s = ctxOf(DB_DOCS.filter((d) => d._id !== 'caltoken-alice'));
+    const body = await (
+      await icsFetch(req('/faves.ics?t=some-other-token-0000000&n=bob'), s.ctx)
+    ).text();
+    expect(body).not.toContain('Skills');
+    expect((body.match(/BEGIN:VEVENT/g) || []).length).toBe(1); // anchor only
+  });
+
+  it('resolves a token with no hint by paging field:token — a first page that filters to EMPTY still carries next', async () => {
+    // The idiom's whole trap. These fillers sort ahead of `caltoken-*` and carry
+    // no `token` field, so page one comes back with zero docs and a live `next`.
+    // A loop that stops on an empty page loses every subscriber.
+    feedOk();
+    const filler = Array.from({ length: PAGE_LIMIT + 50 }, (_, i) => ({
+      _id: `0filler-${String(i).padStart(5, '0')}`,
+      type: 'other',
+      userId: 'nobody',
+    }));
+    const s = ctxOf([...filler, ...DB_DOCS]);
+    const body = await (await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).text();
+    const tokenPages = s.queries.filter((q) => q.field === 'token');
+    expect(tokenPages.length).toBeGreaterThan(1); // it kept going past the empty page
+    expect(body).toContain('SUMMARY:Built to Spill');
+  });
+
+  it('pages the picks read too — favorites past the first page still reach the feed', async () => {
+    feedOk();
+    // Docs that HAVE a userId but the wrong one: they survive the field filter,
+    // fail the key filter, and fill a whole page with nothing.
+    const filler = Array.from({ length: PAGE_LIMIT + 50 }, (_, i) => ({
+      _id: `0filler-${String(i).padStart(5, '0')}`,
+      type: 'favorite',
+      userId: 'someoneelse',
+      eventId: 102,
+    }));
+    const s = ctxOf([...filler, ...DB_DOCS]);
+    const body = await (await icsFetch(req(`/faves.ics?t=${T_ALICE}&n=alice`), s.ctx)).text();
+    expect(body).toContain('SUMMARY:Built to Spill');
+    expect(body).toContain('SUMMARY:Night Act');
+    expect(body).not.toContain('Skills'); // someoneelse's pick never leaks in
+  });
+
+  it('a read failure degrades to the anchor calendar, never a 500', async () => {
+    feedOk();
+    const s = ctxOf(DB_DOCS);
+    s.failGets(new Error('Access denied'));
+    const bad = { db: { ...s.db, query: async () => Promise.reject(new Error('Access denied')) } };
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), bad);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain('SUMMARY:Gates Open');
+  });
+
+  it('an opted-out user has no feed: deleting the caltoken drains it to the anchor', async () => {
+    feedOk();
+    const s = ctxOf(DB_DOCS.filter((d) => d._id !== 'caltoken-alice'));
+    const body = await (await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).text();
+    expect(body).not.toContain('Built to Spill');
+    expect((body.match(/BEGIN:VEVENT/g) || []).length).toBe(1);
   });
 });
 
@@ -496,44 +700,24 @@ describe('fetch handler — POST /faves.ics', () => {
 // any db size, so a steady schedule costs ZERO writes.
 describe('schedule mirror — unchanged schedule must cost zero writes', () => {
   beforeEach(() => {
-    __resetSubCacheForTests();
     __resetScheduleSyncForTests();
     __resetHeartbeatForTests();
     __resetShedForTests();
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  // A ctx that records every write and replays the docs a capped read returns.
-  const mkCtx = (docs = []) => {
-    const store = new Map(docs.map((d) => [d._id, d]));
-    const puts = [];
-    const deletes = [];
-    return {
-      puts,
-      deletes,
-      docs: () => [...store.values()],
-      db: {
-        query: async () => [...store.values()],
-        put: async (doc) => {
-          puts.push(doc);
-          store.set(doc._id, doc);
-          return doc._id;
-        },
-        delete: async (id) => {
-          deletes.push(id);
-          store.delete(id);
-          return id;
-        },
-      },
-    };
-  };
+  // The tick's ctx is the shared store mock: it reads its state docs BY ID and
+  // never scans, so `queries` staying empty is itself an assertion.
+  const mkCtx = (docs = []) => mkStore(docs);
   const feedOk = () => {
     const spy = vi.fn(async () => new Response(JSON.stringify(FEED), { status: 200 }));
     vi.stubGlobal('fetch', spy);
     return spy;
   };
   // Successive ticks, SCHEDULE_SYNC_INTERVAL_MS apart so each one is due.
-  const at = (n) => ({ scheduledTime: new Date(1e12 + n * SCHEDULE_SYNC_INTERVAL_MS).toISOString() });
+  const at = (n) => ({
+    scheduledTime: new Date(1e12 + n * SCHEDULE_SYNC_INTERVAL_MS).toISOString(),
+  });
 
   it('mirrors the feed on the first sync and records a fingerprint per event', async () => {
     feedOk();
@@ -561,37 +745,58 @@ describe('schedule mirror — unchanged schedule must cost zero writes', () => {
     expect(ctx.deletes).toEqual([]);
   });
 
-  it('stays quiet even when the capped read cannot see the schedule docs at all', async () => {
-    // Prod's exact shape: the read returns the state doc (its _id leads with a
-    // digit, so it sorts to the front and survives the cap) but NOT one single
-    // `schedule-event-*` doc. This is the case that used to re-put everything.
+  it('never scans the db — every tick read is by id', async () => {
+    // #4293's root cause was the tick reading the whole db and diffing against
+    // what it happened to see. There is no whole-db read left to be capped.
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    await scheduled(at(1), ctx);
+    expect(ctx.queries).toEqual([]);
+    expect(ctx.gets.map((g) => g.id).sort()).toEqual(
+      expect.arrayContaining([HEARTBEAT_ID, SCHEDULE_STATE_ID])
+    );
+  });
+
+  it('stays quiet on a fresh isolate that reads its state doc back', async () => {
+    // A restarted isolate has no memory: the durable state doc read BY ID is
+    // what keeps it from re-putting every event. This is the case that used to
+    // re-put everything, because the state fell outside the capped window.
     feedOk();
     const seed = mkCtx(DB_DOCS);
     await scheduled(at(0), seed);
-    const state = seed.puts.find((d) => d._id === SCHEDULE_STATE_ID);
-    const capped = mkCtx([...DB_DOCS, state]); // no scheduleitem docs survive the cap
-    await scheduled(at(1), capped);
-    expect(capped.puts).toEqual([]);
-    expect(capped.deletes).toEqual([]);
+    __resetScheduleSyncForTests(); // isolate boot: memory gone, db intact
+    const restarted = mkCtx([...seed.store.values()]);
+    await scheduled(at(1), restarted);
+    expect(restarted.puts).toEqual([]);
+    expect(restarted.deletes).toEqual([]);
   });
 
-  it('falls back to the in-isolate copy when the state doc is not in the read', async () => {
-    // The state doc's _id sorts ahead of everything this app mints, but _id is a
-    // free string — enough docs beginning with punctuation would evict it, and a
-    // signed-in stranger can write those (unknown types are accepted, just routed
-    // to `discard`). Losing it must NOT read as "nothing is mirrored".
+  it('falls back to the in-isolate copy when the state doc read comes back empty', async () => {
+    // A keyed get is authoritative about absence — but "absent" must still mean
+    // "use the copy", never "nothing is mirrored". That second reading is the
+    // one that reopens the rewrite loop, whatever the read mechanism.
     feedOk();
     const ctx = mkCtx(DB_DOCS);
     await scheduled(at(0), ctx);
     ctx.puts.length = 0;
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    // Same isolate, but the read no longer contains the state doc.
-    const evicted = {
-      db: { ...ctx.db, query: async () => ctx.docs().filter((d) => d._id !== SCHEDULE_STATE_ID) },
-    };
-    await scheduled(at(1), evicted);
+    ctx.store.delete(SCHEDULE_STATE_ID); // same isolate, state doc gone
+    await scheduled(at(1), ctx);
     expect(ctx.puts).toEqual([]); // the isolate remembered — no rewrite storm
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing from the db read'));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining(SCHEDULE_STATE_ID));
+    warn.mockRestore();
+  });
+
+  it('uses the in-isolate copy when the state read FAILS outright', async () => {
+    feedOk();
+    const ctx = mkCtx(DB_DOCS);
+    await scheduled(at(0), ctx);
+    ctx.puts.length = 0;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    ctx.failGets(new Error('Access denied'));
+    await scheduled(at(1), ctx);
+    expect(ctx.puts).toEqual([]);
     warn.mockRestore();
   });
 
@@ -633,7 +838,7 @@ describe('schedule mirror — unchanged schedule must cost zero writes', () => {
     const ctx = mkCtx(DB_DOCS);
     await scheduled(at(0), ctx);
     expect(spy).toHaveBeenCalledTimes(1);
-    // A minute later: the aggregate still refreshes, the feed is left alone.
+    // A minute later: the tick ran, the feed was left alone.
     await scheduled({ scheduledTime: new Date(1e12 + 60_000).toISOString() }, ctx);
     expect(spy).toHaveBeenCalledTimes(1);
   });
@@ -666,24 +871,26 @@ describe('schedule mirror — unchanged schedule must cost zero writes', () => {
     expect(ctx.puts.filter((d) => d.type === 'scheduleitem').length).toBe(3);
   });
 
-  it('warns when the db read comes back capped, because the host says nothing', async () => {
+  it('costs the same on a huge db as on an empty one (no scan to be capped)', async () => {
+    // The old tick read every doc, so its cost — and its correctness — tracked
+    // the db's size. 20k docs must not change a single read it makes.
     feedOk();
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const filler = Array.from({ length: 2000 }, (_, i) => ({
+    const filler = Array.from({ length: 20000 }, (_, i) => ({
       _id: `favorite-user${String(i).padStart(5, '0')}-1`,
       type: 'favorite',
       userId: `user${i}`,
       eventId: 101,
     }));
-    await scheduled(at(0), mkCtx(filler));
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('2000-doc query cap'));
-    warn.mockRestore();
+    const big = mkCtx([...filler, ...DB_DOCS]);
+    await scheduled(at(0), big);
+    expect(big.queries).toEqual([]);
+    expect(big.gets.length).toBeLessThanOrEqual(4);
+    expect(big.puts.filter((d) => d.type === 'scheduleitem').length).toBe(3);
   });
 });
 
 describe('tick liveness heartbeat — the only durable proof the alarm ran', () => {
   beforeEach(() => {
-    __resetSubCacheForTests();
     __resetScheduleSyncForTests();
     __resetHeartbeatForTests();
     __resetShedForTests();
@@ -695,13 +902,7 @@ describe('tick liveness heartbeat — the only durable proof the alarm ran', () 
   });
   afterEach(() => vi.unstubAllGlobals());
 
-  const mkCtx = (docs = []) => {
-    const puts = [];
-    return {
-      puts,
-      db: { query: async () => docs, put: async (d) => puts.push(d), delete: async () => {} },
-    };
-  };
+  const mkCtx = (docs = []) => mkStore(docs);
   const beats = (ctx) => ctx.puts.filter((d) => d.type === HEARTBEAT_TYPE);
   const tick = (ms) => ({ scheduledTime: new Date(ms).toISOString() });
   const T0 = 1e12;
@@ -714,7 +915,7 @@ describe('tick liveness heartbeat — the only durable proof the alarm ran', () 
     ]);
   });
 
-  it('beats at most once an hour — a 1m tick must not mint a write a minute', async () => {
+  it('beats at most once an hour — a frequent tick must not mint a write per tick', async () => {
     const ctx = mkCtx([]);
     await scheduled(tick(T0), ctx);
     await scheduled(tick(T0 + 60_000), ctx);
@@ -731,9 +932,9 @@ describe('tick liveness heartbeat — the only durable proof the alarm ran', () 
     expect(stamps[0]).not.toBe(stamps[1]);
   });
 
-  it('honours a recent heartbeat doc from the read after an isolate restart', async () => {
-    // Fresh isolate (no memory), but the doc is right there in the whole-db read
-    // its digit-leading _id guarantees a seat in — so nothing is due.
+  it('honours a recent heartbeat doc read BY ID after an isolate restart', async () => {
+    // Fresh isolate (no memory), but one keyed get finds the doc — reachable at
+    // any db size, no sort window to fall out of — so nothing is due.
     const ctx = mkCtx([
       { _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at: new Date(T0 - 60_000).toISOString() },
     ]);
@@ -741,20 +942,30 @@ describe('tick liveness heartbeat — the only durable proof the alarm ran', () 
     expect(beats(ctx)).toEqual([]);
   });
 
-  it('beats when the doc in the read is stale — a dead-then-revived alarm says so', async () => {
+  it('beats when the doc it reads back is stale — a dead-then-revived alarm says so', async () => {
     const ctx = mkCtx([
-      { _id: HEARTBEAT_ID, type: HEARTBEAT_TYPE, at: new Date(T0 - 3 * 60 * 60 * 1000).toISOString() },
+      {
+        _id: HEARTBEAT_ID,
+        type: HEARTBEAT_TYPE,
+        at: new Date(T0 - 3 * 60 * 60 * 1000).toISOString(),
+      },
     ]);
     await scheduled(tick(T0), ctx);
     expect(beats(ctx)).toHaveLength(1);
   });
 
-  it('a doc missing from a capped read means "don’t know", never "never beat"', async () => {
-    // The #4293 shape: losing the doc from the read must not restart the writes.
+  it('a missing or unreadable doc means "don’t know", never "never beat"', async () => {
+    // The #4293 shape: losing the doc must not restart the writes. The isolate's
+    // own memory is the backstop, whichever way the read fails.
     const ctx = mkCtx([]);
     await scheduled(tick(T0), ctx);
-    await scheduled(tick(T0 + 60_000), mkCtx([])); // same isolate, doc absent
-    expect(beats(ctx)).toHaveLength(1);
+    const absent = mkCtx([]); // same isolate, doc absent
+    await scheduled(tick(T0 + 60_000), absent);
+    expect(beats(absent)).toEqual([]);
+    const broken = mkCtx([]);
+    broken.failGets(new Error('Access denied'));
+    await scheduled(tick(T0 + 120_000), broken);
+    expect(beats(broken)).toEqual([]);
   });
 
   it('treats an unparseable stamp as no evidence and beats now', async () => {
@@ -770,7 +981,6 @@ describe('tick liveness heartbeat — the only durable proof the alarm ran', () 
 
 describe('load shedding — the owner-flipped config doc', () => {
   beforeEach(() => {
-    __resetSubCacheForTests();
     __resetScheduleSyncForTests();
     __resetHeartbeatForTests();
     __resetShedForTests();
@@ -783,45 +993,25 @@ describe('load shedding — the owner-flipped config doc', () => {
     return spy;
   };
   const shedDoc = (level) => ({ _id: LOADSHED_ID, type: LOADSHED_TYPE, level });
-  const mkCtx = (docs = []) => {
-    const puts = [];
-    const deletes = [];
-    let rows = docs;
-    return {
-      puts,
-      deletes,
-      setDocs: (d) => {
-        rows = d;
-      },
-      db: {
-        query: async () => rows,
-        put: async (d) => {
-          puts.push(d);
-          return d._id;
-        },
-        delete: async (id) => {
-          deletes.push(id);
-          return id;
-        },
-      },
-    };
-  };
-  const at = (n) => ({ scheduledTime: new Date(1e12 + n * SCHEDULE_SYNC_INTERVAL_MS).toISOString() });
+  const at = (n) => ({
+    scheduledTime: new Date(1e12 + n * SCHEDULE_SYNC_INTERVAL_MS).toISOString(),
+  });
 
   it('serves the subscription normally when the doc is absent (fail-open)', async () => {
     feedOk();
-    await scheduled(at(0), mkCtx(DB_DOCS));
-    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    const { ctx } = ctxOf(DB_DOCS);
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), ctx);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('SUMMARY:Built to Spill');
   });
 
   it('serves normally when the level is off or unrecognized (a typo must not shed)', async () => {
     feedOk();
-    await scheduled(at(0), mkCtx([...DB_DOCS, shedDoc('off')]));
-    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(200);
-    await scheduled(at(1), mkCtx([...DB_DOCS, shedDoc('readonly')])); // fat-fingered
-    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(200);
+    const off = ctxOf([...DB_DOCS, shedDoc('off')]);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), off.ctx)).status).toBe(200);
+    __resetShedForTests();
+    const typo = ctxOf([...DB_DOCS, shedDoc('readonly')]); // fat-fingered
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), typo.ctx)).status).toBe(200);
   });
 
   it('503s the subscription lane with a retry-after while shedding, in BOTH shed levels', async () => {
@@ -829,10 +1019,9 @@ describe('load shedding — the owner-flipped config doc', () => {
     // synced — which is why this is a 503 and not an empty calendar.
     for (const level of ['read-only', 'schedule-only']) {
       __resetShedForTests();
-      __resetSubCacheForTests();
       feedOk();
-      await scheduled(at(0), mkCtx([...DB_DOCS, shedDoc(level)]));
-      const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+      const { ctx } = ctxOf([...DB_DOCS, shedDoc(level)]);
+      const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), ctx);
       expect(res.status).toBe(503);
       expect(res.headers.get('retry-after')).toBe(String(SHED_RETRY_AFTER_SECONDS));
       expect(res.headers.get('cache-control')).toBe('no-store');
@@ -842,67 +1031,87 @@ describe('load shedding — the owner-flipped config doc', () => {
     }
   });
 
+  it('sheds BEFORE doing any viewer work — no token lookup, no feed join', async () => {
+    // The point of the switch is to stop viewer-driven amplification, so the
+    // 503 has to come first, not after the reads it is meant to prevent.
+    const feed = feedOk();
+    const s = ctxOf([...DB_DOCS, shedDoc('read-only')]);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(503);
+    expect(s.queries).toEqual([]);
+    expect(s.gets.map((g) => g.id)).toEqual([LOADSHED_ID]);
+    expect(feed).not.toHaveBeenCalled();
+  });
+
+  it('takes effect on the very next request — no tick to wait for', async () => {
+    feedOk();
+    const s = ctxOf(DB_DOCS);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(200);
+    s.store.set(LOADSHED_ID, shedDoc('read-only'));
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(503);
+  });
+
   it('a malformed token still 400s before the shed check (shedding is not a bug bucket)', async () => {
     feedOk();
-    await scheduled(at(0), mkCtx([...DB_DOCS, shedDoc('read-only')]));
-    expect((await icsFetch(req('/faves.ics?t=short'), {})).status).toBe(400);
+    const { ctx } = ctxOf([...DB_DOCS, shedDoc('read-only')]);
+    expect((await icsFetch(req('/faves.ics?t=short'), ctx)).status).toBe(400);
   });
 
-  it('skips the aggregate while shedding but STILL writes the heartbeat', async () => {
-    // Liveness must survive shedding: a shed tick is still a tick that ran, and
-    // the heartbeat is the only durable evidence of that (#4305).
-    feedOk();
-    const ctx = mkCtx([...DB_DOCS, shedDoc('read-only')]);
-    await scheduled(at(0), ctx);
-    expect(ctx.puts.filter((d) => d.type === HEARTBEAT_TYPE)).toHaveLength(1);
-    // No aggregate was built, so the GET has nothing to serve even if it tried.
-    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(503);
-  });
-
-  it('keeps the 5-minute schedule mirror running in BOTH shed levels', async () => {
-    // Shedding targets viewer-driven amplification, not the fixed-cost mirror —
-    // and the schedule staying fresh is the whole point of staying up.
+  it('does not shed the tick: heartbeat and mirror both run in BOTH shed levels', async () => {
+    // Shedding targets viewer-driven amplification, not the fixed-cost tick —
+    // and the schedule staying fresh is the whole point of staying up. Liveness
+    // must survive shedding too: a shed tick is still a tick that ran (#4305).
     for (const level of ['read-only', 'schedule-only']) {
       __resetShedForTests();
       __resetScheduleSyncForTests();
+      __resetHeartbeatForTests();
       feedOk();
-      const ctx = mkCtx([...DB_DOCS, shedDoc(level)]);
+      const ctx = mkStore([...DB_DOCS, shedDoc(level)]);
       await scheduled(at(0), ctx);
+      expect(ctx.puts.filter((d) => d.type === HEARTBEAT_TYPE)).toHaveLength(1);
       expect(ctx.puts.filter((d) => d.type === 'scheduleitem').length).toBe(3);
       expect(ctx.puts.some((d) => d._id === SCHEDULE_STATE_ID)).toBe(true);
     }
   });
 
-  it('honours the in-isolate copy when the doc falls out of a capped read', async () => {
-    // §4a: a missing doc means "don't know" → use the remembered level. It must
-    // never read as "shedding is off", which would re-open the very load spike
-    // the switch was flipped for.
+  it('keeps the remembered level when the shed doc cannot be read', async () => {
+    // §4a: a read that fails means "don't know" → keep the level we last saw. It
+    // must never read as "shedding is off", which would re-open the very load
+    // spike the switch was flipped for. (A doc that is genuinely ABSENT from a
+    // keyed read is a different, authoritative answer — see the test below.)
     feedOk();
-    const ctx = mkCtx([...DB_DOCS, shedDoc('read-only')]);
-    await scheduled(at(0), ctx);
+    const s = ctxOf([...DB_DOCS, shedDoc('read-only')]);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(503);
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    ctx.setDocs(DB_DOCS); // same isolate, the config doc is no longer in the read
-    await scheduled(at(1), ctx);
-    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(503);
+    s.failGets(new Error('Access denied'));
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(503);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining(LOADSHED_ID));
     warn.mockRestore();
   });
 
-  it('lifts the shed as soon as the doc says off, and re-fills the aggregate', async () => {
+  it('lifts the shed as soon as the doc says off, and serves the real feed again', async () => {
     feedOk();
-    const ctx = mkCtx([...DB_DOCS, shedDoc('read-only')]);
-    await scheduled(at(0), ctx);
-    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {})).status).toBe(503);
-    ctx.setDocs([...DB_DOCS, shedDoc('off')]);
-    await scheduled(at(1), ctx);
-    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
+    const s = ctxOf([...DB_DOCS, shedDoc('read-only')]);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(503);
+    s.store.set(LOADSHED_ID, shedDoc('off'));
+    const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('SUMMARY:Built to Spill');
   });
 
-  it('a cold isolate that has never seen the doc serves normally (fail-open)', async () => {
-    // The GET lane cannot read the db at all, so before the first tick it has no
-    // idea whether we are shedding. Fail-open is the only safe default.
+  it('a DELETED shed doc lifts the shed — a keyed read is authoritative about absence', async () => {
+    // The capped-scan design could not tell "deleted" from "fell off the end",
+    // so it had to keep shedding and the runbook said never to delete the doc.
+    // A keyed get can, so deleting it is now a legitimate way to lift.
+    feedOk();
+    const s = ctxOf([...DB_DOCS, shedDoc('read-only')]);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(503);
+    s.store.delete(LOADSHED_ID);
+    expect((await icsFetch(req(`/faves.ics?t=${T_ALICE}`), s.ctx)).status).toBe(200);
+  });
+
+  it('a ctx that cannot read the db at all serves normally (fail-open)', async () => {
+    // Before #3650's unfilteredReads declaration the GET lane could not read the
+    // db, and that must stay the safe direction: serve, never shed by accident.
     feedOk();
     const res = await icsFetch(req(`/faves.ics?t=${T_ALICE}`), {});
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Why

Roughly two in five people subscribed to the Pickathon picker's calendar feed have been getting an incomplete one, silently. The app's server code builds every subscriber's feed from a single read of the whole database, and that read stops at 2,000 documents sorted by id — so once the database grew past that line, everyone whose name sorts after it simply vanished from the aggregate and their feed went quiet. This rewrites the feed to read each subscriber's own data at request time, which has no such ceiling.

The platform capability that makes this possible shipped to production yesterday in `12.1.2`. Before that, the server code genuinely could not read the database on the request path, and the whole-database aggregate was the only option available — the header comment being replaced here says so honestly. That constraint is gone.

**Staged, not deployed.** The live app still runs the previous source; this branch exists so the work is reviewable and survives, and it merges when the deploy happens. Tracking issue: VibesDIY/vibes.diy#4531 stage 3.

## What changed

| Gone | Replaced by |
|---|---|
| `subCache` + the 1-minute tick's whole-database aggregate | per-request keyed reads (`ctx.db.get`, `query` with `field`/`key`/`keys`/`prefix`, `after` cursor) |
| the cold-window / anchor-only-until-first-tick branch | a token resolved directly, so a just-minted subscription works immediately |
| `BACKEND_QUERY_MAX_DOCS` truncation warning | nothing to truncate — there is no scan left |
| `isShedding()` reading module state | `readShedLevel` as a keyed read on the request path |

Plus `config.fetch.unfilteredReads = { dbs: ["pickathon"] }`, which is what lifts the anonymous-read denial for this feed, and `readAllPages`, which loops on the cursor's `next` — **never on emptiness**, because filtering happens after paging, so an empty page can still carry a `next`.

### The tick is kept, deliberately, for the two things that aren't user data

The public `scheduleitem` mirror (what every client renders offline) and the hourly heartbeat. No subscriber data flows through it any more, so it no longer sheds, and its cadence drops from 1 minute to 5 — the 1-minute cadence existed only to shrink the aggregate's cold window, which no longer exists. Both jobs remember their own work in a state doc **read by id**, with an in-isolate backstop, so a missing state doc means "use the copy", never "nothing is done". That second reading is the one that reopens the rewrite loop this pattern caused before.

## Three things that were nearly bugs

**Case-folded handles.** The old aggregate lower-cased handles as it built the map, and the live data really does contain both `Alice` and `alice`. A naive keyed read asks for one spelling and silently loses migrated users' picks, so the picks read asks for both via `keys`.

**A partial read must answer empty, not partial.** If the picks read fails halfway, the feed falls back to the never-empty anchor calendar rather than serving what it got. A half-read feed looks exactly like a subscriber deleting their picks, and calendar clients would act on that.

**The `n=` parameter is a hint, never a capability.** It turns token→handle from a paged scan into one `ctx.db.get`, but the resolved document's token must still equal the presented one. Tested with a hostile `n` pointing at someone else's document.

Unchanged on purpose: the deterministic content-hashed `eventId`s (changing them orphans every saved favorite), `icsUid`, the anchor event, the 502-on-feed-failure that keeps established subscribers' previously-synced events, `max-age=300`, and the 400s.

## Verification

`npx vitest run` → **248 passed, 0 failed** across 9 files (235 before). The two paging tests were proven to bite by temporarily making the loop stop on an empty page — exactly those two fail.

The declaration was also checked against the real platform parser rather than by eye: `parseBackendConfig` on the actual file reports `handlers [fetch, scheduled]`, `schedule 5m`, `unfilteredReads {dbs:["pickathon"]}`, zero errors.

Cost check, as a test: the feed now costs the same on a 20,000-document database as on an empty one.

## Before this merges

The deploy is a separate operation with its own preconditions, all on the vibes.diy side: a capability probe against the live host first (an old host **ignores** the new read options rather than rejecting them, so a clean push proves nothing), a byte-identical feed check for an unaffected subscriber, an acceptance count for an affected one, a DO load watch, and a morning deploy window — never a festival evening. Rollback is a re-push of the saved previous source, which is preserved.

## Docs touched beyond the code

`RUNBOOK.md` and three stale `App.jsx` comments described the deleted cache as current, including a "watch for the 2000-doc cap" callout that no longer applies and a "never `db del` the load-shed doc" rule that is now obsolete — a keyed read can distinguish "deleted" from "sorted off the end", so deleting the document lifts the shed, and there's a test for it.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vVMbCnpP4pjeZF9vYNuhn)_